### PR TITLE
Rename list variable for clarity

### DIFF
--- a/second-edition/src/ch10-00-generics.md
+++ b/second-edition/src/ch10-00-generics.md
@@ -47,11 +47,11 @@ Listing 10-1:
 
 ```rust
 fn main() {
-    let numbers = vec![34, 50, 25, 100, 65];
+    let number_list = vec![34, 50, 25, 100, 65];
 
-    let mut largest = numbers[0];
+    let mut largest = number_list[0];
 
-    for number in numbers {
+    for number in number_list {
         if number > largest {
             largest = number;
         }
@@ -65,7 +65,7 @@ fn main() {
 <span class="caption">Listing 10-1: Code to find the largest number in a list
 of numbers</span>
 
-This code takes a list of integers, stored here in the variable `numbers`. It
+This code takes a list of integers, stored here in the variable `number_list`. It
 puts the first item in the list in a variable named `largest`. Then it iterates
 through all the numbers in the list, and if the current value is greater than
 the number stored in `largest`, it replaces the value in `largest`. If the
@@ -81,11 +81,11 @@ places in the program, as in Listing 10-2:
 
 ```rust
 fn main() {
-    let numbers = vec![34, 50, 25, 100, 65];
+    let number_list = vec![34, 50, 25, 100, 65];
 
-    let mut largest = numbers[0];
+    let mut largest = number_list[0];
 
-    for number in numbers {
+    for number in number_list {
         if number > largest {
             largest = number;
         }
@@ -93,11 +93,11 @@ fn main() {
 
     println!("The largest number is {}", largest);
 
-    let numbers = vec![102, 34, 6000, 89, 54, 2, 43, 8];
+    let number_list = vec![102, 34, 6000, 89, 54, 2, 43, 8];
 
-    let mut largest = numbers[0];
+    let mut largest = number_list[0];
 
-    for number in numbers {
+    for number in number_list {
         if number > largest {
             largest = number;
         }
@@ -144,15 +144,15 @@ fn largest(list: &[i32]) -> i32 {
 }
 
 fn main() {
-    let numbers = vec![34, 50, 25, 100, 65];
+    let number_list = vec![34, 50, 25, 100, 65];
 
-    let result = largest(&numbers);
+    let result = largest(&number_list);
     println!("The largest number is {}", result);
 #    assert_eq!(result, 100);
 
-    let numbers = vec![102, 34, 6000, 89, 54, 2, 43, 8];
+    let number_list = vec![102, 34, 6000, 89, 54, 2, 43, 8];
 
-    let result = largest(&numbers);
+    let result = largest(&number_list);
     println!("The largest number is {}", result);
 #    assert_eq!(result, 6000);
 }

--- a/second-edition/src/ch10-01-syntax.md
+++ b/second-edition/src/ch10-01-syntax.md
@@ -46,9 +46,9 @@ fn largest_char(list: &[char]) -> char {
 }
 
 fn main() {
-    let numbers = vec![34, 50, 25, 100, 65];
+    let number_list = vec![34, 50, 25, 100, 65];
 
-    let result = largest_i32(&numbers);
+    let result = largest_i32(&number_list);
     println!("The largest number is {}", result);
 #    assert_eq!(result, 100);
 
@@ -115,9 +115,9 @@ fn largest<T>(list: &[T]) -> T {
 }
 
 fn main() {
-    let numbers = vec![34, 50, 25, 100, 65];
+    let number_list = vec![34, 50, 25, 100, 65];
 
-    let result = largest(&numbers);
+    let result = largest(&number_list);
     println!("The largest number is {}", result);
 
     let chars = vec!['y', 'm', 'a', 'q'];

--- a/second-edition/src/ch10-01-syntax.md
+++ b/second-edition/src/ch10-01-syntax.md
@@ -52,9 +52,9 @@ fn main() {
     println!("The largest number is {}", result);
 #    assert_eq!(result, 100);
 
-    let chars = vec!['y', 'm', 'a', 'q'];
+    let char_list = vec!['y', 'm', 'a', 'q'];
 
-    let result = largest_char(&chars);
+    let result = largest_char(&char_list);
     println!("The largest char is {}", result);
 #    assert_eq!(result, 'y');
 }
@@ -120,9 +120,9 @@ fn main() {
     let result = largest(&number_list);
     println!("The largest number is {}", result);
 
-    let chars = vec!['y', 'm', 'a', 'q'];
+    let char_list = vec!['y', 'm', 'a', 'q'];
 
-    let result = largest(&chars);
+    let result = largest(&char_list);
     println!("The largest char is {}", result);
 }
 ```

--- a/second-edition/src/ch10-02-traits.md
+++ b/second-edition/src/ch10-02-traits.md
@@ -433,9 +433,9 @@ fn main() {
     let result = largest(&number_list);
     println!("The largest number is {}", result);
 
-    let chars = vec!['y', 'm', 'a', 'q'];
+    let char_list = vec!['y', 'm', 'a', 'q'];
 
-    let result = largest(&chars);
+    let result = largest(&char_list);
     println!("The largest char is {}", result);
 }
 ```

--- a/second-edition/src/ch10-02-traits.md
+++ b/second-edition/src/ch10-02-traits.md
@@ -428,9 +428,9 @@ fn largest<T: PartialOrd + Copy>(list: &[T]) -> T {
 }
 
 fn main() {
-    let numbers = vec![34, 50, 25, 100, 65];
+    let number_list = vec![34, 50, 25, 100, 65];
 
-    let result = largest(&numbers);
+    let result = largest(&number_list);
     println!("The largest number is {}", result);
 
     let chars = vec!['y', 'm', 'a', 'q'];


### PR DESCRIPTION
Signed-off-by: echohack <echohack@users.noreply.github.com>


Hello,

This is a small (but important) variable name change. It's important when naming variables that hold collections to name them something different from the iterator. Simply putting an `s` on the end of the iterator name is a good way to introduce bugs into your program.

This isn't a strict rule, but in general, collection names should be longer than the iterator name. Many times the collection name is a group of something or a list of something, like `player_group`, `equipment_list`, or in the book's example, `number_list`. Which makes it easy to identify the iterator, `player`, `equipment`, or `number`. Using an underscore is a great way to identify the collection, because most autocompletion will require a second hit of the tab key or intentional typing of the underscore to write out that variable name. Thus, it makes the programmer think just a little bit more when writing that variable.

Finally, naming the variable `number_list` illustrates the point about building a generic function that takes a generic named `list` as a parameter better, I think.

Similarly, `chars` to `char_list` is a better way of avoiding a name collision with the reserved word `char`.

Thanks for considering my pull request. I hope you don't think it's too pedantic and feel that good names can help result in less bugs too. This is my first pull request to this project, so I wanted to fully explain my thoughts.

Have a good one!

