### PR TITLE
Fix `impl State for PendingReview`

### DIFF
--- a/second-edition/src/ch17-03-oo-design-patterns.md
+++ b/second-edition/src/ch17-03-oo-design-patterns.md
@@ -318,7 +318,7 @@ struct PendingReview {}
 
 impl State for PendingReview {
 #     fn request_review(self: Box<Self>) -> Box<State> {
-#         Box::new(PendingReview {})
+#         self
 #     }
 #
     // ...snip...


### PR DESCRIPTION
Fix `impl State for PendingReview` to match the previous `impl`

### Second edition

I think this still qualifies, in case it doesn't... well, sorry for the noise. 
Not that it is a big issue really neither. Just was slightly confusing reading through the book at night :)