### PR TITLE
Improve clarity

### DIFF
--- a/second-edition/src/ch19-03-advanced-traits.md
+++ b/second-edition/src/ch19-03-advanced-traits.md
@@ -461,9 +461,9 @@ trait bound to the trait. Listing 19-29 shows an implementation of the
 `OutlinePrint` trait:
 
 ```rust
-use std::fmt::Display;
+use std::fmt;
 
-trait OutlinePrint: Display {
+trait OutlinePrint: fmt::Display {
     fn outline_print(&self) {
         let output = self.to_string();
         let len = output.len();


### PR DESCRIPTION
This code snippet is different from others (ex. next ones)
and can be a bit misleading when coding exercises from the book.

This change make the snippet feel more connected
to other code from the same "file" as we add code to it (during reading). :smiley: