### PR TITLE
details in error E0382 changed over time

### DIFF
--- a/src/ch04-01-what-is-ownership.md
+++ b/src/ch04-01-what-is-ownership.md
@@ -364,14 +364,16 @@ You’ll get an error like this because Rust prevents you from using the
 invalidated reference:
 
 ```text
-5:22 error: use of moved value: `s1` [E0382]
-println!("{}", s1);
-               ^~
-5:24 note: in this expansion of println! (defined in <std macros>)
-3:11 note: `s1` moved here because it has type `collections::string::String`,
-which is moved by default
- let s2 = s1;
-     ^~
+error[E0382]: use of moved value: `s1`
+ --> src/main.rs:4:27
+  |
+3 |     let s2 = s1;
+  |         -- value moved here
+4 |     println!("{}, world!",s1);
+  |                           ^^ value used here after move
+  |
+  = note: move occurs because `s1` has type `std::string::String`,
+which does not implement the `Copy` trait
 ```
 
 If you’ve heard the terms “shallow copy” and “deep copy” while working with


### PR DESCRIPTION
The "move" error output is different now. Also the name-space of `String` changed.
Using `rustc 1.14.0 (e8a012324 2016-12-16)`
Probably there are other differences like this.
May be a review of all errors and warnings output is needed.
I see this chapter is also frozen. Do what you think is best.
Thanks!
