### PR TITLE
ch20 /sleep instead of /slow

### DIFF
--- a/second-edition/src/ch20-05-adding-a-thread-pool.md
+++ b/second-edition/src/ch20-05-adding-a-thread-pool.md
@@ -1201,8 +1201,8 @@ Let's bump that request count up to five:
     if counter == 5 {
 ```
 
-And try hitting `/slow` and `/` at the same time, as we did before. You
-should see the request for `/` complete before the request for `/slow`;
+And try hitting `/sleep` and `/` at the same time, as we did before. You
+should see the request for `/` complete before the request for `/seep`;
 we're doing our processing in the background, and not processing requests
 sequentially any more!
 


### PR DESCRIPTION
The endpoint is called /sleep and not /slow.
