### PR TITLE
Link to related page in the 2nd edition

### DIFF
--- a/redirects/associated-types.md
+++ b/redirects/associated-types.md
@@ -1,12 +1,13 @@
 % There is a new edition of the book
 
 This is an old link. You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+If you're trying to learn Rust, checking out [the second edition][3] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Similar page][2] in [the second edition of The Rust Programming Language][3]
 
 
 [1]: first-edition/associated-types.html
-[2]: second-edition/index.html
+[2]: second-edition/ch19-03-advanced-traits.html
+[3]: second-edition/index.html

--- a/redirects/casting-between-types.md
+++ b/redirects/casting-between-types.md
@@ -1,12 +1,13 @@
 % There is a new edition of the book
 
 This is an old link. You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+If you're trying to learn Rust, checking out [the second edition][3] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Similar page][2] in [the second edition of The Rust Programming Language][3]
 
 
 [1]: first-edition/casting-between-types.html
-[2]: second-edition/index.html
+[2]: second-edition/appendix-02-operators.html
+[3]: second-edition/index.html

--- a/redirects/closures.md
+++ b/redirects/closures.md
@@ -1,12 +1,13 @@
 % There is a new edition of the book
 
 This is an old link. You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+If you're trying to learn Rust, checking out [the second edition][3] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Similar page][2] in [the second edition of The Rust Programming Language][3]
 
 
 [1]: first-edition/closures.html
-[2]: second-edition/index.html
+[2]: second-edition/ch13-01-closures.html
+[3]: second-edition/index.html

--- a/redirects/comments.md
+++ b/redirects/comments.md
@@ -1,12 +1,13 @@
 % There is a new edition of the book
 
 This is an old link. You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+If you're trying to learn Rust, checking out [the second edition][3] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Similar page][2] in [the second edition of The Rust Programming Language][3]
 
 
 [1]: first-edition/comments.html
-[2]: second-edition/index.html
+[2]: second-edition/ch03-04-comments.html
+[3]: second-edition/index.html

--- a/redirects/concurrency.md
+++ b/redirects/concurrency.md
@@ -1,12 +1,13 @@
 % There is a new edition of the book
 
 This is an old link. You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+If you're trying to learn Rust, checking out [the second edition][3] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Similar page][2] in [the second edition of The Rust Programming Language][3]
 
 
 [1]: first-edition/concurrency.html
-[2]: second-edition/index.html
+[2]: second-edition/ch16-00-concurrency.html
+[3]: second-edition/index.html

--- a/redirects/const-and-static.md
+++ b/redirects/const-and-static.md
@@ -1,12 +1,13 @@
 % There is a new edition of the book
 
 This is an old link. You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+If you're trying to learn Rust, checking out [the second edition][3] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Similar page][2] in [the second edition of The Rust Programming Language][3]
 
 
 [1]: first-edition/const-and-static.html
-[2]: second-edition/index.html
+[2]: second-edition/ch03-01-variables-and-mutability.html
+[3]: second-edition/index.html

--- a/redirects/crates-and-modules.md
+++ b/redirects/crates-and-modules.md
@@ -1,12 +1,13 @@
 % There is a new edition of the book
 
 This is an old link. You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+If you're trying to learn Rust, checking out [the second edition][3] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Similar page][2] in [the second edition of The Rust Programming Language][3]
 
 
 [1]: first-edition/crates-and-modules.html
-[2]: second-edition/index.html
+[2]: second-edition/ch07-00-modules.html
+[3]: second-edition/index.html

--- a/redirects/deref-coercions.md
+++ b/redirects/deref-coercions.md
@@ -1,12 +1,13 @@
 % There is a new edition of the book
 
 This is an old link. You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+If you're trying to learn Rust, checking out [the second edition][3] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Similar page][2] in [the second edition of The Rust Programming Language][3]
 
 
 [1]: first-edition/deref-coercions.html
