### PR TITLE
Use std::time::Duration::from_secs in ch16-02

### DIFF
--- a/second-edition/src/ch16-02-message-passing.md
+++ b/second-edition/src/ch16-02-message-passing.md
@@ -210,7 +210,7 @@ fn main() {
 
         for val in vals {
             tx.send(val).unwrap();
-            thread::sleep(Duration::new(1, 0));
+            thread::sleep(Duration::from_secs(1));
         }
     });
 
@@ -275,7 +275,7 @@ thread::spawn(move || {
 
     for val in vals {
         tx1.send(val).unwrap();
-        thread::sleep(Duration::new(1, 0));
+        thread::sleep(Duration::from_secs(1));
     }
 });
 
@@ -289,7 +289,7 @@ thread::spawn(move || {
 
     for val in vals {
         tx.send(val).unwrap();
-        thread::sleep(Duration::new(1, 0));
+        thread::sleep(Duration::from_secs(1));
     }
 });
 // ...snip...


### PR DESCRIPTION
The function `std::time::Duration::from_secs` has a more explicit name which is arguably more appropriate in a book to learn Rust.