### PR TITLE
Make a sentence about trait objects easier to understand

### DIFF
--- a/second-edition/src/ch17-02-trait-objects.md
+++ b/second-edition/src/ch17-02-trait-objects.md
@@ -398,9 +398,9 @@ The trait `Sized` is now a *supertrait* of trait `Foo`, which means trait `Foo`
 requires types that implement `Foo` (that is, `Self`) to be `Sized`. We’re
 going to talk about supertraits in more detail in Chapter 19.
 
-The reason a trait like `Foo` that requires `Self` to be `Sized` is not allowed
-to be a trait object is that it would be impossible to implement the trait
-`Foo` for the trait object `Foo`: trait objects aren’t sized, but `Foo`
+`Foo` requires `Self` to be `Sized`, and therefore is not allowed to be a trait
+object. This is because it wold be impossible to implement the trait `Foo` for
+a trait object like`Box<Foo>`: trait objects aren’t sized, but `Foo`
 requires `Self` to be `Sized`. A type can’t be both sized and unsized at the
 same time!
 

--- a/second-edition/src/ch17-02-trait-objects.md
+++ b/second-edition/src/ch17-02-trait-objects.md
@@ -398,11 +398,11 @@ The trait `Sized` is now a *supertrait* of trait `Foo`, which means trait `Foo`
 requires types that implement `Foo` (that is, `Self`) to be `Sized`. We’re
 going to talk about supertraits in more detail in Chapter 19.
 
-`Foo` requires `Self` to be `Sized`, and therefore is not allowed to be a trait
-object. This is because it wold be impossible to implement the trait `Foo` for
-a trait object like `Box<Foo>`: trait objects aren’t sized, but `Foo`
-requires `Self` to be `Sized`. A type can’t be both sized and unsized at the
-same time!
+`Foo` requires `Self` to be `Sized`, and therefore is not allowed to be used in 
+a trait object like `Box<Foo>`. This is because it wold be impossible to implement
+the trait `Foo` for a trait object like `Box<Foo>`: trait objects aren’t sized, 
+but `Foo` requires `Self` to be `Sized`. A type can’t be both sized and unsized
+at the same time!
 
 For the second object safety requirement that says all of a trait’s methods
 must be object safe, a method is object safe if either:

--- a/second-edition/src/ch17-02-trait-objects.md
+++ b/second-edition/src/ch17-02-trait-objects.md
@@ -399,7 +399,7 @@ requires types that implement `Foo` (that is, `Self`) to be `Sized`. We’re
 going to talk about supertraits in more detail in Chapter 19.
 
 `Foo` requires `Self` to be `Sized`, and therefore is not allowed to be used in 
-a trait object like `Box<Foo>`. This is because it wold be impossible to implement
+a trait object like `Box<Foo>`. This is because it would be impossible to implement
 the trait `Foo` for a trait object like `Box<Foo>`: trait objects aren’t sized, 
 but `Foo` requires `Self` to be `Sized`. A type can’t be both sized and unsized
 at the same time!

--- a/second-edition/src/ch17-02-trait-objects.md
+++ b/second-edition/src/ch17-02-trait-objects.md
@@ -400,7 +400,7 @@ going to talk about supertraits in more detail in Chapter 19.
 
 `Foo` requires `Self` to be `Sized`, and therefore is not allowed to be a trait
 object. This is because it wold be impossible to implement the trait `Foo` for
-a trait object like`Box<Foo>`: trait objects aren’t sized, but `Foo`
+a trait object like `Box<Foo>`: trait objects aren’t sized, but `Foo`
 requires `Self` to be `Sized`. A type can’t be both sized and unsized at the
 same time!
 


### PR DESCRIPTION
This sentence was very hard to parse for me as a non-native english speaker. Maybe it's better this way? Also for a trait `Foo` one should imho not refer to a trait object as `Foo`, but give an example, e.g. `Box<Foo>`, which was introduced before. Just because `Foo` is a trait which is not a trait object (nitpick? Not sure, but I think this might lessen confusion).
