### PR TITLE
Typo fix: parenthesis -> parentheses

### DIFF
--- a/src/functions.md
+++ b/src/functions.md
@@ -18,7 +18,7 @@ fn another_function() {
 
 Rust code uses `snake_case` as a style for function names: all lower case, with underscores separating words.
 (It also uses them for variable names, too.)
-We can can call any function we’ve defined by using its name and some parenthesis:
+We can can call any function we’ve defined by using its name and some parentheses:
 
 ```rust
 fn main() {


### PR DESCRIPTION
This is a little tenuous since a parenthesis is one of either '(' or ')', but the correct plural form is 'parentheses'.