### PR TITLE
remove extraneous and potentially confusing variable declaration

### DIFF
--- a/src/loops.md
+++ b/src/loops.md
@@ -183,7 +183,6 @@ Instead, we can use our last kind of loop: the `for` loop. It looks like this:
 ```rust
 fn main() {
     let a = [1, 2, 3, 4, 5];
-    let mut index = 0;
 
     for element in a.iter() {
         println!("the value is: {}", element);


### PR DESCRIPTION
The `index` variable is unnecessary in the give code example. I assume it was left over from the previous code example. Before the removal, compiling the code produced warnings. 