### PR TITLE
Fix failing tidy

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # Set the default behavior, in case people don't have core.autocrlf set.
-* text=auto
+* text=auto eol=lf


### PR DESCRIPTION
When this book was included into https://github.com/rust-lang/rust as a submodule, `tidy` started failing on Windows.
Not sure how this passed through Appveyor.

This patch sets `.gitattributes` to the same value that is used by the main repo.
@steveklabnik @carols10cents Could you please merge this sooner rather than later