### PR TITLE
Replace double & triple hyphens with em dashes

### DIFF
--- a/src/ch09-02-recoverable-errors-with-result.md
+++ b/src/ch09-02-recoverable-errors-with-result.md
@@ -392,7 +392,7 @@ io::Error>`. This means that the function is returning a value of the type
 `Result<T, E>` where the generic parameter `T` has been filled in with the
 concrete type `String`, and the generic type `E` has been filled in with the
 concrete type `io::Error`. If this function succeeds without any problems, the
-caller of this function will receive an `Ok` value that holds a `String` -- the
+caller of this function will receive an `Ok` value that holds a `String`—the
 username that this function read from the file. If this function encounters any
 problems, the caller of this function will receive an `Err` value that holds an
 instance of `io::Error` that contains more information about what the problems

--- a/src/ch09-03-to-panic-or-not-to-panic.md
+++ b/src/ch09-03-to-panic-or-not-to-panic.md
@@ -73,9 +73,9 @@ we'd definitely want to handle the `Result` in a more robust way instead.
 ### Guidelines for Error Handling
 
 It's advisable to have your code `panic!` when it's possible that you could end
-up in a *bad state*---in this context, *bad state* is when some assumption,
+up in a *bad state*—in this context, *bad state* is when some assumption,
 guarantee, contract, or invariant has been broken, such as when invalid values,
-contradictory values, or missing values are passed to your code---plus one or
+contradictory values, or missing values are passed to your code—plus one or
 more of the following:
 
 * The bad state is not something that's *expected* to happen occasionally

--- a/src/ch10-03-lifetime-syntax.md
+++ b/src/ch10-03-lifetime-syntax.md
@@ -127,7 +127,7 @@ annotations:
 Here, we've annotated the lifetime of `r` with `'a` and the lifetime of `x`
 with `'b`. Rust looks at these lifetimes and sees that `r` has a lifetime of
 `'a`, but that it refers to something with a lifetime of `'b`. It rejects the
-program because the lifetime `'b` is shorter than the lifetime of `'a`-- the
+program because the lifetime `'b` is shorter than the lifetime of `'a`—the
 value that the reference is referring to does not live as long as the reference
 does.
 


### PR DESCRIPTION
In prose only; I left them as is in author's comments.