### PR TITLE
Fix footnote in macros.md (first edition)

### DIFF
--- a/first-edition/src/macros.md
+++ b/first-edition/src/macros.md
@@ -58,6 +58,7 @@ We can implement this shorthand, using a macro: [^actual]
 
 [^actual]: The actual definition of `vec!` in libcollections differs from the
            one presented here, for reasons of efficiency and reusability.
+		   
 
 ```rust
 macro_rules! vec {


### PR DESCRIPTION
By lacking an additional newline at the end, the footnote contained
the rest of the Markdown file. With mdbook it's not very visible
unless you inspect the HTML code, but it causes more problems for
export in other formats.
