### PR TITLE
(minor) Use Iterator::take rather than a manual counter

### DIFF
--- a/second-edition/dictionary.txt
+++ b/second-edition/dictionary.txt
@@ -54,6 +54,7 @@ charset
 chXX
 chYY
 coercions
+combinator
 ConcreteType
 config
 Config

--- a/second-edition/src/ch20-06-graceful-shutdown-and-cleanup.md
+++ b/second-edition/src/ch20-06-graceful-shutdown-and-cleanup.md
@@ -326,9 +326,10 @@ Only serving two requests isn’t behavior you’d like a production web server 
 have, but this will let us see the graceful shutdown and cleanup working since
 we won’t be stopping the server with <span class="keystroke">ctrl-C</span>.
 
-We’ve limited the `TcpStream` iterator with a `take(2)`. The `ThreadPool` will
-go out of scope at the end of `main`, and we’ll see the `drop` implementation
-run.
+The `.take(2)` we added to `listener.incoming()` artificially limits the
+iteration to the first 2 items at most. This combinator works for any
+implementation of the `Iterator` trait. The `ThreadPool` will go out of scope
+at the end of `main`, and we’ll see the `drop` implementation run.
 
 Start the server with `cargo run`, and make three requests. The third request
 should error, and in your terminal you should see output that looks like:


### PR DESCRIPTION
I feel like this makes Rust look cooler and probably reads better
because it's a smaller/more natural diff from the previous version of
`main()`.