### PR TITLE
Update MathJax URL

### DIFF
--- a/second-edition/src/theme/index.hbs
+++ b/second-edition/src/theme/index.hbs
@@ -21,7 +21,7 @@
         <link rel="stylesheet" href="tomorrow-night.css">
 
         <!-- MathJax -->
-        <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 
         <!-- Fetch JQuery from CDN but have a local fallback -->
         <script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>


### PR DESCRIPTION
[MathJax CDN will shut down soon](https://www.mathjax.org/cdn-shutting-down/), so the URL is updated to use their recommended CDNJS.
