### PR TITLE
[RFC] Fix statements not having return values in Chapter 3 and some small improvements

### DIFF
--- a/second-edition/src/ch02-00-guessing-game-tutorial.md
+++ b/second-edition/src/ch02-00-guessing-game-tutorial.md
@@ -752,15 +752,15 @@ to another type. Shadowing lets us reuse the `guess` variable name rather than
 forcing us to create two unique variables, like `guess_str` and `guess` for
 example. (Chapter 3 covers shadowing in more detail.)
 
-We bind `guess` to the expression `guess.trim().parse()`. The `guess` in the
-expression refers to the original `guess` that was a `String` with the input in
-it. The `trim` method on a `String` instance will eliminate any whitespace at
-the beginning and end. `u32` can only contain numerical characters, but the
-user must press the Return key to satisfy `read_line`. When the user presses
-Return, a newline character is added to the string. For example, if the user
-types 5 and presses return, `guess` looks like this: `5\n`. The `\n` represents
-“newline,” the return key. The `trim` method eliminates `\n`, resulting in just
-`5`.
+We bind `guess` to the value of the expression `guess.trim().parse()`. The
+`guess` in the expression refers to the original `guess` that was a `String`
+with the input in it. The `trim` method on a `String` instance will eliminate
+any whitespace at the beginning and end. `u32` can only contain numerical
+characters, but the user must press the Return key to satisfy `read_line`.
+When the user presses Return, a newline character is added to the string.
+For example, if the user types 5 and presses return, `guess` looks like this:
+`5\n`. The `\n` represents the “newline” character that results from pressing
+the return key. The `trim` method eliminates `\n`, resulting in just `5`.
 
 The [`parse` method on strings][parse]<!-- ignore --> parses a string into some
 kind of number. Because this method can parse a variety of number types, we
@@ -778,7 +778,7 @@ comparison will be between two values of the same type!
 The call to `parse` could easily cause an error. If, for example, the string
 contained `A👍%`, there would be no way to convert that to a number. Because it
 might fail, the `parse` method returns a `Result` type, much like the
-`read_line` method does as discussed earlier in “Handling Potential Failure
+`read_line` method does, as discussed earlier in “Handling Potential Failure
 with the Result Type”. We’ll treat this `Result` the same way by
 using the `expect` method again. If `parse` returns an `Err` `Result` variant
 because it couldn’t create a number from the string, the `expect` call will

--- a/second-edition/src/ch03-02-data-types.md
+++ b/second-edition/src/ch03-02-data-types.md
@@ -61,14 +61,14 @@ integer value.
 
 Each variant can be either signed or unsigned and has an explicit size.
 Signed and unsigned refers to whether it’s possible for the number to be
-negative or positive; in other words, whether the number needs to have a sign
-with it (signed) or whether it will only ever be positive and can therefore be
-represented without a sign (unsigned). It’s like writing numbers on paper: when
-the sign matters, a number is shown with a plus sign or a minus sign; however,
-when it’s safe to assume the number is positive, it’s shown with no sign.
-Signed numbers are stored using two’s complement representation (if you’re
-unsure what this is, you can search for it online; an explanation is outside
-the scope of this book).
+negative or not; in other words, whether the number needs to have a sign
+with it (signed) or whether it will only ever be positive or zero and can
+therefore be represented without a sign (unsigned). It’s like writing numbers
+on paper: when the sign matters, a number is shown with a plus sign or a minus
+sign; however, when it’s safe to assume the number is positive, it’s shown with
+no sign. Signed numbers are stored using two’s complement representation (if
+you’re unsure what this is, you can search for it online; an explanation is
+outside the scope of this book).
 
 Each signed variant can store numbers from -(2<sup>n - 1</sup>) to 2<sup>n -
 1</sup> - 1 inclusive, where `n` is the number of bits that variant uses. So an

--- a/second-edition/src/ch03-03-how-functions-work.md
+++ b/second-edition/src/ch03-03-how-functions-work.md
@@ -101,19 +101,17 @@ declarations with commas, like this:
 
 ```rust
 fn main() {
-    another_function(5, 6);
+    another_function(5, 'd');
 }
 
-fn another_function(x: i32, y: i32) {
+fn another_function(x: i32, c: char) {
     println!("The value of x is: {}", x);
-    println!("The value of y is: {}", y);
+    println!("The value of c is: {}", c);
 }
 ```
 
-This example creates a function with two parameters, both of which are `i32`
-types. The function then prints out the values in both of its parameters. Note
-that function parameters don't all need to be the same type, they just happen
-to be in this example.
+This example creates a function with two parameters, of type `i32` and `char`
+respectively. The function then prints out the values in both of its parameters.
 
 Let’s try running this code. Replace the program currently in your *function*
 project’s *src/main.rs* file with the preceding example, and run it using
