### PR TITLE
Update instructions to include adding Rust to PATH

### DIFF
--- a/second-edition/src/ch01-01-installation.md
+++ b/second-edition/src/ch01-01-installation.md
@@ -31,16 +31,16 @@ Of course, if you disapprove of the `curl | sh` pattern, you can download, inspe
 and run the script however you like.
 
 The installation script automatically adds Rust to your system PATH after your next login. 
-If you want to start using Rust right away, run the following command in terminal:
+If you want to start using Rust right away, run the following command in your shell:
 
 ```text
-source $HOME/.cargo/env
+$ source $HOME/.cargo/env
 ```
 
 Alternatively, add the following line to your `~/.bash_profile`:
 
 ```text
-export PATH="$HOME/.cargo/bin:$PATH"
+$ export PATH="$HOME/.cargo/bin:$PATH"
 ```
 
 ### Installing on Windows

--- a/second-edition/src/ch01-01-installation.md
+++ b/second-edition/src/ch01-01-installation.md
@@ -30,6 +30,19 @@ Rust is installed now. Great!
 Of course, if you disapprove of the `curl | sh` pattern, you can download, inspect
 and run the script however you like.
 
+The installation script automatically adds Rust to your system PATH after your next login. 
+If you want to start using Rust right away, run the following command in terminal:
+
+```text
+source $HOME/.cargo/env
+```
+
+Alternatively, add the following line to your `~/.bash_profile`:
+
+```text
+export PATH="$HOME/.cargo/bin:$PATH"
+```
+
 ### Installing on Windows
 
 On Windows, go to [https://rustup.rs](https://rustup.rs/)<!-- ignore --> and


### PR DESCRIPTION
Current instructions do not include a callout to adding Rust to the PATH. While this included in the installer output and technically happens automatically after login, you can still miss it if you are trying to use Rust right away.

## What to expect when you open a pull request here

### First edition

The first edition is no longer being actively worked on. We accept pull
requests for the first edition, but prefer small tweaks to large changes, as
larger work should be spent improving the second edition.

### Second edition

For the second edition, we are currently working with No Starch Press to bring
it to print. Chapters go through a number of stages in the editing process, and
once they've gotten to the layout stage, they're effectively frozen.

For chapters that have gotten to the layout stage, we will likely only be
accepting changes that correct factual errors or major problems and not, for
example, minor wording changes.

Scroll all the way to the right on https://github.com/rust-lang/book/projects/1
to see which chapters have been frozen.

Please see CONTRIBUTING.md for more details.

Thank you for reading, you may now delete this text!
