### PR TITLE
Automate normalization of line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto

--- a/README.md
+++ b/README.md
@@ -113,10 +113,3 @@ script. It needs a dictionary of valid words, which is provided in
 `BTreeMap` which the script considers invalid), you need to add this word to
 `dictionary.txt` (keep the sorted order for consistency).
 
-## Converting Windows newlines to Unix
-
-This is mostly for Carol's reference because she keeps having to look it up.
-
-```
-$ tr -d '\015' < DOS-file > UNIX-file
-```


### PR DESCRIPTION
This PR is a bit presumptuous, but the easiest way to see if you would want the change was to submit a PR which can either be merged or closed as appropriate.

I noticed the "reminder" message in the README about converting line endings.  In all the contexts I have ever encountered that problem, letting git handle that automatically has been appropriate.  This PR adds a `.gitattributes` file that ensures Unix line endings are committed to the repository and removes the reminder note about how to manually convert.