### PR TITLE
Minor spelling fixes

### DIFF
--- a/src/ch03-01-variable-bindings-and-mutability.md
+++ b/src/ch03-01-variable-bindings-and-mutability.md
@@ -83,7 +83,7 @@ to help.
 
 <!-- PROD: END BOX -->
 
-The error tells us that the cause of the error is `re-assigment of immutable
+The error tells us that the cause of the error is `re-assignment of immutable
 variable`, because we tried to assign a second value to the immutable `x`
 variable.
 

--- a/src/ch03-05-control-flow.md
+++ b/src/ch03-05-control-flow.md
@@ -235,7 +235,7 @@ error: aborting due to previous error
 error: Could not compile `branches`.
 ```
 
-The expression in the `if` block evaluates to an integer and the expresion in
+The expression in the `if` block evaluates to an integer and the expression in
 the `else` block evaluates to a string. This can’t work, because variable
 bindings must have a single type. Rust needs to know at compile time what type
 the `number` binding is, definitively, so that it can verify at compile time

--- a/src/ch04-02-references-and-borrowing.md
+++ b/src/ch04-02-references-and-borrowing.md
@@ -265,7 +265,7 @@ the parts about lifetimes, the message does contain the key to why this code is
 a problem: `this function’s return type contains a borrowed value, but there is
 no value for it to be borrowed from`.
 
-Let’s have a closer look at exactly what's happenening at each stage of our
+Let’s have a closer look at exactly what's happening at each stage of our
 `dangle` code:
 
 ```rust,ignore

--- a/src/ch05-00-structs.md
+++ b/src/ch05-00-structs.md
@@ -260,7 +260,7 @@ Let's try running with this change and... drat. We still get an error:
 error: the trait bound `Rectangle: std::fmt::Debug` is not satisfied
 ```
 
-Again, though, the compliler has given us a helpful note!
+Again, though, the compiler has given us a helpful note!
 
 ```bash
 note: `Rectangle` cannot be formatted using `:?`; if it is defined in your

--- a/src/ch05-01-method-syntax.md
+++ b/src/ch05-01-method-syntax.md
@@ -154,7 +154,7 @@ would mean we'd need a mutable borrow) and we want `main` to keep ownership of
 `rect2` so that we could use it again after calling this method. The return
 value of `can_hold` will be a boolean, and the implementation will check to see
 if `self`'s length and width are both greater than the length and width of the
-other `Rectagle`, respectively. Let's write that code!
+other `Rectangle`, respectively. Let's write that code!
 
 ```
 # #[derive(Debug)]

--- a/src/ch08-01-vectors.md
+++ b/src/ch08-01-vectors.md
@@ -16,7 +16,7 @@ Note that we added a type annotation here. Since we don't actually do
 anything with the vector, Rust doesn't know what kind of elements we intend to
 store. This is an important point. Vectors are homogenous: they may store many
 values, but those values must all be the same type. Vectors are generic over
-the type stored inside them (we'll talk about Generics more throroughly in
+the type stored inside them (we'll talk about Generics more thoroughly in
 Chapter 10), and the angle brackets here tell Rust that this vector will hold
 elements of the `i32` type.
 

--- a/src/ch08-02-strings.md
+++ b/src/ch08-02-strings.md
@@ -138,7 +138,7 @@ for the `add` method that the `+` operator uses looks something like this:
 fn add(self, s: &str) -> String {
 ```
 
-This isn't excatly what the actual signature is in the standard library because
+This isn't exactly what the actual signature is in the standard library because
 `add` is defined using generics there. Here, we're just looking at what the
 signature of the method would be if `add` was defined specifically for
 `String`. This signature gives us the clues we need in order to understand the

--- a/src/ch08-03-hash-maps.md
+++ b/src/ch08-03-hash-maps.md
@@ -3,7 +3,7 @@
 The last of our fundamental collections is the *hash map*. The type `HashMap<K,
 V>` stores a mapping of keys of type `K` to values of type `V`. It does this
 via a *hashing function*, which determines how it places these keys and values
-into memory. Many different programming languges support this kind of data
+into memory. Many different programming languages support this kind of data
 structure, but often with a different name: hash, map, object, hash table, or
 associative array, just to name a few.
 


### PR DESCRIPTION
Hey.

A few weeks ago I learned that `aspell` can be run as utility. So I've made [one-line script](https://gist.github.com/JIghtuse/c73c0c8db10526618c7ee0afc4c4c808#file-gen_dict-sh) to generate spellings in the book and fixed them. There were lots of false-positives (full list [here](https://gist.github.com/JIghtuse/c73c0c8db10526618c7ee0afc4c4c808#file-spellings-txt)), but now you can add them to file `~/.aspell.en.pws` and check all the book for spellings in a few seconds.

There are some issues with non-ascii symbols (words `Dobrý` and `Olá` cannot be placed in "local dictionary"), but otherwise it works great.