### PR TITLE
Fix a pesky type error

### DIFF
--- a/src/ch08-03-hash-maps.md
+++ b/src/ch08-03-hash-maps.md
@@ -41,7 +41,7 @@ in the prelude. Hash maps also have less support from the standard library;
 there's no built-in macro to construct them, for example.
 
 Just like vectors, hash maps store their data on the heap. This `HashMap` has
-keys of type `&str` and values of type `i32`. Like vectors, hash maps are
+keys of type `String` and values of type `i32`. Like vectors, hash maps are
 homogeneous: all of the keys must have the same type, and all of the values must
 have the same type.
 


### PR DESCRIPTION
```
error[E0308]: mismatched types
  --> src/ch08-03-hash-maps.md:44:15
   |
44 | keys of type `&str` and values of type `i32`. Like vectors, hash maps are
   |               ^ expected struct `std::string::String`, found &str
   |
   = note: to fix, merge this pull request
```