### PR TITLE
Make Arguments usage explicit

### DIFF
--- a/second-edition/src/ch19-04-advanced-types.md
+++ b/second-edition/src/ch19-04-advanced-types.md
@@ -123,14 +123,14 @@ the functions in `std::io` will be returning `Result<T, E>` where the `E` is
 
 ```rust
 use std::io::Error;
-# use std::fmt::Arguments;
+use std::fmt;
 
 pub trait Write {
     fn write(&mut self, buf: &[u8]) -> Result<usize, Error>;
     fn flush(&mut self) -> Result<(), Error>;
 
     fn write_all(&mut self, buf: &[u8]) -> Result<(), Error>;
-    fn write_fmt(&mut self, fmt: Arguments) -> Result<(), Error>;
+    fn write_fmt(&mut self, fmt: fmt::Arguments) -> Result<(), Error>;
 }
 ```
 


### PR DESCRIPTION
I think it will be better to make ```use std::fmt;``` explicit
and turn ```fn write_fmt(&mut self, fmt: Arguments) -> Result<(), Error>;```
into ```fn write_fmt(&mut self, fmt: fmt::Arguments) -> Result<(), Error>;```.

It will help those readers, who code along with reading / IMHO. :smiley: 

Feel free to comment or **close** this one **if** you **strongly disagree** with my point of view.