### PR TITLE
Fix Bug: no method named `write_fmt` found

### DIFF
--- a/second-edition/src/ch12-06-writing-to-stderr-instead-of-stdout.md
+++ b/second-edition/src/ch12-06-writing-to-stderr-instead-of-stdout.md
@@ -34,6 +34,7 @@ extern crate greprs;
 use std::env;
 use std::process;
 use std::io::prelude::*;
+use std::io::Write;
 
 use greprs::Config;
 
@@ -70,7 +71,7 @@ of `stdout`</span>
 <!-- Will add ghosting and wingdings in libreoffice /Carol -->
 
 Rust does not have a convenient function like `println!` for writing to
-standard error. Instead, we use the `writeln!` macro, which is sort of like
+standard error. Instead, we use the `writeln!` macro by `use std::io::Write;`, which is sort of like
 `println!`, but it takes an extra argument. The first thing we pass to it is
 what to write to. We can acquire a handle to standard error through the
 `std::io::stderr` function. We give a mutable reference to `stderr` to


### PR DESCRIPTION
it need `use std::io::Write;` to fix the bug.

```rust

cargo run > output.txt
   Compiling greprs v0.1.0 (file:///Users/blackanger/work/box/data/apps/rust/greprs)
error: no method named `write_fmt` found for type `&mut std::io::Stderr` in the current scope
  --> src/main.rs:13:9
   |
13 |           writeln!(
   |  _________^ starting here...
14 | |             &mut stderr,
15 | |             "Problem parsing arguments: {}",
16 | |             err
17 | |         ).expect("Could not write to stderr");
   | |_________^ ...ending here
   |
   = help: items from traits can only be used if the trait is in scope; the following trait is implemented but not in scope, perhaps add a `use` for it:
   = help: candidate #1: `use std::io::Write;`
   = note: this error originates in a macro outside of the current crate

error: no method named `write_fmt` found for type `&mut std::io::Stderr` in the current scope
  --> src/main.rs:24:9
   |
24 |           writeln!(
   |  _________^ starting here...
25 | |             &mut stderr,
26 | |             "Application error: {}",
27 | |             e
28 | |         ).expect("Could not write to stderr");
   | |_________^ ...ending here
   |
   = help: items from traits can only be used if the trait is in scope; the following trait is implemented but not in scope, perhaps add a `use` for it:
   = help: candidate #1: `use std::io::Write;`
   = note: this error originates in a macro outside of the current crate

error: aborting due to 2 previous errors

error: Could not compile `greprs`.


```

## What to expect when you open a pull request here

### First edition

The first edition is no longer being actively worked on. We accept pull
requests for the first edition, but prefer small tweaks to large changes, as
larger work should be spent improving the second edition.

### Second edition

For the second edition, we are currently working with No Starch Press to bring
it to print. Chapters go through a number of stages in the editing process, and
once they've gotten to the layout stage, they're effectively frozen.

For chapters that have gotten to the layout stage, we will likely only be
accepting changes that correct factual errors or major problems and not, for
example, minor wording changes.

Scroll all the way to the right on https://github.com/rust-lang/book/projects/1
to see which chapters have been frozen.

Please see CONTRIBUTING.md for more details.

Thank you for reading, you may now delete this text!
