### PR TITLE
Fixed a small inconsistency in code listings

### DIFF
--- a/second-edition/src/ch10-03-lifetime-syntax.md
+++ b/second-edition/src/ch10-03-lifetime-syntax.md
@@ -151,9 +151,9 @@ longest string is abcd` once we’ve implemented the `longest` function:
 ```rust,ignore
 fn main() {
     let string1 = String::from("abcd");
-    let string2 = "xyz";
+    let string2 = String::from("xyz");
 
-    let result = longest(string1.as_str(), string2);
+    let result = longest(string1.as_str(), string2.as_str());
     println!("The longest string is {}", result);
 }
 ```


### PR DESCRIPTION
I think `string2` being a string literal in Listing 10-21 doesn't make much sense and makes the example confusing while serving no educational purposes. Even more so when this is changed in Listing 10-24 and Listing 10-25.

While testing the examples, I copied the code in Listing 10-21 then later modified it to look like the code in Listing 10-25 and, surprisingly, it compiled. It took me a couple of minutes to figure out that the definition of `string2` was changed and not knowing yet about static lifetimes (explained later in the chapter) made it impossible for me to figure out why the program would behave like that.