### PR TITLE
Updated pronouns and rustup.sh output in installation.md.

### DIFF
--- a/src/installation.md
+++ b/src/installation.md
@@ -5,14 +5,14 @@ an Internet connection to run the commands in this chapter, as we’ll be
 downloading Rust from the internet.
 
 We’ll be showing off a number of commands using a terminal, and those lines all
-start with `$`. We don't need to type in the `$`s, they are there to indicate
-the start of each command. We’ll see many tutorials and examples around the web
-that follow this convention: `$` for commands run as our regular user, and `#`
-for commands we should be running as an administrator.
+start with `$`. You don't need to type in the `$`s, they are there to indicate
+the start of each command. You’ll see many tutorials and examples around the web
+that follow this convention: `$` for commands run as a regular user, and `#`
+for commands you should be running as an administrator.
 
 ## Installing on Linux or Mac
 
-If we're on Linux or a Mac, all we need to do is open a terminal and type this:
+If you're on Linux or a Mac, all you need to do is open a terminal and type this:
 
 ```bash
 $ curl -sSf https://static.rust-lang.org/rustup.sh | sh
@@ -25,7 +25,6 @@ If it all goes well, you’ll see this appear:
     Rust is ready to roll.
 ```
 
-From here, press `y` for ‘yes’, and then follow the rest of the prompts.
 
 ## Installing on Windows
 
@@ -42,12 +41,12 @@ the uninstall script:
 $ sudo /usr/local/lib/rustlib/uninstall.sh
 ```
 
-If we used the Windows installer, we can re-run the `.msi` and it will give us
+If you used the Windows installer, you can re-run the `.msi` and it will give you
 an uninstall option.
 
 ## Troubleshooting
 
-If we've got Rust installed, we can open up a shell, and type this:
+If you've got Rust installed, you can open up a shell, and type this:
 
 ```bash
 $ rustc --version
@@ -61,10 +60,10 @@ If you don't and you're on Windows, check that Rust is in your %PATH% system
 variable. If it isn't, run the installer again, select "Change" on the "Change,
 repair, or remove installation" page and ensure "Add to PATH" is checked.
 
-If not, there are a number of places where we can get help. The easiest is
-[the #rust IRC channel on irc.mozilla.org][irc], which we can access through
-[Mibbit][mibbit]. Click that link, and we'll be chatting with other Rustaceans
-(a silly nickname we call ourselves) who can help us out. Other great resources
+If not, there are a number of places where you can get help. The easiest is
+[the #rust IRC channel on irc.mozilla.org][irc], which you can access through
+[Mibbit][mibbit]. Click that link, and you'll be chatting with other Rustaceans
+(a silly nickname we call ourselves) who can help you out. Other great resources
 include [the user’s forum][users], and [Stack Overflow][stackoverflow].
 
 [irc]: irc://irc.mozilla.org/#rust
@@ -74,7 +73,7 @@ include [the user’s forum][users], and [Stack Overflow][stackoverflow].
 
 ## Local documentation
 
-This installer also installs a copy of the documentation locally, so we can
+This installer also installs a copy of the documentation locally, so you can
 read it offline. On UNIX systems, `/usr/local/share/doc/rust` is the location.
 On Windows, it's in a `share/doc` directory, inside the directory to which Rust
 was installed.

--- a/src/installation.md
+++ b/src/installation.md
@@ -18,23 +18,11 @@ If we're on Linux or a Mac, all we need to do is open a terminal and type this:
 $ curl -sSf https://static.rust-lang.org/rustup.sh | sh
 ```
 
-This will download a script, and start the installation. If it all goes well,
-you’ll see this appear:
+This will download a script, and start the installation. You may be prompted for your password.
+If it all goes well, you’ll see this appear:
 
 ```text
-Welcome to Rust.
-
-This script will download the Rust compiler and its package manager, Cargo, and
-install them to /usr/local. You may install elsewhere by running this script
-with the --prefix=<path> option.
-
-The installer will run under ‘sudo’ and may ask you for your password. If you do
-not want the script to run ‘sudo’ then pass it the --disable-sudo flag.
-
-You may uninstall later by running /usr/local/lib/rustlib/uninstall.sh,
-or by running this script again with the --uninstall flag.
-
-Continue? (y/N)
+    Rust is ready to roll.
 ```
 
 From here, press `y` for ‘yes’, and then follow the rest of the prompts.


### PR DESCRIPTION
Changed some pronouns from first person plural (we) to second person (you) for clarity and consistency.

When referring to the author, or to the author and reader, I have kept _we_ but when referring to the reader alone I have changed _we_ to _you_ where appropriate.

I have also updated the output of `rustup.sh` to reflect the latest output that it produces (as of 10th April 2016).