### PR TITLE
Update byte example to match the text

### DIFF
--- a/src/ch03-02-data-types.md
+++ b/src/ch03-02-data-types.md
@@ -167,7 +167,7 @@ the ASCII characters using `b` and single quotes:
 
 ```rust
 fn main() {
-    let byte = b' ';
+    let byte = b'a';
     println!("byte is {}", byte);
 }
 ```


### PR DESCRIPTION
The text says:

> Byte literals can be created from the ASCII characters using `b` and single quotes:
> ```rust
> fn main() {
>     let byte = b' ';
>     println!("byte is {}", byte);
> }
> ```
> This will print `byte is 97`.
> 