### PR TITLE
Use unsigned integers as return type for cents

### DIFF
--- a/second-edition/src/ch06-02-match.md
+++ b/second-edition/src/ch06-02-match.md
@@ -27,7 +27,7 @@ enum Coin {
     Quarter,
 }
 
-fn value_in_cents(coin: Coin) -> i32 {
+fn value_in_cents(coin: Coin) -> u32 {
     match coin {
         Coin::Penny => 1,
         Coin::Nickel => 5,
@@ -76,7 +76,7 @@ with a `Coin::Penny` but would still return the last value of the block, `1`:
 #    Quarter,
 # }
 #
-fn value_in_cents(coin: Coin) -> i32 {
+fn value_in_cents(coin: Coin) -> u32 {
     match coin {
         Coin::Penny => {
             println!("Lucky penny!");
@@ -145,7 +145,7 @@ quarter’s state. Then we can use `state` in the code for that arm, like so:
 #    Quarter(UsState),
 # }
 #
-fn value_in_cents(coin: Coin) -> i32 {
+fn value_in_cents(coin: Coin) -> u32 {
     match coin {
         Coin::Penny => 1,
         Coin::Nickel => 5,


### PR DESCRIPTION
It doesn't make sense to convert coins to cents using unsigned integers,
they cannot use negative numbers.