### PR TITLE
Fix wrong semicolon placement

### DIFF
--- a/second-edition/src/ch19-01-unsafe-rust.md
+++ b/second-edition/src/ch19-01-unsafe-rust.md
@@ -337,7 +337,7 @@ extern "C" {
 }
 
 fn main() {
-    unsafe { some_function() };
+    unsafe { some_function(); }
 }
 ```
 


### PR DESCRIPTION
**unsafe** is a **block** and don't return anything here ( example: let v = unsafe { ... }; ),
thus will be better to change semicolon placement :bug: :gun: 