### PR TITLE
Fix figure 4.6

### DIFF
--- a/src/ch04-03-slices.md
+++ b/src/ch04-03-slices.md
@@ -152,7 +152,7 @@ Figure 4-6 shows this in a diagram:
 
 <img alt="world containing a pointer to the 6th byte of String s and a length 5" src="img/trpl04-06.svg" class="center" style="width: 50%;" />
 
-Figure 4-6: Two string slices referring to parts of a `String`
+Figure 4-6: String slice referring to part of a `String`
 
 With Rust’s `..` range syntax, if you want to start at the first index (zero),
 you can drop the value before the `..`. In other words, these are equal:

--- a/src/img/trpl04-06.svg
+++ b/src/img/trpl04-06.svg
@@ -95,11 +95,11 @@
 <polygon fill="none" stroke="black" points="8,-187 8,-207 60,-207 60,-187 8,-187"/>
 <text text-anchor="start" x="25.4482" y="-192.8" font-family="Times,serif" font-size="14.00">len</text>
 <polygon fill="none" stroke="black" points="60,-187 60,-207 96,-207 96,-187 60,-187"/>
-<text text-anchor="start" x="74.5" y="-192.8" font-family="Times,serif" font-size="14.00">5</text>
+<text text-anchor="start" x="70" y="-192.8" font-family="Times,serif" font-size="14.00">11</text>
 <polygon fill="none" stroke="black" points="8,-167 8,-187 60,-187 60,-167 8,-167"/>
 <text text-anchor="start" x="10.6826" y="-172.8" font-family="Times,serif" font-size="14.00">capacity</text>
 <polygon fill="none" stroke="black" points="60,-167 60,-187 96,-187 96,-167 60,-167"/>
-<text text-anchor="start" x="74.5" y="-172.8" font-family="Times,serif" font-size="14.00">5</text>
+<text text-anchor="start" x="70" y="-172.8" font-family="Times,serif" font-size="14.00">11</text>
 </g>
 <!-- table3&#45;&gt;table4 -->
 <g id="edge2" class="edge"><title>table3:pointer:c&#45;&gt;table4:pointee</title>


### PR DESCRIPTION
Updated Figure 4.6 to illustrate slice ```world``` of string ```s``` in the following code:
```rust
let s = String::from("hello world");

let hello = &s[0..5];
let world = &s[6..11];
```