### PR TITLE
Fix inconsistency in final code listing

### DIFF
--- a/second-edition/src/ch20-06-graceful-shutdown-and-cleanup.md
+++ b/second-edition/src/ch20-06-graceful-shutdown-and-cleanup.md
@@ -393,22 +393,15 @@ fn main() {
     let listener = TcpListener::bind("127.0.0.1:8080").unwrap();
     let pool = ThreadPool::new(4);
 
-    let mut counter = 0;
-
-    for stream in listener.incoming() {
-        if counter == 2 {
-            println!("Shutting down.");
-            break;
-        }
-
-        counter += 1;
-
+    for stream in listener.incoming().take(2) {
         let stream = stream.unwrap();
 
         pool.execute(|| {
             handle_connection(stream);
         });
     }
+
+    println!("Shutting down.");
 }
 
 fn handle_connection(mut stream: TcpStream) {


### PR DESCRIPTION
I forgot to apply the change from the penultimate listing of `main()` to
the summary at the end of the chapter.

So sorry! Just noticed when proofreading after it got merged.

@carols10cents 