### PR TITLE
Document the loop_break_value feature

### DIFF
--- a/second-edition/src/appendix-07-newest-features.md
+++ b/second-edition/src/appendix-07-newest-features.md
@@ -29,7 +29,7 @@ fn main() {
 
     // Using field init shorthand:
     let portia = Person { name, age };
-    
+
     println!("{:?}", portia);
 }
 ```

--- a/second-edition/src/appendix-07-newest-features.md
+++ b/second-edition/src/appendix-07-newest-features.md
@@ -33,3 +33,27 @@ fn main() {
     println!("{:?}", portia);
 }
 ```
+
+
+## Returning from loops
+
+One of the uses of a `loop` is to retry an operation you know can fail, such as
+checking if a thread completed its job. However, you might need to pass the
+result of that operation to the rest of your code. If you add it to the `break`
+expression you use to stop the loop, it will be returned by the broken loop:
+
+```rust
+fn main() {
+    let mut counter = 0;
+
+    let result = loop {
+        counter += 1;
+
+        if counter == 10 {
+            break counter * 2;
+        }
+    };
+
+    assert_eq!(result, 20);
+}
+```


### PR DESCRIPTION
This pull requests adds a section in the new features appendix about the `loop_break_value` feature (which should be stabilized after all the documentation is ready), tracked in issue rust-lang/rust#37339.

I reused the basic example I made for Rust by Example, but if something more realistic (maybe with threads and channels) is OK here I'm happy to change it.