-[2]: second-edition/index.html
+[2]: second-edition/ch15-02-deref.html
+[3]: second-edition/index.html

--- a/redirects/documentation.md
+++ b/redirects/documentation.md
@@ -1,12 +1,13 @@
 % There is a new edition of the book
 
 This is an old link. You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+If you're trying to learn Rust, checking out [the second edition][3] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Similar page][2] in [the second edition of The Rust Programming Language][3]
 
 
 [1]: first-edition/documentation.html
-[2]: second-edition/index.html
+[2]: second-edition/nostarch/chapter14.html
+[3]: second-edition/index.html

--- a/redirects/drop.md
+++ b/redirects/drop.md
@@ -1,12 +1,13 @@
 % There is a new edition of the book
 
 This is an old link. You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+If you're trying to learn Rust, checking out [the second edition][3] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Similar page][2] in [the second edition of The Rust Programming Language][3]
 
 
 [1]: first-edition/drop.html
-[2]: second-edition/index.html
+[2]: second-edition/ch15-03-drop.html
+[3]: second-edition/index.html

--- a/redirects/enums.md
+++ b/redirects/enums.md
@@ -1,12 +1,13 @@
 % There is a new edition of the book
 
 This is an old link. You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+If you're trying to learn Rust, checking out [the second edition][3] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Similar page][2] in [the second edition of The Rust Programming Language][3]
 
 
 [1]: first-edition/enums.html
-[2]: second-edition/index.html
+[2]: second-edition/ch06-00-enums.html
+[3]: second-edition/index.html

--- a/redirects/error-handling.md
+++ b/redirects/error-handling.md
@@ -1,12 +1,13 @@
 % There is a new edition of the book
 
 This is an old link. You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+If you're trying to learn Rust, checking out [the second edition][3] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Similar page][2] in [the second edition of The Rust Programming Language][3]
 
 
 [1]: first-edition/error-handling.html
-[2]: second-edition/index.html
+[2]: second-edition/ch09-00-error-handling.html
+[3]: second-edition/index.html

--- a/redirects/ffi.md
+++ b/redirects/ffi.md
@@ -1,12 +1,13 @@
 % There is a new edition of the book
 
 This is an old link. You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+If you're trying to learn Rust, checking out [the second edition][3] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Similar page][2] in [the second edition of The Rust Programming Language][3]
 
 
 [1]: first-edition/ffi.html
-[2]: second-edition/index.html
+[2]: second-edition/ch19-01-unsafe-rust.html
+[3]: second-edition/index.html

--- a/redirects/functions.md
+++ b/redirects/functions.md
@@ -1,12 +1,13 @@
 % There is a new edition of the book
 
 This is an old link. You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+If you're trying to learn Rust, checking out [the second edition][3] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Similar page][2] in [the second edition of The Rust Programming Language][3]
 
 
 [1]: first-edition/functions.html
-[2]: second-edition/index.html
+[2]: second-edition/ch03-03-how-functions-work.html
+[3]: second-edition/index.html

--- a/redirects/generics.md
+++ b/redirects/generics.md
@@ -1,12 +1,13 @@
 % There is a new edition of the book
 
 This is an old link. You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+If you're trying to learn Rust, checking out [the second edition][3] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Similar page][2] in [the second edition of The Rust Programming Language][3]
 
 
 [1]: first-edition/generics.html
-[2]: second-edition/index.html
+[2]: second-edition/ch10-00-generics.html
+[3]: second-edition/index.html

--- a/redirects/guessing-game.md
+++ b/redirects/guessing-game.md
@@ -1,12 +1,13 @@
 % There is a new edition of the book
 
 This is an old link. You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+If you're trying to learn Rust, checking out [the second edition][3] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Similar page][2] in [the second edition of The Rust Programming Language][3]
 
 
 [1]: first-edition/guessing-game.html
