### PR TITLE
Fix the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 sudo: false
 language: rust
-cache: cargo
 rust:
   - nightly
   - stable
 before_script:
-        - cargo install mdbook --git https://github.com/azerupi/mdBook.git
+  - cargo install mdbook
 script:
   - PATH=$PATH:/home/travis/.cargo/bin mdbook test
   - PATH=$PATH:/home/travis/.cargo/bin mdbook build


### PR DESCRIPTION
We can't use the cache dir because cargo install doesn't really have a
way to say "make sure this is installed". If it is, then it errors out,
and you can force it to install, but then we're not using the cache.