### PR TITLE
Remove unnecessary exclamation

### DIFF
--- a/src/ch06-02-match.md
+++ b/src/ch06-02-match.md
@@ -12,7 +12,7 @@ go through each pattern in a `match`, and for the first pattern that the value
 execution.
 
 Since we're already talking about coins, let's use them for an example using
-`match`! We can write a function that can take an unknown American coin and, in
+`match`. We can write a function that can take an unknown American coin and, in
 a similar way as the coin counting machine, determine which coin it is and
 return its value in cents:
 


### PR DESCRIPTION
`match` is not a macro, is that '!' intentional? See line just after the example code, where it seems more appropriate: "let's break down the match!"