-[2]: second-edition/index.html
+[2]: second-edition/ch02-00-guessing-game-tutorial.html
+[3]: second-edition/index.html

--- a/redirects/if-let.md
+++ b/redirects/if-let.md
@@ -1,12 +1,13 @@
 % There is a new edition of the book
 
 This is an old link. You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+If you're trying to learn Rust, checking out [the second edition][3] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Similar page][2] in [the second edition of The Rust Programming Language][3]
 
 
 [1]: first-edition/if-let.html
-[2]: second-edition/index.html
+[2]: second-edition/ch06-03-if-let.html
+[3]: second-edition/index.html

--- a/redirects/iterators.md
+++ b/redirects/iterators.md
@@ -1,12 +1,13 @@
 % There is a new edition of the book
 
 This is an old link. You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+If you're trying to learn Rust, checking out [the second edition][3] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Similar page][2] in [the second edition of The Rust Programming Language][3]
 
 
 [1]: first-edition/iterators.html
-[2]: second-edition/index.html
+[2]: second-edition/ch13-02-iterators.html
+[3]: second-edition/index.html

--- a/redirects/lifetimes.md
+++ b/redirects/lifetimes.md
@@ -1,12 +1,13 @@
 % There is a new edition of the book
 
 This is an old link. You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+If you're trying to learn Rust, checking out [the second edition][3] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Similar page][2] in [the second edition of The Rust Programming Language][3]
 
 
 [1]: first-edition/lifetimes.html
-[2]: second-edition/index.html
+[2]: second-edition/ch04-00-understanding-ownership.html
+[3]: second-edition/index.html

--- a/redirects/match.md
+++ b/redirects/match.md
@@ -1,12 +1,13 @@
 % There is a new edition of the book
 
 This is an old link. You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+If you're trying to learn Rust, checking out [the second edition][3] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Similar page][2] in [the second edition of The Rust Programming Language][3]
 
 
 [1]: first-edition/match.html
-[2]: second-edition/index.html
+[2]: second-edition/ch06-02-match.html
+[3]: second-edition/index.html

--- a/redirects/method-syntax.md
+++ b/redirects/method-syntax.md
@@ -1,12 +1,13 @@
 % There is a new edition of the book
 
 This is an old link. You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+If you're trying to learn Rust, checking out [the second edition][3] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Similar page][2] in [the second edition of The Rust Programming Language][3]
 
 
 [1]: first-edition/method-syntax.html
-[2]: second-edition/index.html
+[2]: second-edition/ch05-01-method-syntax.html
+[3]: second-edition/index.html

--- a/redirects/mutability.md
+++ b/redirects/mutability.md
@@ -1,12 +1,13 @@
 % There is a new edition of the book
 
 This is an old link. You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+If you're trying to learn Rust, checking out [the second edition][3] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Similar page][2] in [the second edition of The Rust Programming Language][3]
 
 
 [1]: first-edition/mutability.html
-[2]: second-edition/index.html
+[2]: second-edition/ch03-01-variables-and-mutability.html
+[3]: second-edition/index.html

--- a/redirects/operators-and-overloading.md
+++ b/redirects/operators-and-overloading.md
@@ -1,12 +1,13 @@
 % There is a new edition of the book
 
 This is an old link. You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+If you're trying to learn Rust, checking out [the second edition][3] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Similar page][2] in [the second edition of The Rust Programming Language][3]
 
 
 [1]: first-edition/operators-and-overloading.html
-[2]: second-edition/index.html
+[2]: second-edition/ch19-03-advanced-traits.html
+[3]: second-edition/index.html

--- a/redirects/ownership.md
+++ b/redirects/ownership.md
@@ -1,12 +1,13 @@
 % There is a new edition of the book
 
 This is an old link. You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+If you're trying to learn Rust, checking out [the second edition][3] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Similar page][2] in [the second edition of The Rust Programming Language][3]
 
 
 [1]: first-edition/ownership.html
-[2]: second-edition/index.html
+[2]: second-edition/ch04-00-understanding-ownership.html
+[3]: second-edition/index.html

--- a/redirects/patterns.md
+++ b/redirects/patterns.md
@@ -1,12 +1,13 @@
 % There is a new edition of the book
 
 This is an old link. You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+If you're trying to learn Rust, checking out [the second edition][3] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Similar page][2] in [the second edition of The Rust Programming Language][3]
 
 
 [1]: first-edition/patterns.html
-[2]: second-edition/index.html
+[2]: second-edition/ch06-00-enums.html
+[3]: second-edition/index.html

--- a/redirects/primitive-types.md
+++ b/redirects/primitive-types.md
@@ -1,12 +1,13 @@
 % There is a new edition of the book
 
 This is an old link. You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+If you're trying to learn Rust, checking out [the second edition][3] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Similar page][2] in [the second edition of The Rust Programming Language][3]
 
 
 [1]: first-edition/primitive-types.html
-[2]: second-edition/index.html
+[2]: second-edition/ch03-02-data-types.html
+[3]: second-edition/index.html

--- a/redirects/raw-pointers.md
+++ b/redirects/raw-pointers.md
@@ -1,12 +1,13 @@
 % There is a new edition of the book
 
 This is an old link. You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+If you're trying to learn Rust, checking out [the second edition][3] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Similar page][2] in [the second edition of The Rust Programming Language][3]
 
 
 [1]: first-edition/raw-pointers.html
-[2]: second-edition/index.html
+[2]: second-edition/ch19-01-unsafe-rust.html
+[3]: second-edition/index.html

--- a/redirects/references-and-borrowing.md
+++ b/redirects/references-and-borrowing.md
@@ -1,12 +1,13 @@
 % There is a new edition of the book
 
 This is an old link. You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+If you're trying to learn Rust, checking out [the second edition][3] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Similar page][2] in [the second edition of The Rust Programming Language][3]
 
 
 [1]: first-edition/references-and-borrowing.html
-[2]: second-edition/index.html
+[2]: second-edition/ch04-02-references-and-borrowing.html
+[3]: second-edition/index.html

--- a/redirects/strings.md
+++ b/redirects/strings.md
@@ -1,12 +1,13 @@
 % There is a new edition of the book
 
 This is an old link. You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+If you're trying to learn Rust, checking out [the second edition][3] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Similar page][2] in [the second edition of The Rust Programming Language][3]
 
 
 [1]: first-edition/strings.html
-[2]: second-edition/index.html
+[2]: second-edition/ch08-02-strings.html
+[3]: second-edition/index.html

--- a/redirects/structs.md
+++ b/redirects/structs.md
@@ -1,12 +1,13 @@
 % There is a new edition of the book
 
 This is an old link. You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+If you're trying to learn Rust, checking out [the second edition][3] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Similar page][2] in [the second edition of The Rust Programming Language][3]
 
 
 [1]: first-edition/structs.html
-[2]: second-edition/index.html
+[2]: second-edition/ch05-00-structs.html
+[3]: second-edition/index.html

--- a/redirects/testing.md
+++ b/redirects/testing.md
@@ -1,12 +1,13 @@
 % There is a new edition of the book
 
 This is an old link. You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+If you're trying to learn Rust, checking out [the second edition][3] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Similar page][2] in [the second edition of The Rust Programming Language][3]
 
 
 [1]: first-edition/testing.html
-[2]: second-edition/index.html
+[2]: second-edition/ch11-00-testing.html
+[3]: second-edition/index.html

--- a/redirects/the-stack-and-the-heap.md
+++ b/redirects/the-stack-and-the-heap.md
@@ -1,12 +1,13 @@
 % There is a new edition of the book
 
 This is an old link. You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+If you're trying to learn Rust, checking out [the second edition][3] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Similar page][2] in [the second edition of The Rust Programming Language][3]
 
 
 [1]: first-edition/the-stack-and-the-heap.html
