### PR TITLE
2nd edition: Fix description of immutability

### DIFF
--- a/second-edition/src/ch03-01-variables-and-mutability.md
+++ b/second-edition/src/ch03-01-variables-and-mutability.md
@@ -7,8 +7,9 @@ still have the option to make your variables mutable. Let’s explore how and wh
 Rust encourages you to favor immutability, and why you might want to opt out.
 
 When a variable is immutable, that means once a value is bound to a name, you
-can’t change that value. To illustrate, let’s generate a new project called
-*variables* in your *projects* directory by using `cargo new --bin variables`.
+can’t bind anything to that variable again. To illustrate, let’s generate a new
+project called *variables* in your *projects* directory by using
+`cargo new --bin variables`.
 
 Then, in your new *variables* directory, open *src/main.rs* and replace its
 code with the following:


### PR DESCRIPTION
Problems with old description:
1. shadowing
2. `let x = 5; x = 5` isn't changing the value
3. interior mutability?

Problems with new description:
1. It's possible to misread 'value' to mean i.e. `5`, when it actually means a particular `5`.

Also feels problematic (haven't read ahead, though):

"In Rust the compiler guarantees that when we state that a value won’t change,
it really won’t change." (interior mutability again? value != reference != what we mean)