### PR TITLE
Updated README for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,18 @@ your web browser.
 
 _Firefox:_
 ```
-$ firefox book/index.html           # Linux
-$ open -a "Firefox" book/index.html # OS X
+$ firefox book/index.html                       # Linux
+$ open -a "Firefox" book/index.html             # OS X
+$ Start-Process "firefox.exe" .\book\index.html # Windows (PowerShell)
+$ start firefox.exe .\book\index.html           # Windows (Cmd)
 ```
 
 _Chrome:_
 ```
-$ google-chrome book/index.html           # Linux
-$ open -a "Google Chrome" book/index.html # OS X
+$ google-chrome book/index.html                 # Linux
+$ open -a "Google Chrome" book/index.html       # OS X
+$ Start-Process "chrome.exe" .\book\index.html  # Windows (PowerShell)
+$ start chrome.exe .\book\index.html            # Windows (Cmd)
 ```
 
 To run the tests:


### PR DESCRIPTION
Updated the README to include how to open Firefox and Chrome from cmd and PowerShell.  I noticed that the commands I included with relative paths to the local index file work if the browser is already open.  Running the command twice or putting in the absolute path will work.  I wasn't sure how to add that note appropriately and am open to suggestions on how change it.  Thanks again!
