### PR TITLE
Make 8-26 print out less specific

### DIFF
--- a/second-edition/src/ch08-03-hash-maps.md
+++ b/second-edition/src/ch08-03-hash-maps.md
@@ -252,7 +252,7 @@ println!("{:?}", map);
 <span class="caption">Listing 8-26: Counting occurrences of words using a hash
 map that stores words and counts</span>
 
-This code will print `{"world": 2, "hello": 1, "wonderful": 1}`. The
+This code will print something similar to `{"world": 2, "hello": 1, "wonderful": 1}`. The
 `or_insert` method actually returns a mutable reference (`&mut V`) to the value
 for this key. Here we store that mutable reference in the `count` variable, so
 in order to assign to that value we must first dereference `count` using the


### PR DESCRIPTION
Looks like it's too late to change this and it's not massively important but;

On my local version (rustc 1.22.1, cargo 0.23.0) it prints:

```rust
{"world": 2, "wonderful": 1, "hello": 1} 
```

In the online snippet it prints:

```rust
{"hello": 1, "world": 2, "wonderful": 1}
```

And in the book text it says:

```rust
{"world": 2, "hello": 1, "wonderful": 1}
```

It would be interesting to know why these differences occur too?