### PR TITLE
Ch17-01 misconstructed sentence

### DIFF
--- a/second-edition/src/ch17-01-what-is-oo.md
+++ b/second-edition/src/ch17-01-what-is-oo.md
@@ -112,12 +112,12 @@ field directly, which could cause the `average` field to get out of sync. The
 external code to read the `average` but not modify it.
 
 Because we've encapsulated the implementation details of `AveragedCollection`,
-we could also change aspects like using a different data structure used for the
-`list` to use a `HashSet` instead of a `Vec`, for instance. As long as the
-signatures of the `add`, `remove`, and `average` public methods stayed the same,
-code using `AveragedCollection` wouldn't need to change. This wouldn't
-necessarily be the case if we exposed `list` to external code: `HashSet` and
-`Vec` have different methods for adding and removing items, so the external
+we can easily change aspects like the data structure in the future; for
+instance, we could use a `HashSet` instead of a `Vec` for the `list` variable.
+As long as the signatures of the `add`, `remove`, and `average` public methods
+stay the same, code using `AveragedCollection` wouldn't need to change. This
+wouldn't necessarily be the case if we exposed `list` to external code: `HashSet`
+and `Vec` have different methods for adding and removing items, so the external
 code would likely have to change if it was modifying `list` directly.
 
 If encapsulation is a required aspect for a language to be considered


### PR DESCRIPTION
Too many times 'use' in one sentence gets very confusing; fixed it for better readability.