### PR TITLE
Added `pub` keyword in Chapter 11-1 for `Guess` examples

### DIFF
--- a/second-edition/src/ch11-01-writing-tests.md
+++ b/second-edition/src/ch11-01-writing-tests.md
@@ -592,7 +592,7 @@ Listing 11-8 shows how we’d write a test that checks the error conditions of
 <span class="filename">Filename: src/lib.rs</span>
 
 ```rust
-struct Guess {
+pub struct Guess {
     value: u32,
 }
 
@@ -638,7 +638,7 @@ Looks good! Now let’s introduce a bug in our code, by removing the condition
 that the `new` function will panic if the value is greater than 100:
 
 ```rust
-# struct Guess {
+# pub struct Guess {
 #     value: u32,
 # }
 #
@@ -686,7 +686,7 @@ different messages depending on whether the value was too small or too large:
 <span class="filename">Filename: src/lib.rs</span>
 
 ```rust
-struct Guess {
+pub struct Guess {
     value: u32,
 }
 


### PR DESCRIPTION
I think the `Guess` struct examples in Chapter 11-1 should contain the `pub` keyword. Also I don't get what are those hash characters doing in the second example? I did not remove those because interestingly, the rendered official page does not seem to contain those.