### PR TITLE
Link to the section in chapter 2

### DIFF
--- a/src/ch09-02-recoverable-errors-with-result.md
+++ b/src/ch09-02-recoverable-errors-with-result.md
@@ -7,10 +7,10 @@ operation fails because the file doesn’t exist, we might want to create the
 file instead of terminating the process.
 
 Recall from Chapter 2 the section on “[Handling Potential Failure with the
-`Result` Type][handlefailure]” that the `Result` enum is defined as having two variants, `Ok`
+`Result` Type][handle_failure]<!-- ignore -->” that the `Result` enum is defined as having two variants, `Ok`
 and `Err`, as follows:
 
-[handlefailure]: ch02-00-guessing-game-tutorial.md#handling-potential-failure-with-the-result-type
+[handle_failure]: ch02-00-guessing-game-tutorial.md#handling-potential-failure-with-the-result-type
 
 ```rust
 enum Result<T, E> {

--- a/src/ch09-02-recoverable-errors-with-result.md
+++ b/src/ch09-02-recoverable-errors-with-result.md
@@ -7,8 +7,8 @@ operation fails because the file doesn’t exist, we might want to create the
 file instead of terminating the process.
 
 Recall from Chapter 2 the section on “[Handling Potential Failure with the
-`Result` Type][handle_failure]<!-- ignore -->” that the `Result` enum is defined as having two variants, `Ok`
-and `Err`, as follows:
+`Result` Type][handle_failure]<!-- ignore -->” that the `Result` enum is defined
+as having two variants, `Ok` and `Err`, as follows:
 
 [handle_failure]: ch02-00-guessing-game-tutorial.md#handling-potential-failure-with-the-result-type
 

--- a/src/ch09-02-recoverable-errors-with-result.md
+++ b/src/ch09-02-recoverable-errors-with-result.md
@@ -6,9 +6,11 @@ interpret and respond to. For example, if we try to open a file and that
 operation fails because the file doesn’t exist, we might want to create the
 file instead of terminating the process.
 
-Recall from Chapter 2 the section on “Handling Potential Failure with the
-`Result` Type” that the `Result` enum is defined as having two variants, `Ok`
+Recall from Chapter 2 the section on “[Handling Potential Failure with the
+`Result` Type][handlefailure]” that the `Result` enum is defined as having two variants, `Ok`
 and `Err`, as follows:
+
+[handlefailure]: ch02-00-guessing-game-tutorial.md#handling-potential-failure-with-the-result-type
 
 ```rust
 enum Result<T, E> {


### PR DESCRIPTION
Just a thought, but I hit this section of the book, couldn't remember much about chapter 2 and, as that chapter's not broken into sections in the nav bar, it took me a bit of scrolling to find the relevant part.

So would it be OK to link through to it? I think I've kept to the style of the links.