### PR TITLE
Ch19 - fix fully qualified syntax

### DIFF
--- a/second-edition/src/ch19-03-advanced-traits.md
+++ b/second-edition/src/ch19-03-advanced-traits.md
@@ -600,7 +600,7 @@ A baby dog is called a puppy
 In general, fully qualified syntax is defined as:
 
 ```rust,ignore
-<Type as Trait>::function(receiver, args);
+<Type as Trait>::function(receiver_if_method, next_arg, ...);
 ```
 
 For associated functions, there would not be a `receiver`, there would only be

--- a/second-edition/src/ch19-03-advanced-traits.md
+++ b/second-edition/src/ch19-03-advanced-traits.md
@@ -637,7 +637,7 @@ In the implementation of `outline_print`, since we want to be able to use the
 `OutlinePrint` trait will only work for types that also implement `Display` and
 provide the functionality that `OutlinePrint` needs. We can do that in the
 trait definition by specifying `OutlinePrint: Display`. It’s like adding a
-trait bound to the trait. Listing 19-29 shows an implementation of the
+trait bound to the trait. Listing 19-33 shows an implementation of the
 `OutlinePrint` trait:
 
 ```rust
@@ -656,7 +656,7 @@ trait OutlinePrint: fmt::Display {
 }
 ```
 
-<span class="caption">Listing 19-29: Implementing the `OutlinePrint` trait that
+<span class="caption">Listing 19-33: Implementing the `OutlinePrint` trait that
 requires the functionality from `Display`</span>
 
 Because we’ve specified that `OutlinePrint` requires the `Display` trait, we
@@ -731,7 +731,7 @@ is elided at compile time.
 
 For example, if we wanted to implement `Display` on `Vec`, we can make a
 `Wrapper` struct that holds an instance of `Vec`. Then we can implement
-`Display` on `Wrapper` and use the `Vec` value as shown in Listing 19-30:
+`Display` on `Wrapper` and use the `Vec` value as shown in Listing 19-34:
 
 <span class="filename">Filename: src/main.rs</span>
 
@@ -752,7 +752,7 @@ fn main() {
 }
 ```
 
-<span class="caption">Listing 19-30: Creating a `Wrapper` type around
+<span class="caption">Listing 19-34: Creating a `Wrapper` type around
 `Vec<String>` to be able to implement `Display`</span>
 
 The implementation of `Display` uses `self.0` to access the inner `Vec`, and

--- a/second-edition/src/ch19-04-advanced-types.md
+++ b/second-edition/src/ch19-04-advanced-types.md
@@ -70,7 +70,7 @@ Box<Fn() + Send + 'static>
 
 Writing this out in function signatures and as type annotations all over the
 place can be tiresome and error-prone. Imagine having a project full of code
-like that in Listing 19-31:
+like that in Listing 19-35:
 
 ```rust
 let f: Box<Fn() + Send + 'static> = Box::new(|| println!("hi"));
@@ -85,12 +85,12 @@ fn returns_long_type() -> Box<Fn() + Send + 'static> {
 }
 ```
 
-<span class="caption">Listing 19-31: Using a long type in many places</span>
+<span class="caption">Listing 19-35: Using a long type in many places</span>
 
 A type alias makes this code more manageable by reducing the amount of
 repetition this project has. Here, we’ve introduced an alias named `Thunk` for
 the verbose type, and we can replace all uses of the type with the shorter
-`Thunk` as shown in Listing 19-32:
+`Thunk` as shown in Listing 19-36:
 
 ```rust
 type Thunk = Box<Fn() + Send + 'static>;
@@ -107,7 +107,7 @@ fn returns_long_type() -> Thunk {
 }
 ```
 
-<span class="caption">Listing 19-32: Introducing a type alias `Thunk` to reduce
+<span class="caption">Listing 19-36: Introducing a type alias `Thunk` to reduce
 repetition</span>
 
 Much easier to read and write! Choosing a good name for a type alias can help
@@ -178,7 +178,7 @@ This is read as “the function `bar` returns never,” and functions that retur
 never are called *diverging functions*. We can’t create values of the type `!`,
 so `bar` can never possibly return. What use is a type you can never create
 values for? If you think all the way back to Chapter 2, we had some code that
-looked like this, reproduced here in Listing 19-33:
+looked like this, reproduced here in Listing 19-37:
 
 ```rust
 # let guess = "3";
@@ -191,7 +191,7 @@ let guess: u32 = match guess.trim().parse() {
 # }
 ```
 
-<span class="caption">Listing 19-33: A `match` with an arm that ends in
+<span class="caption">Listing 19-37: A `match` with an arm that ends in
 `continue`</span>
 
 At the time, we skipped over some details in this code. In Chapter 6, we
@@ -207,7 +207,7 @@ let guess = match guess.trim().parse()  {
 What would the type of `guess` be here? It’d have to be both an integer and a
 string, and Rust requires that `guess` can only have one type. So what does
 `continue` return? Why are we allowed to return a `u32` from one arm in Listing
-19-33 and have another arm that ends with `continue`?
+19-37 and have another arm that ends with `continue`?
 
 As you may have guessed, `continue` has a value of `!`. That is, when Rust goes
 to compute the type of `guess`, it looks at both of the match arms. The former

--- a/second-edition/src/ch19-05-advanced-functions-and-closures.md
+++ b/second-edition/src/ch19-05-advanced-functions-and-closures.md
@@ -9,7 +9,7 @@ We’ve talked about how to pass closures to functions, but you can pass regular
 functions to functions too! Functions coerce to the type `fn`, with a lower
 case ‘f’ not to be confused with the `Fn` closure trait. `fn` is called a
 *function pointer*. The syntax for specifying that a parameter is a function
-pointer is similar to that of closures, as shown in Listing 19-34:
+pointer is similar to that of closures, as shown in Listing 19-38:
 
 <span class="filename">Filename: src/main.rs</span>
 
@@ -29,7 +29,7 @@ fn main() {
 }
 ```
 
-<span class="caption">Listing 19-34: Using the `fn` type to accept a function
+<span class="caption">Listing 19-38: Using the `fn` type to accept a function
 pointer as an argument</span>
 
 This prints `The answer is: 12`. We specify that the parameter `f` in


### PR DESCRIPTION
This builds on top of #914 in order to resolve #903 and #904 - I made the style more consistent, added listing numbers and captions, and reworked the example where the fully qualified syntax is needed to not use a `self` param so that it actually doesn't work without `<Type as Trait>`.

@steveklabnik could you review this please? i feel like I understand this section better now, but I might still have some problems in my mental model.

closes #904
closes #903