### PR TITLE
Caption of Listing 16-11 should differ from 16-10

### DIFF
--- a/second-edition/src/ch16-02-message-passing.md
+++ b/second-edition/src/ch16-02-message-passing.md
@@ -377,8 +377,8 @@ thread::spawn(move || {
 # }
 ```
 
-<span class="caption">Listing 16-11: Sending multiple messages and pausing
-between each one</span>
+<span class="caption">Listing 16-11: Sending multiple messages from multiple
+producers</span>
 
 This time, before we create the first spawned thread, we call `clone` on the
 sending end of the channel. This will give us a new sending handle we can pass


### PR DESCRIPTION
The caption of both Listing 16-10 and 16-11 is:

> Sending multiple messages and pausing between each one

It should probably be different. In listing 16-11 the new point of *multiple producers* should be part of the caption.