### PR TITLE
ch2: unused result warning differs

### DIFF
--- a/second-edition/src/ch02-00-guessing-game-tutorial.md
+++ b/second-edition/src/ch02-00-guessing-game-tutorial.md
@@ -285,7 +285,7 @@ If we don’t call `expect`, the program will compile, but we’ll get a warning
 ```text
 $ cargo build
    Compiling guessing_game v0.1.0 (file:///projects/guessing_game)
-warning: unused `std::result::Result` which must be used
+warning: unused result which must be used
   --> src/main.rs:10:5
    |
 10 |     io::stdin().read_line(&mut guess);


### PR DESCRIPTION
When running `cargo build` with rust 1.21.0 (rustc 1.18.0), the warning appears as:

```
warning: unused result which must be used
```

rather than

```
unused `std::result::Result` which must be used
```