### PR TITLE
update recursive without indirection error message

### DIFF
--- a/second-edition/src/ch15-01-box.md
+++ b/second-edition/src/ch15-01-box.md
@@ -202,7 +202,7 @@ error[E0072]: recursive type `List` has infinite size
 1 | enum List {
   | ^^^^^^^^^ recursive type has infinite size
 2 |     Cons(i32, List),
-  |     --------------- recursive without indirection
+  |               ----- recursive without indirection
   |
   = help: insert indirection (e.g., a `Box`, `Rc`, or `&`) at some point to
   make `List` representable


### PR DESCRIPTION
In Rust 1.22.1, the line that indicates the offending `recursive without indirection` element underlines only the recursive element.

