### PR TITLE
Casting from a pointer should have type 'usize', not 'i32'.

### DIFF
--- a/second-edition/src/ch19-01-unsafe-rust.md
+++ b/second-edition/src/ch19-01-unsafe-rust.md
@@ -100,7 +100,7 @@ There’s not usually a good reason to be writing code like this, but it is
 possible:
 
 ```rust
-let address = 0x012345;
+let address = 0x012345isize;
 let r = address as *const i32;
 ```
 
@@ -305,7 +305,7 @@ location and creates a slice ten thousand items long:
 ```rust
 use std::slice;
 
-let address = 0x012345;
+let address = 0x012345isize;
 let r = address as *mut i32;
 
 let slice = unsafe {

--- a/second-edition/src/ch19-01-unsafe-rust.md
+++ b/second-edition/src/ch19-01-unsafe-rust.md
@@ -100,7 +100,7 @@ There’s not usually a good reason to be writing code like this, but it is
 possible:
 
 ```rust
-let address = 0x012345isize;
+let address = 0x012345usize;
 let r = address as *const i32;
 ```
 
@@ -305,7 +305,7 @@ location and creates a slice ten thousand items long:
 ```rust
 use std::slice;
 
-let address = 0x012345isize;
+let address = 0x012345usize;
 let r = address as *mut i32;
 
 let slice = unsafe {


### PR DESCRIPTION
Found via https://github.com/rust-lang/rust/pull/43641.