### PR TITLE
Explain cargo run as it is in cargo guides

### DIFF
--- a/src/ch01-02-hello-world.md
+++ b/src/ch01-02-hello-world.md
@@ -336,8 +336,8 @@ sparse. Realistically, you won't ever need to touch this file yourself; just
 let Cargo handle it.
 
 We just built a project with `cargo build` and ran it with
-`./target/debug/hello_cargo`, but we can actually do both in one step with
-`cargo run` as follows:
+`./target/debug/hello_cargo`, but we can also use `cargo run` to compile
+and then run:
 
 ```bash
 $ cargo run


### PR DESCRIPTION
Saying `we can actually do both in one step with cargo run` could be confusing to people, the guide just said that it is not possible to compile and run in one step.
Given that the old explanation has this little issue, I'd change the phrase and explain it in the same way it is done in cargo guides.