### PR TITLE
Replace "printed" with "minted"

### DIFF
--- a/second-edition/src/ch06-02-match.md
+++ b/second-edition/src/ch06-02-match.md
@@ -96,7 +96,7 @@ values that match the pattern. This is how we can extract values out of enum
 variants.
 
 As an example, let’s change one of our enum variants to hold data inside it.
-From 1999 through 2008, the United States printed quarters with different
+From 1999 through 2008, the United States minted quarters with different
 designs for each of the 50 states on one side. No other coins got state
 designs, so only quarters have this extra value. We can add this information to
 our `enum` by changing the `Quarter` variant to include a `State` value stored


### PR DESCRIPTION
Fixes #591:

> Coins are not "printed". The verb in this sentence should be minted.

I know it's in the "Frozen" column but I thought maybe it is worth fixing anyway... :confused: