### PR TITLE
Fix an inconsistency between code and explanation

### DIFF
--- a/second-edition/src/ch03-02-data-types.md
+++ b/second-edition/src/ch03-02-data-types.md
@@ -13,7 +13,7 @@ converted a `String` to a numeric type using `parse` in Chapter 2, we must add
 a type annotation, like this:
 
 ```rust
-let guess: u32 = "42".parse().expect("Not a number!");
+let guess: i32 = "42".parse().expect("Not a number!");
 ```
 
 If we don’t add the type annotation here, Rust will display the following


### PR DESCRIPTION
In the explanation (Section `Integer Types`), the book talks about having used an `i32` already, however an u32 was used. Especially for a beginner this might be confusing, so i changed the code to match the explanation.

Now, i know this chapter has already been frozen, but it won't hurt to submit it anyways. After all it is a simple one-character change and shouldn't break any layout.

Of course, i am very aware that this is unlikely to get merged.