### PR TITLE
Refactor code lightly w.r.t whitespace in ch12-03

### DIFF
--- a/second-edition/src/ch12-03-improving-error-handling-and-modularity.md
+++ b/second-edition/src/ch12-03-improving-error-handling-and-modularity.md
@@ -176,9 +176,7 @@ fn parse_config(args: &[String]) -> Config {
     let query = args[1].clone();
     let filename = args[2].clone();
 
-    Config {
-        query, filename
-    }
+    Config { query, filename }
 }
 ```
 
@@ -289,9 +287,7 @@ impl Config {
         let query = args[1].clone();
         let filename = args[2].clone();
 
-        Config {
-            query, filename
-        }
+        Config { query, filename }
     }
 }
 ```
@@ -405,9 +401,7 @@ impl Config {
         let query = args[1].clone();
         let filename = args[2].clone();
 
-        Ok(Config {
-            query, filename
-        })
+        Ok(Config { query, filename })
     }
 }
 ```
@@ -712,9 +706,7 @@ impl Config {
         let query = args[1].clone();
         let filename = args[2].clone();
 
-        Ok(Config {
-            query, filename
-        })
+        Ok(Config { query, filename })
     }
 }
 


### PR DESCRIPTION
I don't know if there are some fixed conventions in Rust, but I think that if either members deserve their own line or they should be on the same line as the constructor. e.g.

```Rust
// This is ok, especialy when there are many members
let _ = Config {
    query,
    filename,
    // many more...
};

// This is prefer when there are few members (up to four, maybe five?)
let _ = Config { query, filename };
```