### PR TITLE
remove beta from the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: rust
 rust:
   - nightly
-  - beta
   - stable
 before_script:
         - cargo install mdbook --git https://github.com/azerupi/mdBook.git


### PR DESCRIPTION
A rust bug is currently preventing this from building, and https://github.com/rust-lang/book/pull/134 will move this to nightly-only for the time being.