### PR TITLE
Correcting first-edition github link

### DIFF
--- a/first-edition/src/README.md
+++ b/first-edition/src/README.md
@@ -36,4 +36,4 @@ is the first. After this:
 The source files from which this book is generated can be found on
 [GitHub][book].
 
-[book]: https://github.com/rust-lang/rust/tree/master/src/doc/book
+[book]: https://github.com/rust-lang/book/tree/master/first-edition/src


### PR DESCRIPTION
The url for the first-edition github source, as visible here
http://rust-lang.github.io/book/first-edition/index.html
is incorrect and links to the old url https://github.com/rust-lang/rust/tree/master/src/doc/book

I have changed this to refer to https://github.com/rust-lang/book/tree/master/first-edition/src
