### PR TITLE
Make explanation on redirect pages shorter

### DIFF
--- a/redirects/README.md
+++ b/redirects/README.md
@@ -1,13 +1,11 @@
-% The Rust Programming Language Has Moved
+% The Rust Programming Language
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+There are two editions of "The Rust Programming Language":
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [First edition](first-edition/index.html)
+* [Second edition](second-edition/index.html)
 
-[first-edition/]: first-edition/index.html
-[second edition]: second-edition/index.html
+The second edition is a complete re-write. It is still under construction;
+though it is far enough along to learn most of Rust; we suggest reading the
+second edition and then checking out the first edition later to pick up some of
+the more esoteric parts of the language.

--- a/redirects/SUMMARY.md
+++ b/redirects/SUMMARY.md
@@ -1,13 +1,11 @@
-% The Rust Programming Language Has Moved
+% The Rust Programming Language
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+There are two editions of "The Rust Programming Language":
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [First edition](first-edition/index.html)
+* [Second edition](second-edition/index.html)
 
-[first-edition/]: first-edition/index.html
-[second edition]: second-edition/index.html
+The second edition is a complete re-write. It is still under construction;
+though it is far enough along to learn most of Rust; we suggest reading the
+second edition and then checking out the first edition later to pick up some of
+the more esoteric parts of the language.

--- a/redirects/associated-types.md
+++ b/redirects/associated-types.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/associated-types.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/associated-types.html
+[2]: second-edition/index.html

--- a/redirects/attributes.md
+++ b/redirects/attributes.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/attributes.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/attributes.html
+[2]: second-edition/index.html

--- a/redirects/bibliography.md
+++ b/redirects/bibliography.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/bibliography.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/bibliography.html
+[2]: second-edition/index.html

--- a/redirects/borrow-and-asref.md
+++ b/redirects/borrow-and-asref.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/borrow-and-asref.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/borrow-and-asref.html
+[2]: second-edition/index.html

--- a/redirects/casting-between-types.md
+++ b/redirects/casting-between-types.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/casting-between-types.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/casting-between-types.html
+[2]: second-edition/index.html

--- a/redirects/choosing-your-guarantees.md
+++ b/redirects/choosing-your-guarantees.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/choosing-your-guarantees.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/choosing-your-guarantees.html
+[2]: second-edition/index.html

--- a/redirects/closures.md
+++ b/redirects/closures.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/closures.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/closures.html
+[2]: second-edition/index.html

--- a/redirects/comments.md
+++ b/redirects/comments.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/comments.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/comments.html
+[2]: second-edition/index.html

--- a/redirects/concurrency.md
+++ b/redirects/concurrency.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/concurrency.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/concurrency.html
+[2]: second-edition/index.html

--- a/redirects/conditional-compilation.md
+++ b/redirects/conditional-compilation.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/conditional-compilation.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/conditional-compilation.html
+[2]: second-edition/index.html

--- a/redirects/const-and-static.md
+++ b/redirects/const-and-static.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/const-and-static.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/const-and-static.html
+[2]: second-edition/index.html

--- a/redirects/crates-and-modules.md
+++ b/redirects/crates-and-modules.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/crates-and-modules.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/crates-and-modules.html
+[2]: second-edition/index.html

--- a/redirects/deref-coercions.md
+++ b/redirects/deref-coercions.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/deref-coercions.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/deref-coercions.html
+[2]: second-edition/index.html

--- a/redirects/documentation.md
+++ b/redirects/documentation.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/documentation.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/documentation.html
+[2]: second-edition/index.html

--- a/redirects/drop.md
+++ b/redirects/drop.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/drop.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/drop.html
+[2]: second-edition/index.html

--- a/redirects/effective-rust.md
+++ b/redirects/effective-rust.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/effective-rust.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/effective-rust.html
+[2]: second-edition/index.html

--- a/redirects/enums.md
+++ b/redirects/enums.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/enums.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/enums.html
+[2]: second-edition/index.html

--- a/redirects/error-handling.md
+++ b/redirects/error-handling.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/error-handling.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/error-handling.html
+[2]: second-edition/index.html

--- a/redirects/ffi.md
+++ b/redirects/ffi.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/ffi.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/ffi.html
+[2]: second-edition/index.html

--- a/redirects/functions.md
+++ b/redirects/functions.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/functions.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/functions.html
+[2]: second-edition/index.html

--- a/redirects/generics.md
+++ b/redirects/generics.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/generics.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/generics.html
+[2]: second-edition/index.html

--- a/redirects/getting-started.md
+++ b/redirects/getting-started.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/getting-started.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/getting-started.html
+[2]: second-edition/index.html

--- a/redirects/glossary.md
+++ b/redirects/glossary.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/glossary.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/glossary.html
+[2]: second-edition/index.html

--- a/redirects/guessing-game.md
+++ b/redirects/guessing-game.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/guessing-game.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/guessing-game.html
+[2]: second-edition/index.html

--- a/redirects/if-let.md
+++ b/redirects/if-let.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/if-let.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/if-let.html
+[2]: second-edition/index.html

--- a/redirects/if.md
+++ b/redirects/if.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/if.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/if.html
+[2]: second-edition/index.html

--- a/redirects/iterators.md
+++ b/redirects/iterators.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/iterators.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/iterators.html
+[2]: second-edition/index.html

--- a/redirects/lifetimes.md
+++ b/redirects/lifetimes.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/lifetimes.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/lifetimes.html
+[2]: second-edition/index.html

