### PR TITLE
Remove superfluous return

### DIFF
--- a/first-edition/src/references-and-borrowing.md
+++ b/first-edition/src/references-and-borrowing.md
@@ -83,7 +83,7 @@ A more concrete example:
 fn main() {
     // Don't worry if you don't understand how `fold` works, the point here is that an immutable reference is borrowed.
     fn sum_vec(v: &Vec<i32>) -> i32 {
-        return v.iter().fold(0, |a, &b| a + b);
+        v.iter().fold(0, |a, &b| a + b)
     }
     // Borrow two vectors and sum them.
     // This kind of borrowing does not allow mutation through the borrowed reference.


### PR DESCRIPTION
Making it arguably more idiomatic and being consistent.

See also: https://doc.rust-lang.org/book/functions.html#early-returns
