### PR TITLE
"so that you could use it" -> "you can"

### DIFF
--- a/second-edition/src/ch02-00-guessing-game-tutorial.md
+++ b/second-edition/src/ch02-00-guessing-game-tutorial.md
@@ -273,7 +273,7 @@ argument to `expect`. If the `read_line` method returns an `Err`, it would
 likely be the result of an error coming from the underlying operating system.
 If this instance of `io::Result` is an `Ok` value, `expect` will take the
 return value that `Ok` is holding and return just that value to you so you
-could use it. In this case, that value is the number of bytes in what the user
+can use it. In this case, that value is the number of bytes in what the user
 entered into standard input.
 
 [expect]: ../../std/result/enum.Result.html#method.expect


### PR DESCRIPTION
A nitpicky grammar fix.  

For an explanation on this, check this page (look for "When giving (or refusing) permission"): http://blog.oxforddictionaries.com/2013/07/can-or-could/

## What to expect when you open a pull request here

### First edition

The first edition is no longer being actively worked on. We accept pull
requests for the first edition, but prefer small tweaks to large changes, as
larger work should be spent improving the second edition.

### Second edition

For the second edition, we are currently working with No Starch Press to bring
it to print. Chapters go through a number of stages in the editing process, and
once they've gotten to the layout stage, they're effectively frozen.

For chapters that have gotten to the layout stage, we will likely only be
accepting changes that correct factual errors or major problems and not, for
example, minor wording changes.

Scroll all the way to the right on https://github.com/rust-lang/book/projects/1
to see which chapters have been frozen.

Please see CONTRIBUTING.md for more details.

Thank you for reading, you may now delete this text!
