### PR TITLE
»!« is the empty type, not the bottom type.

### DIFF
--- a/second-edition/src/ch19-04-advanced-types.md
+++ b/second-edition/src/ch19-04-advanced-types.md
@@ -163,10 +163,10 @@ another `Result<T, E>`, which means we can use any methods that work on
 
 ### The Never Type, `!`, that Never Returns
 
-Rust has a special type named `!`. In type theory lingo, it's called the
-*bottom type*, but we prefer to call it the *never type*. The name describes
-what it does: it stands in the place of the return type when a function will
-never return. For example:
+Rust has a special type named `!`. In type theory lingo, it's called the *empty
+type*, because it has no values. We prefer to call it the *never type*. The name
+describes what it does: it stands in the place of the return type when a
+function will never return. For example:
 
 ```rust,ignore
 fn bar() -> ! {


### PR DESCRIPTION
Hi there, made it to chapter 20 when I finally found a ~~mist~~contribution opportunity! :-)

tl;dr: `!` is the empty type, not the bottom type.

---

The type without values is called the empty or the void type. It is a type that is logically uninhabited, i.e. there are no (sensible) values of that type. An actual »bottom type« would be a type of an uninhabited kind, which is basically the whole thing one rung up the ladder. Since most type systems aim at being consistent (nothing wrong typechecks) but values/programs aim at being complete (everything can be written, even if it doesn’t terminate), the actual »bottom type« is used *very* rarely, as opposed to the empty type, which signals that a certain branch of a program will never be taken, despite it being present in the program.

Now, since Rust’s type system is logically inconsistent (like all other general-purpose ones), we *can* create values of type `!`, but as mentioned, these are rarely useful. The canonical example is the infinite loop,

```rust
fn bottom() -> ! { loop {} }
```

Using `bottom` in our code is valid, and the typechecker won’t interfere, but at runtime we’re in for a surprise. Note that this code is not specific to `!` at all, and indeed `bottom` is a valid value of *any* type, as far as the typechecker is concerned.

---

So where does the name `bottom type` come from then? Well, the nonsensical value created above is called `bottom`, often written as `⊥`, which stands for »no answer«, and many places confuse the *value* ⊥ with a *type* that holds no values. The name `bottom` comes from the fact that if we enumerate all the values of a type, then `⊥` is the least defined one – it’s at the very bottom of the definedness hierarchy.

To sum it up,

- `!` is the empty type, not the bottom type.
- The empty type is inhabited by only `⊥` (»bottom«) in Rust.
