### PR TITLE
Chapter 9: Indexing mistake, arrays start at 0

### DIFF
--- a/second-edition/src/ch09-01-unrecoverable-errors-with-panic.md
+++ b/second-edition/src/ch09-01-unrecoverable-errors-with-panic.md
@@ -81,10 +81,11 @@ fn main() {
 <span class="caption">Listing 9-1: Attempting to access an element beyond the
 end of a vector, which will cause a `panic!`</span>
 
-Here, we’re attempting to access the hundredth element (hundredth since indexing starts at zero) of our vector, but it
-has only three elements. In this situation, Rust will panic. Using `[]` is
-supposed to return an element, but if you pass an invalid index, there’s no
-element that Rust could return here that would be correct.
+Here, we’re attempting to access the hundredth element (hundredth as indexing
+starts at zero) of our vector, but it has only three elements. In this case,
+Rust will panic. Using `[]` is supposed to return an element, but if you pass
+an invalid index, there’s no element that Rust could return here that would be
+correct.
 
 Other languages, like C, will attempt to give you exactly what you asked for in
 this situation, even though it isn’t what you want: you’ll get whatever is at

--- a/second-edition/src/ch09-01-unrecoverable-errors-with-panic.md
+++ b/second-edition/src/ch09-01-unrecoverable-errors-with-panic.md
@@ -74,14 +74,14 @@ element by index in a vector:
 fn main() {
     let v = vec![1, 2, 3];
 
-    v[100];
+    v[99];
 }
 ```
 
 <span class="caption">Listing 9-1: Attempting to access an element beyond the
 end of a vector, which will cause a `panic!`</span>
 
-Here, we’re attempting to access the hundredth element of our vector, but it
+Here, we’re attempting to access the hundredth element (hundredth since indexing starts at zero) of our vector, but it
 has only three elements. In this situation, Rust will panic. Using `[]` is
 supposed to return an element, but if you pass an invalid index, there’s no
 element that Rust could return here that would be correct.


### PR DESCRIPTION
Factual error. `v[99]` refers to the hundredth element in the array. `v[100]` refers to the hundred and first element. May confuse some people like it did me. Changed the index rather than the wording since hundred and first is a bit verbose. 