### PR TITLE
Add updating instructions for Rust

### DIFF
--- a/second-edition/src/ch01-01-installation.md
+++ b/second-edition/src/ch01-01-installation.md
@@ -46,6 +46,15 @@ documentation for the shell you are using.
 If you have reasons for preferring not to use rustup.rs, please see [the Rust
 installation page](https://www.rust-lang.org/install.html) for other options.
 
+### Updating
+
+Once you had Rust installed, updating to the latest version is easy.
+From your shell, run the update script:
+
+```text
+$ rustup update
+```
+
 ### Uninstalling
 
 Uninstalling Rust is as easy as installing it. From your shell, run


### PR DESCRIPTION
The introduction tells how to install and uninstall rust, but not how to update it.

This solves the following use case:
> As a user, I installed Rust according to the book.
Time elapsed without me finishing the book.
Now that I go back to the book, I want to make sure my rust is up to date (just like if I just started the book fresh with a new install).

Without this, users will either need to decide to uninstall then reinstall (seems like a hack), or will have to go outside the book to get their answer.