### PR TITLE
Removed 0 from first_word slice example

### DIFF
--- a/second-edition/src/ch04-03-slices.md
+++ b/second-edition/src/ch04-03-slices.md
@@ -219,7 +219,7 @@ fn first_word(s: &String) -> &str {
 
     for (i, &item) in bytes.iter().enumerate() {
         if item == b' ' {
-            return &s[0..i];
+            return &s[..i];
         }
     }
 


### PR DESCRIPTION
I feel that `[..i]` would be more idomatic Rust syntax than `[0..i]`.
