### PR TITLE
Fix can_hold method

### DIFF
--- a/second-edition/src/ch05-03-method-syntax.md
+++ b/second-edition/src/ch05-03-method-syntax.md
@@ -181,7 +181,7 @@ impl Rectangle {
     }
 
     fn can_hold(&self, other: &Rectangle) -> bool {
-        self.width > other.width && self.height > other.height
+        self.width >= other.width && self.height >= other.height
     }
 }
 ```
@@ -251,7 +251,7 @@ impl Rectangle {
 
 impl Rectangle {
     fn can_hold(&self, other: &Rectangle) -> bool {
-        self.width > other.width && self.height > other.height
+        self.width >= other.width && self.height >= other.height
     }
 }
 ```


### PR DESCRIPTION
I think `>=` is more appropriate, especially with integer dimensions.