### PR TITLE
Corrected run-on sentence in data race definition

### DIFF
--- a/src/ch04-02-references-and-borrowing.md
+++ b/src/ch04-02-references-and-borrowing.md
@@ -157,7 +157,7 @@ something that new Rustaceans struggle with, because most languages let you
 mutate whenever you’d like. The benefit of having this restriction is that Rust
 can prevent data races at compile time. A *data race* is a particular type of
 race condition where two or more pointers access the same data at the same
-time, at least one of the pointers is being used to write to the data, and
+time. At least one of the pointers is being used to write to the data, and
 there’s no mechanism being used to synchronize access to the data. Data races
 cause undefined behavior and can be difficult to diagnose and fix when trying
 to track them down at runtime; Rust prevents this problem from happening since

--- a/src/ch04-02-references-and-borrowing.md
+++ b/src/ch04-02-references-and-borrowing.md
@@ -155,13 +155,17 @@ error[E0499]: cannot borrow `s` as mutable more than once at a time
 This restriction allows for mutation but in a very controlled fashion. It is
 something that new Rustaceans struggle with, because most languages let you
 mutate whenever you’d like. The benefit of having this restriction is that Rust
-can prevent data races at compile time. A *data race* is a particular type of
-race condition where two or more pointers access the same data at the same
-time. At least one of the pointers is being used to write to the data, and
-there’s no mechanism being used to synchronize access to the data. Data races
-cause undefined behavior and can be difficult to diagnose and fix when trying
-to track them down at runtime; Rust prevents this problem from happening since
-it won’t even compile code with data races!
+can prevent data races at compile time.
+
+A *data race* is a particular type of race condition where these three things occur:
+
+-  two or more pointers access the same data at the same time
+-  at least one of the pointers is being used to write to the data
+-  there’s no mechanism being used to synchronize access to the data
+
+Data races cause undefined behavior and can be difficult to diagnose and fix
+when trying to track them down at runtime; Rust prevents this problem from
+happening since it won’t even compile code with data races!
 
 As always, we can use `{}`s to create a new scope, allowing for multiple mutable
 references, just not *simultaneous* ones:


### PR DESCRIPTION
The definition of data races seemed a bit unclear to me at first due to the run-on sentence. I think simply breaking the sentence into two sentences reads better. Thoughts?