### PR TITLE
Update command to open the docs in Firefox

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,13 @@ your web browser.
 
 _Firefox:_
 ```bash
-$ firefox book/index.html
+$ firefox book/index.html           # Linux
+$ open -a "Firefox" book/index.html # OS X
 ```
 
 _Chrome:_
 ```bash
-$ open -a "Google Chrome" book/index.html 
+$ open -a "Google Chrome" book/index.html # OS X
 ```
 
 To run the tests:


### PR DESCRIPTION
The previous Firefox command only worked for Linux, while the previous Chrome command only worked for OS X.

I'm not sure what the Linux + Chome command would be.