### PR TITLE
Remove confusing section from chapter 2

### DIFF
--- a/src/ch02-00-guessing-game-tutorial.md
+++ b/src/ch02-00-guessing-game-tutorial.md
@@ -407,25 +407,6 @@ dependency, we’ve also grabbed a copy of `libc`, because `rand` depends on
 `libc` to work. After downloading them, Rust compiles them and then compiles
 our project.
 
-If we run `cargo build` again, we’ll get different output:
-
-```bash
-$ cargo build
-```
-
-That’s right, no output! Cargo knows that our project has been built, that
-all of its dependencies are built, and that no changes have been made. There’s
-no reason to do all that stuff again. With nothing to do, it simply
-exits. If we open up `src/main.rs`, make a trivial change, then save it again,
-we’ll only see one line:
-
-```bash
-$ cargo build
-   Compiling guessing_game v0.1.0 (file:///projects/guessing_game)
-```
-
-This just updates the build with your tiny change to the `main.rs` file.
-
 #### The Cargo.lock File that Ensures Reproducible Builds
 
 Cargo has a mechanism to make sure we can rebuild the exact same artifact every


### PR DESCRIPTION
This section was effectively re-teaching the concept of trivial changes causing a recompile, which should already be known this far in.

It was confusing for me, because I thought it was saying that the dependencies wouldn't be installed **until** a trivial change was made to `main.rs` (despite the section right above this saying the opposite).

It took me 10+ minutes to understand the mistake I'd made (including running the commands locally). Especially since the concept this is describing has already been mentioned earlier on, it doesn't seem worthwhile to mention here.