### PR TITLE
Nit: explicitly mention the edition of the book

### DIFF
--- a/second-edition/src/ch01-00-introduction.md
+++ b/second-edition/src/ch01-00-introduction.md
@@ -1,9 +1,9 @@
 # Introduction
 
-Welcome to “The Rust Programming Language,” an introductory book about Rust.
-Rust is a programming language that’s focused on safety, speed, and
-concurrency. Its design lets you create programs that have the performance and
-control of a low-level language, but with the powerful abstractions of a
+Welcome to the second edition of “The Rust Programming Language,” an introductory
+book about Rust. Rust is a programming language that’s focused on safety, speed,
+and concurrency. Its design lets you create programs that have the performance
+and control of a low-level language, but with the powerful abstractions of a
 high-level language. These properties make Rust suitable for programmers who
 have experience in languages like C and are looking for a safer alternative, as
 well as those from languages like Python who are looking for ways to write code


### PR DESCRIPTION
I'm never going to be able to visually distinguish between the first and second editions of the book, so going forward it will be nice to have some assurance that I'm linking people to the intended edition. It's also common practice for the covers or forewords of books to mention their edition, and the intro page is the closest thing the book has to either of those.