### PR TITLE
Note about String being UTF-8

### DIFF
--- a/src/ch04-01-what-is-ownership.md
+++ b/src/ch04-01-what-is-ownership.md
@@ -152,8 +152,9 @@ Rust knows when to clean up that data.
 
 We’ll use `String` as the example here and concentrate on the parts of `String`
 that relate to ownership. These aspects also apply to other complex data types
-provided by the standard library and that you create. We’ll discuss `String` in
-more depth in Chapter 8.
+provided by the standard library and that you create. When reading this
+Chapter note that `String` are encoded in UTF-8 which uses one byte only for
+ASCII characters. We’ll discuss `String` in more depth in Chapter 8.
 
 We’ve already seen string literals, where a string value is hardcoded into our
 program. String literals are convenient, but they aren’t always suitable for


### PR DESCRIPTION
When going through Chapter 4 I was chocked by the use of bytes and immediately tried to use higher Unicode character in the example which broke some of the simpler representation in that Chapter, and ended up wasting a lot of time trying to understand what's going on. Using a one for one byte for character helps simplify this chapter but can be confusing for people familiar with Unicode and its encodings.