-[2]: second-edition/index.html
+[2]: second-edition/ch15-01-box.html
+[3]: second-edition/index.html

--- a/redirects/trait-objects.md
+++ b/redirects/trait-objects.md
@@ -1,12 +1,13 @@
 % There is a new edition of the book
 
 This is an old link. You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+If you're trying to learn Rust, checking out [the second edition][3] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Similar page][2] in [the second edition of The Rust Programming Language][3]
 
 
 [1]: first-edition/trait-objects.html
-[2]: second-edition/index.html
+[2]: second-edition/ch17-02-trait-objects.html
+[3]: second-edition/index.html

--- a/redirects/traits.md
+++ b/redirects/traits.md
@@ -1,12 +1,13 @@
 % There is a new edition of the book
 
 This is an old link. You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+If you're trying to learn Rust, checking out [the second edition][3] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Similar page][2] in [the second edition of The Rust Programming Language][3]
 
 
 [1]: first-edition/traits.html
-[2]: second-edition/index.html
+[2]: second-edition/ch10-02-traits.html
+[3]: second-edition/index.html

--- a/redirects/type-aliases.md
+++ b/redirects/type-aliases.md
@@ -1,12 +1,13 @@
 % There is a new edition of the book
 
 This is an old link. You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+If you're trying to learn Rust, checking out [the second edition][3] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Similar page][2] in [the second edition of The Rust Programming Language][3]
 
 
 [1]: first-edition/type-aliases.html
-[2]: second-edition/index.html
+[2]: second-edition/ch19-04-advanced-types.html
+[3]: second-edition/index.html

--- a/redirects/unsafe.md
+++ b/redirects/unsafe.md
@@ -1,12 +1,13 @@
 % There is a new edition of the book
 
 This is an old link. You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+If you're trying to learn Rust, checking out [the second edition][3] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Similar page][2] in [the second edition of The Rust Programming Language][3]
 
 
 [1]: first-edition/unsafe.html
-[2]: second-edition/index.html
+[2]: second-edition/ch19-01-unsafe-rust.html
+[3]: second-edition/index.html

--- a/redirects/unsized-types.md
+++ b/redirects/unsized-types.md
@@ -1,12 +1,13 @@
 % There is a new edition of the book
 
 This is an old link. You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+If you're trying to learn Rust, checking out [the second edition][3] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Similar page][2] in [the second edition of The Rust Programming Language][3]
 
 
 [1]: first-edition/unsized-types.html
-[2]: second-edition/index.html
+[2]: second-edition/ch19-04-advanced-types.html
+[3]: second-edition/index.html

--- a/redirects/variable-bindings.md
+++ b/redirects/variable-bindings.md
@@ -1,12 +1,13 @@
 % There is a new edition of the book
 
 This is an old link. You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+If you're trying to learn Rust, checking out [the second edition][3] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Similar page][2] in [the second edition of The Rust Programming Language][3]
 
 
 [1]: first-edition/variable-bindings.html
-[2]: second-edition/index.html
+[2]: second-edition/ch03-01-variables-and-mutability.html
+[3]: second-edition/index.html

--- a/redirects/vectors.md
+++ b/redirects/vectors.md
@@ -1,12 +1,13 @@
 % There is a new edition of the book
 
 This is an old link. You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+If you're trying to learn Rust, checking out [the second edition][3] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Similar page][2] in [the second edition of The Rust Programming Language][3]
 
 
 [1]: first-edition/vectors.html
-[2]: second-edition/index.html
+[2]: second-edition/ch08-01-vectors.html
+[3]: second-edition/index.html


### PR DESCRIPTION
I've updated some of the redirect pages with a link to a more specific page in the 2nd edition.

I suspect the links aren't stable, and chapter reorgs might break them, so just in case I've left prominent link tho the second edition index page.