### PR TITLE
Move ',' out of quotes: “The Rust Programming Language,”

### DIFF
--- a/second-edition/src/ch01-00-introduction.md
+++ b/second-edition/src/ch01-00-introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-Welcome to “The Rust Programming Language,” an introductory book about Rust.
+Welcome to “The Rust Programming Language”, an introductory book about Rust.
 Rust is a programming language that’s focused on safety, speed, and
 concurrency. Its design lets you create programs that have the performance and
 control of a low-level language, but with the powerful abstractions of a


### PR DESCRIPTION
Both `,”` and `”,` are used widely in book, there should be some convention about it.