### PR TITLE
Remove unnecessary .take(5) in iterator example

### DIFF
--- a/second-edition/src/ch13-02-iterators.md
+++ b/second-edition/src/ch13-02-iterators.md
@@ -217,11 +217,11 @@ method. Since `next` is the only method of the `Iterator` trait that does not
 have a default implementation, once you've done that, you get all of the other
 `Iterator` adaptors for free. There are a lot of them!
 
-For example, if for some reason we wanted to take the first five values that
-an instance of `Counter` produces, pair those values with values produced by
-another `Counter` instance after skipping the first value that instance
-produces, multiply each pair together, keep only those results that are
-divisible by three, and add all the resulting values together, we could do so:
+For example, if for some reason we wanted to take the values that an instance of
+`Counter` produces, pair those values with values produced by another `Counter`
+instance after skipping the first value that instance produces, multiply each
+pair together, keep only those results that are divisible by three, and add all
+the resulting values together, we could do so:
 
 ```rust
 # struct Counter {
@@ -250,8 +250,7 @@ divisible by three, and add all the resulting values together, we could do so:
 #         }
 #     }
 # }
-let sum: u32 = Counter::new().take(5)
-                             .zip(Counter::new().skip(1))
+let sum: u32 = Counter::new().zip(Counter::new().skip(1))
                              .map(|(a, b)| a * b)
                              .filter(|x| x % 3 == 0)
                              .sum();


### PR DESCRIPTION
Although the example is demonstrating different iterator adaptors in an intentionally silly way I believe that the (harmless) `.take(5)` on the iterator of length 5 is potentially confusing if you're new to these things.

Essentially the correlation between then length of the iterator and the argument to `take` vaguely imply that it's not optional.

I don't think this is a big deal and you might not agree.

An alternative would be to change it to `.take(4)`. If that's preferable (to sneak in the name of another useful iterator adaptor) I can amend my commit.