### PR TITLE
Omit the unnecessary import of std::cmp::PartialOrd on ch10-02-traits

### DIFF
--- a/second-edition/src/ch10-02-traits.md
+++ b/second-edition/src/ch10-02-traits.md
@@ -413,8 +413,6 @@ and `Copy` traits, like `i32` and `char`:
 <span class="filename">Filename: src/main.rs</span>
 
 ```rust
-use std::cmp::PartialOrd;
-
 fn largest<T: PartialOrd + Copy>(list: &[T]) -> T {
     let mut largest = list[0];
 


### PR DESCRIPTION
Omit the unnecessary import of `std::cmp::PartialOrd` on `ch10-02-traits`.

This module is in the prelude and that is stated clearly on the same chapter ( "We don’t need to bring PartialOrd into scope because it’s in the prelude." ), so it's preferable to omit the import of `std::cmp::PartialOrd`.