### PR TITLE
update documentation test example from 14.2

### DIFF
--- a/second-edition/src/ch14-02-publishing-to-crates-io.md
+++ b/second-edition/src/ch14-02-publishing-to-crates-io.md
@@ -34,7 +34,7 @@ comments for an `add_one` function:
 /// ```
 /// let five = 5;
 ///
-/// assert_eq!(6, add_one(5));
+/// assert_eq!(6, add_one(five));
 /// # fn add_one(x: i32) -> i32 {
 /// #     x + 1
 /// # }

--- a/second-edition/src/ch14-02-publishing-to-crates-io.md
+++ b/second-edition/src/ch14-02-publishing-to-crates-io.md
@@ -26,7 +26,7 @@ comments for an `add_one` function:
 
 <span class="filename">Filename: src/lib.rs</span>
 
-````rust
+````rust,ignore
 /// Adds one to the number given.
 ///
 /// # Examples


### PR DESCRIPTION
When I first saw this I thought it was a bit odd that the variable declaration wasn't getting used in the assertion, so I changed that in the first commit.

Then it struck me that when running the code through with `mdbook` you'd always get a dead code warning as the function is never actually called, so I've annotated the code fence with an `ignore`.

(we could just allow dead_code, but this seemed better to me)
