### PR TITLE
Fix for generic method definition example in Ch 10

### DIFF
--- a/second-edition/src/ch10-01-syntax.md
+++ b/second-edition/src/ch10-01-syntax.md
@@ -392,7 +392,7 @@ struct Point<T, U> {
 }
 
 impl<T, U> Point<T, U> {
-    fn mixup<V, W>(&self, other: &Point<V, W>) -> Point<T, W> {
+    fn mixup<V, W>(self, other: Point<V, W>) -> Point<T, W> {
         Point {
             x: self.x,
             y: other.y,


### PR DESCRIPTION
Hey,

I was reading the Generics chapter tonight when I noticed that one of the examples in the "Using Generic Data Types in Method Definitions" section didn't compile.

I went with a fix that replaced the reference with a move, as I figured the only other way to fix it would be to add a `Copy` trait bound - and that's not covered until the next section.

Unless there's a better example that could cover the same idea?