### PR TITLE
Remove excess #s from code examples

### DIFF
--- a/src/ch05-01-method-syntax.md
+++ b/src/ch05-01-method-syntax.md
@@ -156,13 +156,13 @@ value of `can_hold` will be a boolean, and the implementation will check to see
 if `self`'s length and width are both greater than the length and width of the
 other `Rectangle`, respectively. Let's write that code!
 
-```
-# #[derive(Debug)]
-# struct Rectangle {
-#     length: u32,
-#     width: u32,
-# }
-#
+```rust
+#[derive(Debug)]
+struct Rectangle {
+    length: u32,
+    width: u32,
+}
+
 impl Rectangle {
     fn area(&self) -> u32 {
         self.length * self.width
@@ -195,12 +195,12 @@ thus making it easier to create a square `Rectangle` rather than having to
 specify the same value twice:
 
 ```rust
-# #[derive(Debug)]
-# struct Rectangle {
-#     length: u32,
-#     width: u32,
-# }
-#
+#[derive(Debug)]
+struct Rectangle {
+    length: u32,
+    width: u32,
+}
+
 impl Rectangle {
     fn square(size: u32) -> Rectangle {
         Rectangle { length: size, width: size }


### PR DESCRIPTION
I'm a rust beginner and working through your book as part of my learning process (I know this is a work in progress but still very useful to a beginner like me). 

I've been typing in the code examples as I go and noticed there were some parts of the code with extra `#`s in front of them which doesn't seem to be valid rust. They are also visible in the github pages version [here](http://rust-lang.github.io/book/ch05-01-method-syntax.html#Methods%20with%20More%20Arguments) (as of 2016/10/15) so this is a pull request to remove them.

Of course if they are supposed to be there then please just close this :)
Thanks for all the hard work you have put into this book!