### PR TITLE
the test generated by cargo new isn't empty

### DIFF
--- a/second-edition/src/ch11-01-writing-tests.md
+++ b/second-edition/src/ch11-01-writing-tests.md
@@ -46,6 +46,7 @@ follows:
 mod tests {
     #[test]
     fn it_works() {
+        assert_eq!(2 + 2, 4);
     }
 }
 ```
@@ -60,9 +61,9 @@ function as a test. We could also have non-test functions in the `tests` module
 to help set up common scenarios or perform common operations, so we need to
 indicate which functions are tests with the `#[test]` attribute.
 
-The function currently has no body, which means there is no code to fail the
-test; an empty test is a passing test! Let’s run it and see that this test
-passes.
+The function boddy use the `assert_eq!` macro to assert that 2 + 2 equals 4.
+This assersion serves as an example of the form for a typical test.
+Let’s run it and see that this test passes.
 
 The `cargo test` command runs all tests we have in our project, as shown in
 Listing 11-2:

--- a/second-edition/src/ch11-03-test-organization.md
+++ b/second-edition/src/ch11-03-test-organization.md
@@ -42,6 +42,7 @@ this chapter, Cargo generated this code for us:
 mod tests {
     #[test]
     fn it_works() {
+        assert_eq!(2 + 2, 4);
     }
 }
 ```


### PR DESCRIPTION
The default test generated by `cargo new mylib` has an `assert_eq!(2 + 2, 4)` line.

The text that describe this should be updated as well.