@@ -124,11 +122,11 @@ $ cargo run
    Compiling functions v0.1.0 (file:///projects/functions)
      Running `target/debug/functions`
 The value of x is: 5
-The value of y is: 6
+The value of c is: d
 ```
 
-Because we called the function with `5` as the value for  `x` and `6` is passed
-as the value for `y`, the two strings are printed with these values.
+Because we called the function with `5` as the value for  `x` and `d` is passed
+as the value for `c`, the two strings are printed with these values.
 
 ### Function Bodies
 
@@ -142,9 +140,11 @@ functions.
 
 ### Statements and Expressions
 
-We’ve actually already used statements and expressions. *Statements* are
-instructions that perform some action and do not return a value. *Expressions*
-evaluate to a resulting value. Let’s look at some examples.
+We’ve actually already used statements and expressions. *Expressions* evaluate
+to a resulting value. *Statements* are instructions that perform some action
+and either have no value or have value unit.  The unit value is the empty
+tuple, denoted as `()`, and since it has no useful content it is used as the
+result of some statements. Let’s look at some examples.
 
 Creating a variable and assigning a value to it with the `let` keyword is a
 statement. In Listing 3-3, `let y = 6;` is a statement:
@@ -162,7 +162,7 @@ fn main() {
 Function definitions are also statements; the entire preceding example is a
 statement in itself.
 
-Statements do not return values. Therefore, you can’t assign a `let` statement
+The `let` statement do not return a value. Therefore, you can’t assign a `let` statement
 to another variable, as the following code tries to do:
 
 <span class="filename">Filename: src/main.rs</span>
@@ -193,13 +193,32 @@ where the assignment returns the value of the assignment. In those languages,
 you can write `x = y = 6` and have both `x` and `y` have the value `6`; that is
 not the case in Rust.
 
-Expressions evaluate to something and make up most of the rest of the code that
-you’ll write in Rust. Consider a simple math operation, such as `5 + 6`, which
-is an expression that evaluates to the value `11`. Expressions can be part of
-statements: in Listing 3-3 that had the statement `let y = 6;`, `6` is an
-expression that evaluates to the value `6`. Calling a function is an
-expression. Calling a macro is an expression. The block that we use to create
-new scopes, `{}`, is an expression, for example:
+While the `let` statement does not evaluate to any value, some other statements
+will evaluate to the unit value (`()`), which can be convenient because they
+can be used in any place where an expression can. (Technically these statements
+are expressions, they are just of type unit.) For these statements you can see
+that they have a value, it is just not a value that you can do anything useful
+with:
+
+<span class="filename">Filename: src/main.rs</span>
+
+```rust
+fn main() {
+    let mut x = 0;
+    let y: () = (x = 6);
+}
+```
+
+The assignment statement is of type `()`, as can be seen by the explicit type
+annotation in the second `let`.
+
+Expressions make up most of the rest of the code that you’ll write in Rust.
+Consider a simple math operation, such as `5 + 6`, which is an expression
+that evaluates to the value `11`. Expressions can be part of statements: in
+Listing 3-3 that had the statement `let y = 6;`, `6` is an expression that
+evaluates to the value `6`. Calling a function is an expression. Calling a
+macro is an expression. The block that we use to create new scopes, `{}`,
+is an expression, for example:
 
 <span class="filename">Filename: src/main.rs</span>
 
@@ -229,8 +248,8 @@ is a block that, in this case, evaluates to `4`. That value gets bound to `y`
 as part of the `let` statement. Note the line without a semicolon at the end,
 unlike most of the lines you’ve seen so far. Expressions do not include ending
 semicolons. If you add a semicolon to the end of an expression, you turn it
-into a statement, which will then not return a value. Keep this in mind as you
-explore function return values and expressions next.
+into a statement, which will evaluate to `()`. Keep this in mind as you explore
+function return values and expressions next.
 
 ### Functions with Return Values
 
@@ -299,15 +318,7 @@ Running this code will print `The value of x is: 6`. What happens if we place a
 semicolon at the end of the line containing `x + 1`, changing it from an
 expression to a statement?
 
-<span class="filename">Filename: src/main.rs</span>
-
 ```rust,ignore
-fn main() {
-    let x = plus_one(5);
-
-    println!("The value of x is: {}", x);
-}
-
 fn plus_one(x: i32) -> i32 {
     x + 1;
 }
@@ -336,8 +347,7 @@ help: consider removing this semicolon:
 
 The main error message, “mismatched types,” reveals the core issue with this
 code. The definition of the function `plus_one` says that it will return an
-`i32`, but statements don’t evaluate to a value, which is expressed by `()`,
-the empty tuple. Therefore, nothing is returned, which contradicts the function
-definition and results in an error. In this output, Rust provides a message to
+`i32`, but the statement evaluate to `()`. This contradicts the return type
+declared and results in an error. In this output, Rust provides a message to
 possibly help rectify this issue: it suggests removing the semicolon, which
 would fix the error.


### PR DESCRIPTION
This is an RFC with some small changes on Chapters 2 and 3.

The most important change is on the explanation of how Rust deals with expressions, which previously stated that statements do not evaluate to any value, which is not correct (some of them have no value but most of them evaluate to `()`).

I understand that chapters in the "frozen" state are not candidates for changes, but I think the "statements have no return value" is a factual error bad enough to deserve fixing before printing.

The other changes are small improvements and are not valuable enough to justify redoing the layout etc, but they still deserve to exist (i.e. for the "live" online version and for a second print).
