### PR TITLE
Point references to prelude to correct documentation links

### DIFF
--- a/first-edition/src/guessing-game.md
+++ b/first-edition/src/guessing-game.md
@@ -106,8 +106,8 @@ prelude, you’ll have to `use` it directly. There is also a second ‘prelude�
 [`io` prelude][ioprelude], which serves a similar function: you import it, and it
 imports a number of useful, `io`-related things.
 
-[prelude]: ../../std/prelude/index.html
-[ioprelude]: ../../std/io/prelude/index.html
+[prelude]: https://doc.rust-lang.org/std/prelude
+[ioprelude]: https://doc.rust-lang.org/std/io/prelude
 
 ```rust,ignore
 fn main() {

--- a/second-edition/src/ch02-00-guessing-game-tutorial.md
+++ b/second-edition/src/ch02-00-guessing-game-tutorial.md
@@ -112,7 +112,7 @@ prelude, you have to bring that type into scope explicitly with a `use`
 statement. Using the `std::io` library provides you with a number of useful
 `io`-related features, including the functionality to accept user input.
 
-[prelude]: ../../std/prelude/index.html
+[prelude]: https://doc.rust-lang.org/std/prelude
 
 As you saw in Chapter 1, the `main` function is the entry point into the
 program:


### PR DESCRIPTION
I started learning Rust today and noticed that the references to `prelude` linking to the documentation in both editions of the book seem to be broken. My guess is that they should be pointing to `https://doc.rust-lang.org`. 

(Please let me know if I haven't made this PR correctly—this is my first open source contribution, ever! Hopefully I did it right. 🙈)