--- a/redirects/loops.md
+++ b/redirects/loops.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/loops.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/loops.html
+[2]: second-edition/index.html

--- a/redirects/macros.md
+++ b/redirects/macros.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/macros.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/macros.html
+[2]: second-edition/index.html

--- a/redirects/match.md
+++ b/redirects/match.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/match.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/match.html
+[2]: second-edition/index.html

--- a/redirects/method-syntax.md
+++ b/redirects/method-syntax.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/method-syntax.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/method-syntax.html
+[2]: second-edition/index.html

--- a/redirects/mutability.md
+++ b/redirects/mutability.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/mutability.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/mutability.html
+[2]: second-edition/index.html

--- a/redirects/operators-and-overloading.md
+++ b/redirects/operators-and-overloading.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/operators-and-overloading.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/operators-and-overloading.html
+[2]: second-edition/index.html

--- a/redirects/ownership.md
+++ b/redirects/ownership.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/ownership.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/ownership.html
+[2]: second-edition/index.html

--- a/redirects/patterns.md
+++ b/redirects/patterns.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/patterns.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/patterns.html
+[2]: second-edition/index.html

--- a/redirects/primitive-types.md
+++ b/redirects/primitive-types.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/primitive-types.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/primitive-types.html
+[2]: second-edition/index.html

--- a/redirects/procedural-macros.md
+++ b/redirects/procedural-macros.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/procedural-macros.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/procedural-macros.html
+[2]: second-edition/index.html

--- a/redirects/raw-pointers.md
+++ b/redirects/raw-pointers.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/raw-pointers.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/raw-pointers.html
+[2]: second-edition/index.html

--- a/redirects/references-and-borrowing.md
+++ b/redirects/references-and-borrowing.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/references-and-borrowing.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/references-and-borrowing.html
+[2]: second-edition/index.html

--- a/redirects/release-channels.md
+++ b/redirects/release-channels.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/release-channels.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/release-channels.html
+[2]: second-edition/index.html

--- a/redirects/strings.md
+++ b/redirects/strings.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/strings.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/strings.html
+[2]: second-edition/index.html

--- a/redirects/structs.md
+++ b/redirects/structs.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/structs.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/structs.html
+[2]: second-edition/index.html

--- a/redirects/syntax-and-semantics.md
+++ b/redirects/syntax-and-semantics.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/syntax-and-semantics.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/syntax-and-semantics.html
+[2]: second-edition/index.html

--- a/redirects/syntax-index.md
+++ b/redirects/syntax-index.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/syntax-index.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/syntax-index.html
+[2]: second-edition/index.html

--- a/redirects/testing.md
+++ b/redirects/testing.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/testing.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/testing.html
+[2]: second-edition/index.html

--- a/redirects/the-stack-and-the-heap.md
+++ b/redirects/the-stack-and-the-heap.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/the-stack-and-the-heap.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/the-stack-and-the-heap.html
+[2]: second-edition/index.html

--- a/redirects/trait-objects.md
+++ b/redirects/trait-objects.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/trait-objects.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/trait-objects.html
+[2]: second-edition/index.html

--- a/redirects/traits.md
+++ b/redirects/traits.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/traits.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/traits.html
+[2]: second-edition/index.html

--- a/redirects/type-aliases.md
+++ b/redirects/type-aliases.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/type-aliases.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/type-aliases.html
+[2]: second-edition/index.html

--- a/redirects/ufcs.md
+++ b/redirects/ufcs.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/ufcs.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/ufcs.html
+[2]: second-edition/index.html

--- a/redirects/unsafe.md
+++ b/redirects/unsafe.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/unsafe.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/unsafe.html
+[2]: second-edition/index.html

--- a/redirects/unsized-types.md
+++ b/redirects/unsized-types.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/unsized-types.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/unsized-types.html
+[2]: second-edition/index.html

--- a/redirects/using-rust-without-the-standard-library.md
+++ b/redirects/using-rust-without-the-standard-library.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/using-rust-without-the-standard-library.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/using-rust-without-the-standard-library.html
+[2]: second-edition/index.html

--- a/redirects/variable-bindings.md
+++ b/redirects/variable-bindings.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/variable-bindings.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/variable-bindings.html
+[2]: second-edition/index.html

--- a/redirects/vectors.md
+++ b/redirects/vectors.md
@@ -1,13 +1,12 @@
-% The Rust Programming Language Has Moved
+% There is a new edition of the book
 
-When The Rust Programming Language only had one edition, it was all hosted at
-`book/`. Now that it has two, they are properly namespaced under
-`first-edition/` and `second-edition/`.
+This is an old link. You can [continue to the exact older page][1].
+If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-You've found this page because you have a link to the older URL structure; you
-probably want to visit [first-edition/] if you need the exact older page; if
-you're trying to learn Rust, checking out the [second edition] might be a
-better choice.
+* [This page in the first edition of the The Rust Programming Language][1]
 
-[first-edition/]: first-edition/vectors.html
-[second edition]: second-edition/index.html
+* [Index of the second edition of The Rust Programming Language][2]
+
+
+[1]: first-edition/vectors.html
+[2]: second-edition/index.html


### PR DESCRIPTION
Fix for https://github.com/rust-lang/rust/issues/42632

Makes links more prominent, so users will be more likely to follow them instead of assuming without reading that it's a 404.