### PR TITLE
Reword description of how ! coerces into other types

### DIFF
--- a/second-edition/src/ch19-04-advanced-types.md
+++ b/second-edition/src/ch19-04-advanced-types.md
@@ -213,11 +213,11 @@ As you may have guessed, `continue` has a value of `!`. That is, when Rust goes
 to compute the type of `guess`, it looks at both of the match arms. The former
 has a value of `u32`, and the latter has a value of `!`. Since `!` can never
 have a value, Rust is okay with this, and decides that the type of `guess` is
-`u32`. The formal way of describing this behavior of `!` is that the never type
-unifies with all other types. We’re allowed to end this `match` arm with
-`continue` because `continue` doesn’t actually return a value; it instead moves
-control back to the top of the loop, so in the `Err` case, we never actually
-assign a value to `guess`.
+`u32`. The formal way of describing this behavior is that expressions of type
+`!` can be coerced into any other type. We’re allowed to end this `match` arm
+with `continue` because `continue` doesn’t actually return a value; it instead
+moves control back to the top of the loop, so in the `Err` case, we never
+actually assign a value to `guess`.
 
 Another use of the never type is `panic!`. Remember the `unwrap` function that
 we call on `Option<T>` values to produce a value or panic? Here’s its


### PR DESCRIPTION
This is a bit nit-picky but it's not quite correct to say that `!` unifies with all other types. If it did then could (for example) treat a `Result<T, !>` as a `Result<T, E>` (not that `Result<T, !>` is a valid type on stable yet).