### PR TITLE
Fix verbose explanation of cmp() return value

### DIFF
--- a/src/ch02-00-guessing-game-tutorial.md
+++ b/src/ch02-00-guessing-game-tutorial.md
@@ -637,11 +637,10 @@ match guess.cmp(&secret_number) {
 
 The `cmp()` method compares two values, and can be called on anything that can
 be compared. It takes a reference to the thing you want to compare it to, so
-here it's comparing our `guess` to our `secret_number`. `cmp()` returns a
-variant of the `Ordering` type we imported with the `use` statement earlier. We
-use a [`match`][match] statement to decide what to do next based on which
-variant of `Ordering` we got back from our call to `cmp()` with the values in
-`guess` and `secret_number`.
+here it's comparing our `guess` to our `secret_number` and returning a variant 
+of the `Ordering` enum. We use a [`match`][match] statement to decide what to 
+do next based on which variant of `Ordering` we got back from our call to 
+`cmp()` with the values in `guess` and `secret_number`.
 
 [match]: match.html
 


### PR DESCRIPTION
"use std::cmp::Ordering" was very recently explained and restating it here makes the paragraph more difficult to follow.

"with the values in `guess` and `secret_number`" (at the end) may be unnecessary repetition, but I'm not sure, so it's not removed in this pull request.