### PR TITLE
Use env variable aware version of I/O program

### DIFF
--- a/second-edition/src/ch13-03-improving-our-io-project.md
+++ b/second-edition/src/ch13-03-improving-our-io-project.md
@@ -159,6 +159,7 @@ we can call the `next` method on it! Listing 13-26 has the new code:
 # struct Config {
 #     query: String,
 #     filename: String,
+#     case_sensitive: bool,
 # }
 #
 impl Config {
@@ -175,8 +176,10 @@ impl Config {
             None => return Err("Didn't get a file name"),
         };
 
+        let case_sensitive = env::var("CASE_INSENSITIVE").is_err();
+
         Ok(Config {
-            query, filename
+            query, filename, case_sensitive
         })
     }
 }

--- a/second-edition/src/ch13-03-improving-our-io-project.md
+++ b/second-edition/src/ch13-03-improving-our-io-project.md
@@ -156,6 +156,8 @@ we can call the `next` method on it! Listing 13-26 has the new code:
 <span class="filename">Filename: src/lib.rs</span>
 
 ```rust
+# use std::env;
+#
 # struct Config {
 #     query: String,
 #     filename: String,


### PR DESCRIPTION
This updates this section to use a version of the code made earlier if the reader didn't skip the
chapter on environment variables.

It's submitted as an FYI; perhaps it's intentional that the code here doesn't include the version
from the "optional" chapter that was suggested could be skipped.
