### PR TITLE
Remove redundant duplicate 'can'

### DIFF
--- a/src/ch08-02-strings.md
+++ b/src/ch08-02-strings.md
@@ -100,7 +100,7 @@ let hello = "Hola";
 
 ### Updating a String
 
-A `String` can can grow in size and its contents can change just like the
+A `String` can grow in size and its contents can change just like the
 contents of a `Vec`, by pushing more data into it. In addition, `String` has
 concatenation operations implemented with the `+` operator for convenience.
 


### PR DESCRIPTION
Currently reading through the book and just stumbled across this tiny tiny tiny typo. Really loving the rest so far though! 😍