### PR TITLE
Use correct pluralisation for 'hash maps'

### DIFF
--- a/second-edition/src/ch08-02-strings.md
+++ b/second-edition/src/ch08-02-strings.md
@@ -410,4 +410,4 @@ of strings than other programming languages do, but this will prevent you from
 having to handle errors involving non-ASCII characters later in your
 development lifecycle.
 
-Let’s switch to something a bit less complex: hash map!
+Let’s switch to something a bit less complex: hash maps!


### PR DESCRIPTION
Hash Maps is referenced in the plural form elsewhere in the book (and its title chapter) so we should pluralise it here for consistency also.
