### PR TITLE
Remove third rule of data race definition

### DIFF
--- a/second-edition/src/ch04-02-references-and-borrowing.md
+++ b/second-edition/src/ch04-02-references-and-borrowing.md
@@ -158,12 +158,11 @@ something that new Rustaceans struggle with, because most languages let you
 mutate whenever you’d like. The benefit of having this restriction is that Rust
 can prevent data races at compile time.
 
-A *data race* is a particular type of race condition in which these three
+A *data race* is a particular type of race condition in which these two
 behaviors occur:
 
 1. Two or more pointers access the same data at the same time.
 1. At least one of the pointers is being used to write to the data.
-1. There’s no mechanism being used to synchronize access to the data.
 
 Data races cause undefined behavior and can be difficult to diagnose and fix
 when you’re trying to track them down at runtime; Rust prevents this problem


### PR DESCRIPTION
The term pointer assumes unsynchronized access. Rule three makes the definition more complex for little correctness gain. If you don't know about synchronization then you will only be confused since this is the only place where the term synchronization appears in the book, and the only place where it should appear is more than 10 chapters forward in the concurrency chapter.

Considering this chapter is frozen should this change be stashed for when you are ready to accept changes again?