### PR TITLE
fix(bibiliography): link to thesis by Florian

### DIFF
--- a/first-edition/src/bibliography.md
+++ b/first-edition/src/bibliography.md
@@ -61,8 +61,7 @@ Language](http://www.cs.indiana.edu/~eholk/papers/hips2013.pdf). Early GPU work 
   Rust](http://scialex.github.io/reenix.pdf). Undergrad paper by Alex
   Light.
 * [Evaluation of performance and productivity metrics of potential
-  programming languages in the HPC environment]
-  (http://octarineparrot.com/assets/mrfloya-thesis-ba.pdf).
+  programming languages in the HPC environment](http://octarineparrot.com/assets/mrfloya-thesis-ba.pdf).
   Bachelor's thesis by Florian Wilkens. Compares C, Go and Rust.
 * [Nom, a byte oriented, streaming, zero copy, parser combinators library
   in Rust](http://spw15.langsec.org/papers/couprie-nom.pdf). By


### PR DESCRIPTION
Fixes missing click-able link for `Evaluation of performance and productivity ...` on https://doc.rust-lang.org/book/bibliography.html