### PR TITLE
Fix code example compile error due to missing use

### DIFF
--- a/src/ch09-02-recoverable-errors-with-result.md
+++ b/src/ch09-02-recoverable-errors-with-result.md
@@ -361,6 +361,7 @@ to the code that called this function:
 
 ```rust
 use std::io;
+use std::io::Read;
 use std::fs::File;
 
 fn read_username_from_file() -> Result<String, io::Error> {


### PR DESCRIPTION
Got the following from the compiler when trying to run the example:

```
error: no method named `read_to_string` found for type `std::fs::File` in the current scope
  --> src/main.rs:32:13
   |
32 |     match f.read_to_string(&mut s) {
   |             ^^^^^^^^^^^^^^
   |
   = help: items from traits can only be used if the trait is in scope; the following trait is implemented but not in scope, perhaps add a `use` for it:
   = help: candidate #1: `use std::io::Read;`
```

A small oddity I don't understand is why GitHub doesn't seem to want to render that code section here 😕 Perhaps it's only on my end though.