### PR TITLE
Remove claim f32 is faster on 32-bit platforms

### DIFF
--- a/second-edition/dictionary.txt
+++ b/second-edition/dictionary.txt
@@ -57,6 +57,7 @@ const
 constant's
 copyeditor
 couldn
+CPUs
 cratesio
 CRLF
 cryptographically

--- a/second-edition/src/ch03-02-data-types.md
+++ b/second-edition/src/ch03-02-data-types.md
@@ -104,12 +104,8 @@ you’d use `isize` or `usize` is when indexing some sort of collection.
 Rust also has two primitive types for *floating-point numbers*, which are
 numbers with decimal points. Rust’s floating-point types are `f32` and `f64`,
 which are 32 bits and 64 bits in size, respectively. The default type is `f64`
-because it’s roughly the same speed as `f32` but is capable of more precision.
-It’s possible to use an `f64` type on 32-bit systems, but it will be slower
-than using an `f32` type on those systems. Most of the time, trading potential
-worse performance for better precision is a reasonable initial choice, and you
-should benchmark your code if you suspect floating-point size is a problem in
-your situation.
+because on modern CPUs it’s roughly the same speed as `f32` but is capable of
+more precision.
 
 Here’s an example that shows floating-point numbers in action:
 


### PR DESCRIPTION
I'm not exactly a CPU ISA expert, but as someone currently reading this book (hi, it's great!), this didn't sound right to me. After all, x86 had 64-bit (well, sort of) floats for 2.5 decades before it had 64-bit integers! Is there any truth to this claim that `f32` is faster *on 32-bit platforms 
specifically*?

`f32` may be slower than `f64` in some circumstances, on some platforms, but to single out 32-bit platforms seems quite misleading. The code won't necessarily run slower on 32-bit platforms, nor do you *not* have to worry about `f64` performance on 64-bit platforms.