### PR TITLE
Omit needless ref

### DIFF
--- a/second-edition/src/ch15-06-reference-cycles.md
+++ b/second-edition/src/ch15-06-reference-cycles.md
@@ -100,8 +100,8 @@ fn main() {
     println!("a rc count after b creation = {}", Rc::strong_count(&a));
     println!("b initial rc count = {}", Rc::strong_count(&b));
     println!("b next item = {:?}", b.tail());
-
-    if let Some(link) = a.tail() {
+    
+    if let Some(link) = a.tail() {
         *link.borrow_mut() = Rc::clone(&b);
     }
 

--- a/second-edition/src/ch15-06-reference-cycles.md
+++ b/second-edition/src/ch15-06-reference-cycles.md
@@ -101,7 +101,7 @@ fn main() {
     println!("b initial rc count = {}", Rc::strong_count(&b));
     println!("b next item = {:?}", b.tail());
 
-    if let Some(ref link) = a.tail() {
+    if let Some(link) = a.tail() {
         *link.borrow_mut() = Rc::clone(&b);
     }
 


### PR DESCRIPTION
Just learning rust and this `ref` confused me; removing it doesn't change the program's behavior, so it seems best omitted. (If this is wrong, I'd love to understand why.)
