### PR TITLE
Added missing script tag to load store.js

### DIFF
--- a/second-edition/theme/index.hbs
+++ b/second-edition/theme/index.hbs
@@ -159,6 +159,7 @@
         {{{livereload}}}
 
         <script src="highlight.js"></script>
+        <script src="store.js"></script>
         <script src="book.js"></script>
     </body>
 </html>


### PR DESCRIPTION
https://github.com/azerupi/mdBook/pull/337 has fixed #705 but https://github.com/azerupi/mdBook/pull/324 introduced an additional javascript file which must be loaded but this book custom `index.hbs`

This pull request adds the missing `script` tag and fixes #705