### PR TITLE
Compile error of Listing 17-10 have `rust_gui::`

### DIFF
--- a/second-edition/src/ch17-02-trait-objects.md
+++ b/second-edition/src/ch17-02-trait-objects.md
@@ -333,17 +333,17 @@ fn main() {
 <span class="caption">Listing 17-10: Attempting to use a type that doesn’t
 implement the trait object’s trait</span>
 
-We’ll get this error because `String` doesn’t implement the `Draw` trait:
+We’ll get this error because `String` doesn’t implement the `rust_gui::Draw` trait:
 
 ```text
-error[E0277]: the trait bound `std::string::String: Draw` is not satisfied
+error[E0277]: the trait bound `std::string::String: rust_gui::Draw` is not satisfied
   -->
    |
  4 |             Box::new(String::from("Hi")),
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Draw` is not
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `rust_gui::Draw` is not
    implemented for `std::string::String`
    |
-   = note: required for the cast to the object type `Draw`
+   = note: required for the cast to the object type `rust_gui::Draw`
 ```
 
 This lets us know that either we’re passing something to `Screen` we didn’t


### PR DESCRIPTION
Not sure if this was intentional to make the lines shorter, and the text more didactic, but just in the case it was an oversight...

P.S. was verified with Rust 1.21.0
