### PR TITLE
Removing unnecessary semicolon

### DIFF
--- a/second-edition/src/ch20-01-single-threaded.md
+++ b/second-edition/src/ch20-01-single-threaded.md
@@ -438,7 +438,7 @@ fn handle_connection(mut stream: TcpStream) {
         stream.flush().unwrap();
     } else {
         // some other request
-    };
+    }
 }
 ```
 


### PR DESCRIPTION
Just stumbled over it while reading, there was a trailing semicolon in the code example for "Validating the request and selectively responding".

## What to expect when you open a pull request here

### First edition

The first edition is no longer being actively worked on. We accept pull
requests for the first edition, but prefer small tweaks to large changes, as
larger work should be spent improving the second edition.

### Second edition

For the second edition, we are currently working with No Starch Press to bring
it to print. Chapters go through a number of stages in the editing process, and
once they've gotten to the layout stage, they're effectively frozen.

For chapters that have gotten to the layout stage, we will likely only be
accepting changes that correct factual errors or major problems and not, for
example, minor wording changes.

Scroll all the way to the right on https://github.com/rust-lang/book/projects/1
to see which chapters have been frozen.

Please see CONTRIBUTING.md for more details.

Thank you for reading, you may now delete this text!
