### PR TITLE
Fix inaccurate wording

### DIFF
--- a/second-edition/src/ch07-01-mod-and-the-filesystem.md
+++ b/second-edition/src/ch07-01-mod-and-the-filesystem.md
@@ -383,7 +383,7 @@ previously, we can do what the note suggests:
 
 1. Make a new *directory* named *network*, the parent module’s name.
 2. Move the *src/network.rs* file into the new *network* directory, and
-   rename *src/network/mod.rs*.
+   rename it to *src/network/mod.rs*.
 3. Move the submodule file *src/server.rs* into the *network* directory.
 
 Here are commands to carry out these steps:


### PR DESCRIPTION
"rename src/network/mod.rs" implies that the file being renamed is
`src/network/mod.rs`. However, it's clear from context that actually
`src/network.rs` is the source file that is being renamed _to_
destination file `src/network/mod.rs`