### PR TITLE
Update ch11-01-writing-tests.md

### DIFF
--- a/second-edition/src/ch11-01-writing-tests.md
+++ b/second-edition/src/ch11-01-writing-tests.md
@@ -211,8 +211,7 @@ helps us check that our code is functioning in the way we intend.
 
 Remember all the way back in Chapter 5, Listing 5-9, where we had a `Rectangle`
 struct and a `can_hold` method, repeated here in Listing 11-5. Let’s put this
-code in *src/lib.rs* instead of *src/main.rs* and write some tests for it using
-the `assert!` macro.
+code in *src/lib.rs* and write some tests for it using the `assert!` macro.
 
 <span class="filename">Filename: src/lib.rs</span>
 


### PR DESCRIPTION
Perhaps an older version of this file had us working in *src/main.rs*, but earlier we are called upon to use `cargo new adder` which I don't believe auto-generates a *src/main.rs* file; and seeing as how there are no other references to such a file in this section, I assume it's safe to remove the bit telling us not to put our code there.