### PR TITLE
Fix traits being referred to as types

### DIFF
--- a/second-edition/src/ch15-01-box.md
+++ b/second-edition/src/ch15-01-box.md
@@ -340,7 +340,7 @@ The `Box<T>` type is a smart pointer because it implements the `Deref` trait,
 which allows `Box<T>` values to be treated like references. When a `Box<T>`
 value goes out of scope, the heap data that the box is pointing to is cleaned
 up as well because of the `Box<T>` type’s `Drop` trait implementation. Let’s
-explore these two types in more detail; these traits are going to be even more
+explore these two traits in more detail; these traits are going to be even more
 important to the functionality provided by the other smart pointer types we’ll
 be discussing in the rest of this chapter.
 


### PR DESCRIPTION
Deref and Drop are traits, not types.

This change duplicates "these...traits", which could use some editing.

>  Let’s explore these two traits in more detail; these traits are going to be [...]