### PR TITLE
ch01-01: prefer “distrust” over “disapprove”

### DIFF
--- a/second-edition/src/ch01-01-installation.md
+++ b/second-edition/src/ch01-01-installation.md
@@ -27,8 +27,8 @@ your password. If it all goes well, you’ll see this appear:
 Rust is installed now. Great!
 ```
 
-Of course, if you disapprove of the `curl | sh` pattern, you can download, inspect
-and run the script however you like.
+Of course, if you distrust using `curl URL | sh` to install software, you can download, 
+inspect, and run the script however you like.
 
 The installation script automatically adds Rust to your system PATH after your next login. 
 If you want to start using Rust right away, run the following command in your shell:


### PR DESCRIPTION
Hello!  First-time contributor here.

If merged, this PR will change two things in a very important section of the installation instructions.

I “disapprove” of useing “curl | sh” but I trust you, so this is what I did.  Therefore I propose that “distrust” is a more appropriate noun here.

Second, I feel `curl URL | sh` is more apt.

Thank you for this opportunity to contribute to Rust documentation, which I am just starting to explore.

## What to expect when you open a pull request here

### First edition

The first edition is no longer being actively worked on. We accept pull
requests for the first edition, but prefer small tweaks to large changes, as
larger work should be spent improving the second edition.

### Second edition

For the second edition, we are currently working with No Starch Press to bring
it to print. Chapters go through a number of stages in the editing process, and
once they've gotten to the layout stage, they're effectively frozen.

For chapters that have gotten to the layout stage, we will likely only be
accepting changes that correct factual errors or major problems and not, for
example, minor wording changes.

Scroll all the way to the right on https://github.com/rust-lang/book/projects/1
to see which chapters have been frozen.

Please see CONTRIBUTING.md for more details.

Thank you for reading, you may now delete this text!
