### PR TITLE
Add redirect link to correct new page

### DIFF
--- a/redirects/associated-types.md
+++ b/redirects/associated-types.md
@@ -1,12 +1,12 @@
 % There is a new edition of the book
 
 This is an old link. You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+If you're trying to learn Rust, checking out [the equivalent second edition page][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [The equivalent page in the second edition of The Rust Programming Language][2]
 
 
 [1]: first-edition/associated-types.html
-[2]: second-edition/index.html
+[2]: second-edition/ch19-03-advanced-traits.html#associated-types


### PR DESCRIPTION
I Google Rust concepts a lot, and almost always end up at the redirect page, which almost always points me at the index of the Second Edition instead of the thing I Googled for. I'd love if the link pointed to the correct section to save me lots of clicking and scanning time.

This is a "test PR," if you will, to see what y'all think of doing this in general before I invest the time to do other pages.