### PR TITLE
Fix string literal to match output

### DIFF
--- a/second-edition/src/ch04-01-what-is-ownership.md
+++ b/second-edition/src/ch04-01-what-is-ownership.md
@@ -327,7 +327,7 @@ use `s1` after `s2` is created:
 let s1 = String::from("hello");
 let s2 = s1;
 
-println!("{}", s1);
+println!("{}, world! ", s1);
 ```
 
 You’ll get an error like this because Rust prevents you from using the


### PR DESCRIPTION
The string literal used in the source didn't match the one displayed in the compilation output.

Not sure if this is too late to be merged, since the chapter is frozen.