### PR TITLE
Update ch15-02-deref.md

### DIFF
--- a/second-edition/src/ch15-02-deref.md
+++ b/second-edition/src/ch15-02-deref.md
@@ -81,10 +81,10 @@ error:
 ```text
 error[E0277]: the trait bound `{integer}: std::cmp::PartialEq<&{integer}>` is
 not satisfied
- --> <assert_eq macros>:5:19
+ --> src/main.rs:6:5
   |
-5 | if ! ( * left_val == * right_val ) {
-  |                   ^^ can't compare `{integer}` with `&{integer}`
+6 |     assert_eq!(5, y);
+  |     ^^^^^^^^^^^^^^^^^ can't compare `{integer}` with `&{integer}`
   |
   = help: the trait `std::cmp::PartialEq<&{integer}>` is not implemented for
   `{integer}`


### PR DESCRIPTION
In Rust 1.22.1 the compiler is smart enough to point at the macro call and not what the macro is expanded into. It has the added value of being more pedagogical.
Also the line that it should point at is line 6 not line 5.
