### PR TITLE
Enhance Windows examples

### DIFF
--- a/src/ch01-02-hello-world.md
+++ b/src/ch01-02-hello-world.md
@@ -28,11 +28,11 @@ $ cd hello_world
 
 Windows:
 
-```bash
-$ mkdir %USERPROFILE%\projects
-$ cd %USERPROFILE%\projects
-$ mkdir hello_world
-$ cd hello_world
+```cmd
+> mkdir %USERPROFILE%\projects
+> cd %USERPROFILE%\projects
+> mkdir hello_world
+> cd hello_world
 ```
 
 ### Writing and Running a Rust Program
@@ -137,8 +137,8 @@ main  main.rs
 
 On Windows, you'd enter:
 
-```bash
-$ dir /B # the /B option says to only show the file names
+```cmd
+> dir /B %= the /B option says to only show the file names =%
 main.exe
 main.rs
 ```
@@ -211,8 +211,8 @@ $ cd ~/projects
 
 Windows:
 
-```bash
-$ cd %USERPROFILE%\projects
+```cmd
+> cd %USERPROFILE%\projects
 ```
 
 And then on any operating system run:


### PR DESCRIPTION
Most importantly, `#` does not introduce a comment in Windows CMD.
Also, switch the Windows code blocks to `cmd` instead of `bash`
and change the prompt to a more Windows typical `>`.