### PR TITLE
fix #493 - appendix section letters

### DIFF
--- a/second-edition/src/appendix-01-keywords.md
+++ b/second-edition/src/appendix-01-keywords.md
@@ -1,4 +1,4 @@
-## Keywords
+## Appendix A: Keywords
 
 The following keywords are reserved by the Rust language and may not be used as
 names of functions, variables, macros, modules, crates, constants, static

--- a/second-edition/src/appendix-02-operators.md
+++ b/second-edition/src/appendix-02-operators.md
@@ -1,4 +1,4 @@
-## Operators
+## Appendix B: Operators
 
 ### Unary operator expressions
 

--- a/second-edition/src/appendix-03-derivable-traits.md
+++ b/second-edition/src/appendix-03-derivable-traits.md
@@ -1,1 +1,1 @@
-## Derivable Traits
+## Appendix C: Derivable Traits

--- a/second-edition/src/appendix-04-nightly-rust.md
+++ b/second-edition/src/appendix-04-nightly-rust.md
@@ -1,1 +1,1 @@
-# Nightly Rust
+## Appendix D: Nightly Rust

--- a/second-edition/src/appendix-05-macros.md
+++ b/second-edition/src/appendix-05-macros.md
@@ -1,4 +1,4 @@
-# Macros
+## Appendix E: Macros
 
 ## Basics of writing your own macros
 

--- a/second-edition/src/appendix-06-translation.md
+++ b/second-edition/src/appendix-06-translation.md
@@ -1,4 +1,4 @@
-## Translations of the Book
+## Appendix F: Translations of the Book
 
 For resources in languages other than English. Most are still in progress; see
 [the Translations label][label] to help or let us know about a new translation!


### PR DESCRIPTION
Hey - This is a fix for #493. I've changed each appendix title to `Appendix {letter}: {Appendix Title}`.

I did it like that as, well, I thought it looked better that way rather than pollute the title with the full MdBook chapter number/section.

Hope it's alright!