### PR TITLE
Synchronize operator precedence with reference

### DIFF
--- a/second-edition/src/appendix-02-operators.md
+++ b/second-edition/src/appendix-02-operators.md
@@ -171,25 +171,25 @@ Any such expression always has the `unit` type.
 
 #### Operator precedence
 
-The precedence of Rust binary operators is ordered as follows, going from
-strong to weak:
+The precedence of Rust operators is ordered as follows, going from strong to
+weak. Binary Operators at the same precedence level are evaluated in the order
+given by their associativity.
 
-```text
-as :
-* / %
-+ -
-<< >>
-&
-^
-|
-== != < > <= >=
-&&
-||
-.. ...
-<-
-=
-```
 
-Operators at the same precedence level are evaluated left-to-right. Unary
-operators have the same precedence level and are stronger than any of the
-binary operators.
+| Operator                    | Associativity       |
+|-----------------------------|---------------------|
+| `?`                         |                     |
+| Unary `-` `*` `!` `&` `&mut` |                    |
+| `as` `:`                    | left to right       |
+| `*` `/` `%`                 | left to right       |
+| `+` `-`                     | left to right       |
+| `<<` `>>`                   | left to right       |
+| `&`                         | left to right       |
+| `^`                         | left to right       |
+| <code>&#124;</code>         | left to right       |
+| `==` `!=` `<` `>` `<=` `>=` | Require parentheses |
+| `&&`                        | left to right       |
+| <code>&#124;&#124;</code>   | left to right       |
+| `..` `...`                  | Require parentheses |
+| `<-`                        | right to left       |
+| `=` `+=` `-=` `*=` `/=` `%=` <br> `&=` <code>&#124;=</code> `^=` `<<=` `>>=` | right to left |


### PR DESCRIPTION
The reference is here https://github.com/rust-lang-nursery/reference/blob/266d429a48468371d2d90669f6a30dd659bb4bdb/src/expressions.md#operator-precedence.

It is both more complete (includes the `?`) and more accurate.

Previous version said:

>Unary operators have the same precedence level and are stronger than any of the binary operators.

which is technically incorrect. Unary `..` and `...` have low precedence: `println!("{:?}", .. 90 + 2)` prints `.. 92`.

## What to expect when you open a pull request here

### First edition

The first edition is no longer being actively worked on. We accept pull
requests for the first edition, but prefer small tweaks to large changes, as
larger work should be spent improving the second edition.

### Second edition

For the second edition, we are currently working with No Starch Press to bring
it to print. Chapters go through a number of stages in the editing process, and
once they've gotten to the layout stage, they're effectively frozen.

For chapters that have gotten to the layout stage, we will likely only be
accepting changes that correct factual errors or major problems and not, for
example, minor wording changes.

Scroll all the way to the right on https://github.com/rust-lang/book/projects/1
to see which chapters have been frozen.

Please see CONTRIBUTING.md for more details.

Thank you for reading, you may now delete this text!
