### PR TITLE
Fix line number for error message example

### DIFF
--- a/second-edition/src/ch09-02-recoverable-errors-with-result.md
+++ b/second-edition/src/ch09-02-recoverable-errors-with-result.md
@@ -128,7 +128,7 @@ code, we’ll see the following output from the `panic!` macro:
 
 ```text
 thread 'main' panicked at 'There was a problem opening the file: Error { repr:
-Os { code: 2, message: "No such file or directory" } }', src/main.rs:8
+Os { code: 2, message: "No such file or directory" } }', src/main.rs:9:12
 ```
 
 As usual, this output tells us exactly what has gone wrong.


### PR DESCRIPTION
The line number of the error message in the text is not correct.
Besides, the column number is also missing.
