### PR TITLE
Fix off-by-one mistake in while loop explanation

### DIFF
--- a/src/ch03-05-control-flow.md
+++ b/src/ch03-05-control-flow.md
@@ -383,7 +383,7 @@ the value is: 50
 ```
 
 All five array values appear in the terminal, as expected. Even though `index`
-will reach a value of `6` at some point, the loop stops executing before trying
+will reach a value of `5` at some point, the loop stops executing before trying
 to fetch a sixth value from the array.
 
 But this approach is error prone; we could cause the program to panic if the


### PR DESCRIPTION
There seems to be a confusing off-by-one mistake in the section about while-loops. This was discovered by one of my assistants.
