### PR TITLE
Improve redirects

### DIFF
--- a/redirects/associated-types.md
+++ b/redirects/associated-types.md
@@ -4,9 +4,9 @@ There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 3.30 — Associated Types][1]
 
-* [Related page in the second edition of The Rust Programming Language][2]
+* [In the second edition: Ch 19.03 — Advanced Traits][2]
 
 
 [1]: first-edition/associated-types.html

--- a/redirects/associated-types.md
+++ b/redirects/associated-types.md
@@ -1,6 +1,6 @@
 % Associated Types
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > Associated types are a way of associating a type placeholder with a trait such that the trait method definitions can use these placeholder types in their signatures.
 
@@ -13,12 +13,10 @@ pub trait Iterator {
 
 ---
 
-You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+Here are the relevant sections in the new and old books:
 
-* [In the first edition: Ch 3.30 — Associated Types][1]
-
-* [In the second edition: Ch 19.03 — Advanced Traits][2]
+* **[In the second edition: Ch 19.03 — Advanced Traits][2]**
+* <small>[In the first edition: Ch 3.30 — Associated Types][1]</small>
 
 
 [1]: first-edition/associated-types.html

--- a/redirects/associated-types.md
+++ b/redirects/associated-types.md
@@ -1,6 +1,18 @@
 % Associated Types
 
 There is a new edition of the book and this is an old link.
+
+> Associated types are a way of associating a type placeholder with a trait such that the trait method definitions can use these placeholder types in their signatures.
+
+```rust
+pub trait Iterator {
+    type Item;
+    fn next(&mut self) -> Option<Self::Item>;
+}
+```
+
+---
+
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 

--- a/redirects/associated-types.md
+++ b/redirects/associated-types.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Associated Types
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/attributes.md
+++ b/redirects/attributes.md
@@ -1,6 +1,19 @@
 % Attributes
 
 There is a new edition of the book and this is an old link.
+
+> Any item declaration may have an attribute applied to it.
+
+```rust
+// A function marked as a unit test
+#[test]
+fn test_foo() {
+    /* ... */
+}
+```
+
+---
+
 You can [continue to the exact older page][1].
 
 This particular chapter does not exist in the second edition.

--- a/redirects/attributes.md
+++ b/redirects/attributes.md
@@ -2,12 +2,14 @@
 
 There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+
+This particular chapter does not exist in the second edition.
+The best place to learn about it is [the Rust Reference][2].
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [This page in The Rust Reference][2]
 
 
 [1]: first-edition/attributes.html
-[2]: second-edition/index.html
+[2]: ../reference/attributes.html

--- a/redirects/attributes.md
+++ b/redirects/attributes.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Attributes
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/attributes.md
+++ b/redirects/attributes.md
@@ -1,6 +1,6 @@
 % Attributes
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > Any item declaration may have an attribute applied to it.
 
@@ -14,14 +14,10 @@ fn test_foo() {
 
 ---
 
-You can [continue to the exact older page][1].
+Here are the relevant sections in the new and old books:
 
-This particular chapter does not exist in the second edition.
-The best place to learn about it is [the Rust Reference][2].
-
-* [In the first edition: Ch 3.27 — Attributes][1]
-
-* [In the Rust Reference: Ch 5.3 — Attributes][2]
+* **[In the Rust Reference: Ch 5.3 — Attributes][2]**
+* <small>[In the first edition: Ch 3.27 — Attributes][1]</small>
 
 
 [1]: first-edition/attributes.html

--- a/redirects/attributes.md
+++ b/redirects/attributes.md
@@ -6,9 +6,9 @@ You can [continue to the exact older page][1].
 This particular chapter does not exist in the second edition.
 The best place to learn about it is [the Rust Reference][2].
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 3.27 — Attributes][1]
 
-* [This page in The Rust Reference][2]
+* [In the Rust Reference: Ch 5.3 — Attributes][2]
 
 
 [1]: first-edition/attributes.html

--- a/redirects/bibliography.md
+++ b/redirects/bibliography.md
@@ -1,14 +1,13 @@
 % Bibliography
 
-There is a new edition of the book and this is an old link.
-You can [continue to the exact older page][1].
+<small>There is a new edition of the book and this is an old link.</small>
 
 This page does not exist in [the second edition][2].
 You might be interested in a similar page in [the Rust Reference][3].
 
-* [In the first edition: Section 7 — Bibliography][1]
+* **[In the Rust Reference: Appendix — Influences][3]**
+* <small>[In the first edition: Section 7 — Bibliography][1]</small>
 
-* [In the Rust Reference: Appendix — Influences][3]
 
 [1]: first-edition/bibliography.html
 [2]: second-edition/index.html

--- a/redirects/bibliography.md
+++ b/redirects/bibliography.md
@@ -6,11 +6,9 @@ You can [continue to the exact older page][1].
 This page does not exist in [the second edition][2].
 You might be interested in a similar page in [the Rust Reference][3].
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Section 7 — Bibliography][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
-
-* [Related page in The Rust Reference][3]
+* [In the Rust Reference: Appendix — Influences][3]
 
 [1]: first-edition/bibliography.html
 [2]: second-edition/index.html

--- a/redirects/bibliography.md
+++ b/redirects/bibliography.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Bibliography
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/bibliography.md
+++ b/redirects/bibliography.md
@@ -2,12 +2,16 @@
 
 There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+
+This page does not exist in [the second edition][2].
+You might be interested in a similar page in [the Rust Reference][3].
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
 * [Index of the second edition of The Rust Programming Language][2]
 
+* [Related page in The Rust Reference][3]
 
 [1]: first-edition/bibliography.html
 [2]: second-edition/index.html
+[3]: ../reference/influences.html

--- a/redirects/borrow-and-asref.md
+++ b/redirects/borrow-and-asref.md
@@ -1,6 +1,18 @@
 % Borrow and AsRef
 
 There is a new edition of the book and this is an old link.
+
+> A cheap reference-to-reference conversion.
+> Used to convert a value to a reference value within generic code.
+
+```rust
+fn is_hello<T: AsRef<str>>(s: T) {
+   assert_eq!("hello", s.as_ref());
+}
+```
+
+---
+
 You can [continue to the exact older page][1].
 
 This chapter does not exist in [the second edition][2].

--- a/redirects/borrow-and-asref.md
+++ b/redirects/borrow-and-asref.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Borrow and AsRef
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/borrow-and-asref.md
+++ b/redirects/borrow-and-asref.md
@@ -1,6 +1,6 @@
 % Borrow and AsRef
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > A cheap reference-to-reference conversion.
 > Used to convert a value to a reference value within generic code.
@@ -13,14 +13,11 @@ fn is_hello<T: AsRef<str>>(s: T) {
 
 ---
 
-You can [continue to the exact older page][1].
-
 This chapter does not exist in [the second edition][2].
 The best place to learn more about this is [the Rust documentation][3].
 
-* [In the first edition: Ch 4.10 — Borrow and AsRef][1]
-
-* [In the Rust documentation: `convert::AsRef`][3]
+* **[In the Rust documentation: `convert::AsRef`][3]**
+* <small>[In the first edition: Ch 4.10 — Borrow and AsRef][1]</small>
 
 
 [1]: first-edition/borrow-and-asref.html

--- a/redirects/borrow-and-asref.md
+++ b/redirects/borrow-and-asref.md
@@ -2,12 +2,17 @@
 
 There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+
+This chapter does not exist in [the second edition][2].
+The best place to learn more about this is [the Rust documentation][3].
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
 * [Index of the second edition of The Rust Programming Language][2]
 
+* [AsRef in The Rust Standard Library Documentation][3]
+
 
 [1]: first-edition/borrow-and-asref.html
 [2]: second-edition/index.html
+[3]: ../std/convert/trait.AsRef.html

--- a/redirects/borrow-and-asref.md
+++ b/redirects/borrow-and-asref.md
@@ -6,11 +6,9 @@ You can [continue to the exact older page][1].
 This chapter does not exist in [the second edition][2].
 The best place to learn more about this is [the Rust documentation][3].
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 4.10 — Borrow and AsRef][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
-
-* [AsRef in The Rust Standard Library Documentation][3]
+* [In the Rust documentation: `convert::AsRef`][3]
 
 
 [1]: first-edition/borrow-and-asref.html

--- a/redirects/casting-between-types.md
+++ b/redirects/casting-between-types.md
@@ -1,6 +1,6 @@
 % Casting between types
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > A type cast expression is denoted with the binary operator `as`.
 > Executing an `as` expression casts the value on the left-hand side to the type on the right-hand side.
@@ -18,16 +18,13 @@ fn average(values: &[f64]) -> f64 {
 
 ---
 
-You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+Here are the relevant sections in the new and old books:
 
-* [In the first edition: Ch 3.29 — Casting between types][1]
-
-* [In the second edition: Appendix B — Operators][2]
-
+* **[In the second edition: Appendix B — Operators, section Type Cast Expressions][2]**
 * [In the Rust Reference: Type Cast Expressions][3]
-
 * [In the Rust documentation: `mem::transmute`][4]
+* <small>[In the first edition: Ch 3.29 — Casting between types][1]</small>
+
 
 [1]: first-edition/casting-between-types.html
 [2]: second-edition/appendix-02-operators.html#type-cast-expressions

--- a/redirects/casting-between-types.md
+++ b/redirects/casting-between-types.md
@@ -1,6 +1,23 @@
 % Casting between types
 
 There is a new edition of the book and this is an old link.
+
+> A type cast expression is denoted with the binary operator `as`.
+> Executing an `as` expression casts the value on the left-hand side to the type on the right-hand side.
+
+```rust
+# fn sum(values: &[f64]) -> f64 { 0.0 }
+# fn len(values: &[f64]) -> i32 { 0 }
+
+fn average(values: &[f64]) -> f64 {
+    let sum: f64 = sum(values);
+    let size: f64 = len(values) as f64;
+    sum / size
+}
+```
+
+---
+
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 

--- a/redirects/casting-between-types.md
+++ b/redirects/casting-between-types.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Casting between types
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/casting-between-types.md
+++ b/redirects/casting-between-types.md
@@ -4,13 +4,13 @@ There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 3.29 — Casting between types][1]
 
-* [Related page in the second edition of The Rust Programming Language][2]
+* [In the second edition: Appendix B — Operators][2]
 
-* [Related page in The Rust Reference][3]
+* [In the Rust Reference: Type Cast Expressions][3]
 
-* [Documentation of `transmute` in The Rust Standard Library Documentation][4]
+* [In the Rust documentation: `mem::transmute`][4]
 
 [1]: first-edition/casting-between-types.html
 [2]: second-edition/appendix-02-operators.html#type-cast-expressions

--- a/redirects/casting-between-types.md
+++ b/redirects/casting-between-types.md
@@ -6,8 +6,13 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Related page in the second edition of The Rust Programming Language][2]
 
+* [Related page in The Rust Reference][3]
+
+* [Documentation of `transmute` in The Rust Standard Library Documentation][4]
 
 [1]: first-edition/casting-between-types.html
-[2]: second-edition/index.html
+[2]: second-edition/appendix-02-operators.html#type-cast-expressions
+[3]: ../reference/expressions/operator-expr.html#type-cast-expressions
+[4]: ../std/mem/fn.transmute.html

--- a/redirects/choosing-your-guarantees.md
+++ b/redirects/choosing-your-guarantees.md
@@ -4,9 +4,9 @@ There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 4.8 — Choosing your Guarantees][1]
 
-* [Related chapter in the second edition of The Rust Programming Language][2]
+* [In the second edition: Ch 15.00 — Smart Pointers][2]
 
 
 [1]: first-edition/choosing-your-guarantees.html

--- a/redirects/choosing-your-guarantees.md
+++ b/redirects/choosing-your-guarantees.md
@@ -1,6 +1,6 @@
 % Choosing your Guarantees
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > Smart pointers are data structures that act like a pointer, but they also have additional metadata and capabilities.
 > The different smart pointers defined in Rust’s standard library provide extra functionality beyond what references provide.
@@ -12,12 +12,10 @@ println!("b = {}", b);
 
 ---
 
-You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+Here are the relevant sections in the new and old books:
 
-* [In the first edition: Ch 4.8 — Choosing your Guarantees][1]
-
-* [In the second edition: Ch 15.00 — Smart Pointers][2]
+* **[In the second edition: Ch 15.00 — Smart Pointers][2]**
+* <small>[In the first edition: Ch 4.8 — Choosing your Guarantees][1]</small>
 
 
 [1]: first-edition/choosing-your-guarantees.html

--- a/redirects/choosing-your-guarantees.md
+++ b/redirects/choosing-your-guarantees.md
@@ -1,6 +1,17 @@
 % Choosing your Guarantees
 
 There is a new edition of the book and this is an old link.
+
+> Smart pointers are data structures that act like a pointer, but they also have additional metadata and capabilities.
+> The different smart pointers defined in Rust’s standard library provide extra functionality beyond what references provide.
+
+```rust
+let b = Box::new(5);
+println!("b = {}", b);
+```
+
+---
+
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 

--- a/redirects/choosing-your-guarantees.md
+++ b/redirects/choosing-your-guarantees.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Choosing your Guarantees
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/closures.md
+++ b/redirects/closures.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Closures
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/closures.md
+++ b/redirects/closures.md
@@ -1,6 +1,23 @@
 % Closures
 
 There is a new edition of the book and this is an old link.
+
+> Anonymous functions you can save in a variable or pass as arguments to other functions.
+
+```rust
+# use std::thread;
+# use std::time::Duration;
+
+let expensive_closure = |num| {
+    println!("calculating slowly...");
+    thread::sleep(Duration::from_secs(2));
+    num
+};
+#expensive_closure(5);
+```
+
+---
+
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 

--- a/redirects/closures.md
+++ b/redirects/closures.md
@@ -4,9 +4,9 @@ There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 3.23 — Closures][1]
 
-* [Related page in the second edition of The Rust Programming Language][2]
+* [In the second edition: Ch 13.01 — Closures][2]
 
 
 [1]: first-edition/closures.html

--- a/redirects/closures.md
+++ b/redirects/closures.md
@@ -1,6 +1,6 @@
 % Closures
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > Anonymous functions you can save in a variable or pass as arguments to other functions.
 
@@ -18,12 +18,10 @@ let expensive_closure = |num| {
 
 ---
 
-You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+Here are the relevant sections in the new and old books:
 
-* [In the first edition: Ch 3.23 — Closures][1]
-
-* [In the second edition: Ch 13.01 — Closures][2]
+* **[In the second edition: Ch 13.01 — Closures][2]**
+* <small>[In the first edition: Ch 3.23 — Closures][1]</small>
 
 
 [1]: first-edition/closures.html

--- a/redirects/comments.md
+++ b/redirects/comments.md
@@ -1,6 +1,6 @@
 % Comments
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > Comments must start with two slashes and continue until the end of the line.
 > For comments that extend beyond a single line, you’ll need to include // on each line.
@@ -13,12 +13,10 @@ There is a new edition of the book and this is an old link.
 
 ---
 
-You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+Here are the relevant sections in the new and old books:
 
-* [In the first edition: Ch 3.4 — Comments][1]
-
-* [In the second edition: Ch 3.04 — Comments][2]
+* **[In the second edition: Ch 3.04 — Comments][2]**
+* <small>[In the first edition: Ch 3.4 — Comments][1]</small>
 
 
 [1]: first-edition/comments.html

--- a/redirects/comments.md
+++ b/redirects/comments.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Comments
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/comments.md
+++ b/redirects/comments.md
@@ -4,9 +4,9 @@ There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 3.4 — Comments][1]
 
-* [Related page in the second edition of The Rust Programming Language][2]
+* [In the second edition: Ch 3.04 — Comments][2]
 
 
 [1]: first-edition/comments.html

--- a/redirects/comments.md
+++ b/redirects/comments.md
@@ -1,6 +1,18 @@
 % Comments
 
 There is a new edition of the book and this is an old link.
+
+> Comments must start with two slashes and continue until the end of the line.
+> For comments that extend beyond a single line, you’ll need to include // on each line.
+
+```rust
+// So we’re doing something complicated here, long enough that we need
+// multiple lines of comments to do it! Whew! Hopefully, this comment will
+// explain what’s going on.
+```
+
+---
+
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 

--- a/redirects/compiler-plugins.md
+++ b/redirects/compiler-plugins.md
@@ -1,6 +1,10 @@
-% The Rust Programming Language Has Moved
+% Compiler Plugins
 
-This chapter of the book has moved to [a chapter in the Unstable
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
+
+This particular chapter has moved to [a chapter in the Unstable
 Book][unstable book plugins]. Please check it out there.
 
+[1]: first-edition/compiler-plugins.html
 [unstable book plugins]: ../unstable-book/language-features/plugin.html

--- a/redirects/compiler-plugins.md
+++ b/redirects/compiler-plugins.md
@@ -1,15 +1,16 @@
 % Compiler Plugins
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > Compiler plugins are user-provided libraries that extend the compiler's behavior with new syntax extensions, lint checks, etc.
 
 ---
 
-You can [continue to the exact older page][1].
+This particular chapter has moved to [the Unstable Book][2].
 
-This particular chapter has moved to [a chapter in the Unstable
-Book][unstable book plugins]. Please check it out there.
+* **[In the Unstable Rust Book: `plugin`][2]**
+* <small><del>[In the first edition: Compiler Plugins][1]</del> (does not exist anymore)</small>
+
 
 [1]: first-edition/compiler-plugins.html
-[unstable book plugins]: ../unstable-book/language-features/plugin.html
+[2]: ../unstable-book/language-features/plugin.html

--- a/redirects/compiler-plugins.md
+++ b/redirects/compiler-plugins.md
@@ -1,6 +1,11 @@
 % Compiler Plugins
 
 There is a new edition of the book and this is an old link.
+
+> Compiler plugins are user-provided libraries that extend the compiler's behavior with new syntax extensions, lint checks, etc.
+
+---
+
 You can [continue to the exact older page][1].
 
 This particular chapter has moved to [a chapter in the Unstable

--- a/redirects/concurrency.md
+++ b/redirects/concurrency.md
@@ -4,9 +4,9 @@ There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 4.6 — Concurrency][1]
 
-* [Related chapter in the second edition of The Rust Programming Language][2]
+* [In the second edition: Ch 16.00 — Concurrency][2]
 
 
 [1]: first-edition/concurrency.html

--- a/redirects/concurrency.md
+++ b/redirects/concurrency.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Concurrency
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/concurrency.md
+++ b/redirects/concurrency.md
@@ -1,12 +1,18 @@
 % Concurrency
 
 There is a new edition of the book and this is an old link.
+
+> Historically, programming [concurrency] has been difficult and error prone: Rust hopes to change that.
+> Fearless concurrency allows you to write code that’s free of subtle bugs and is easy to refactor without introducing new bugs.
+
+---
+
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [In the first edition: Ch 4.6 — Concurrency][1]
 
-* [In the second edition: Ch 16.00 — Concurrency][2]
+* [In the second edition: Ch 16.00 — Fearless Concurrency][2]
 
 
 [1]: first-edition/concurrency.html

--- a/redirects/concurrency.md
+++ b/redirects/concurrency.md
@@ -1,18 +1,16 @@
 % Concurrency
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > Historically, programming [concurrency] has been difficult and error prone: Rust hopes to change that.
 > Fearless concurrency allows you to write code that’s free of subtle bugs and is easy to refactor without introducing new bugs.
 
 ---
 
-You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+Here are the relevant sections in the new and old books:
 
-* [In the first edition: Ch 4.6 — Concurrency][1]
-
-* [In the second edition: Ch 16.00 — Fearless Concurrency][2]
+* **[In the second edition: Ch 16.00 — Fearless Concurrency][2]**
+* <small>[In the first edition: Ch 4.6 — Concurrency][1]</small>
 
 
 [1]: first-edition/concurrency.html

--- a/redirects/conditional-compilation.md
+++ b/redirects/conditional-compilation.md
@@ -1,6 +1,6 @@
 % Conditional Compilation
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > Sometimes one wants to have different compiler outputs from the same code, depending on build target, such as targeted operating system, or to enable release builds.
 > Configuration options are either provided by the compiler or passed in on the command line using.
@@ -16,15 +16,13 @@ fn macos_only() {
 
 ---
 
-You can [continue to the exact older page][1].
+This particular chapter does not exist in [the second edition][2].
+The best place to learn about it is [the Rust Reference][3].
 
-This particular chapter does not exist in the second edition.
-The best place to learn about it is [the Rust Reference][2].
-
-* [In the first edition: Ch 4.3 — Conditional Compilation][1]
-
-* [In the Rust Reference: Ch 5.3 — Attributes, Conditional Compilation section][2]
+* **[In the Rust Reference: Ch 5.3 — Attributes, Conditional Compilation section][3]**
+* <small>[In the first edition: Ch 4.3 — Conditional Compilation][1]</small>
 
 
 [1]: first-edition/conditional-compilation.html
-[2]: ../reference/attributes.html#conditional-compilation
+[2]: second-edition/
+[3]: ../reference/attributes.html#conditional-compilation

--- a/redirects/conditional-compilation.md
+++ b/redirects/conditional-compilation.md
@@ -2,12 +2,14 @@
 
 There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+
+This particular chapter does not exist in the second edition.
+The best place to learn about it is [the Rust Reference][2].
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [This page in The Rust Reference][2]
 
 
 [1]: first-edition/conditional-compilation.html
-[2]: second-edition/index.html
+[2]: ../reference/attributes.html#conditional-compilation

--- a/redirects/conditional-compilation.md
+++ b/redirects/conditional-compilation.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Conditional Compilation
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/conditional-compilation.md
+++ b/redirects/conditional-compilation.md
@@ -1,6 +1,21 @@
 % Conditional Compilation
 
 There is a new edition of the book and this is an old link.
+
+> Sometimes one wants to have different compiler outputs from the same code, depending on build target, such as targeted operating system, or to enable release builds.
+> Configuration options are either provided by the compiler or passed in on the command line using.
+> Rust code then checks for their presence using the `#[cfg(...)]` attribute
+
+```rust
+// The function is only included in the build when compiling for macOS
+#[cfg(target_os = "macos")]
+fn macos_only() {
+  // ...
+}
+```
+
+---
+
 You can [continue to the exact older page][1].
 
 This particular chapter does not exist in the second edition.

--- a/redirects/conditional-compilation.md
+++ b/redirects/conditional-compilation.md
@@ -6,9 +6,9 @@ You can [continue to the exact older page][1].
 This particular chapter does not exist in the second edition.
 The best place to learn about it is [the Rust Reference][2].
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 4.3 — Conditional Compilation][1]
 
-* [This page in The Rust Reference][2]
+* [In the Rust Reference: Ch 5.3 — Attributes, Conditional Compilation section][2]
 
 
 [1]: first-edition/conditional-compilation.html

--- a/redirects/const-and-static.md
+++ b/redirects/const-and-static.md
@@ -1,6 +1,18 @@
 % `const` and `static`
 
 There is a new edition of the book and this is an old link.
+
+> Constants are _always_ immutable, and may only be set to a constant expression, not the result of a function call or any other value that could only be computed at runtime.
+>
+> Global variables are called `static` in Rust.
+
+```rust
+const MAX_POINTS: u32 = 100_000;
+static HELLO_WORLD: &str = "Hello, world!";
+```
+
+---
+
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 

--- a/redirects/const-and-static.md
+++ b/redirects/const-and-static.md
@@ -1,6 +1,6 @@
 % `const` and `static`
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > Constants are _always_ immutable, and may only be set to a constant expression, not the result of a function call or any other value that could only be computed at runtime.
 >
@@ -13,14 +13,11 @@ static HELLO_WORLD: &str = "Hello, world!";
 
 ---
 
-You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+Here are the relevant sections in the new and old books:
 
-* [In the first edition: Ch 3.26 — `const` and `static`][1]
-
-* [In the second edition: Ch 3.01 — Variables and Mutability, section Constants][2]
-
-* [In the second edition: Ch 19.01 — Unsafe Rust, section Static Variables][3]
+* **[In the second edition: Ch 3.01 — Variables and Mutability, section Constants][2]**
+* **[In the second edition: Ch 19.01 — Unsafe Rust, section Static Variables][3]**
+* <small>[In the first edition: Ch 3.26 — `const` and `static`][1]</small>
 
 
 [1]: first-edition/const-and-static.html

--- a/redirects/const-and-static.md
+++ b/redirects/const-and-static.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% `const` and `static`
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/const-and-static.md
+++ b/redirects/const-and-static.md
@@ -4,10 +4,11 @@ There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 3.26 — `const` and `static`][1]
 
-* [Related section about `const` in the second edition of The Rust Programming Language][2]
-* [Related section about `static` in the second edition of The Rust Programming Language][3]
+* [In the second edition: Ch 3.01 — Variables and Mutability, section Constants][2]
+
+* [In the second edition: Ch 19.01 — Unsafe Rust, section Static Variables][3]
 
 
 [1]: first-edition/const-and-static.html

--- a/redirects/crates-and-modules.md
+++ b/redirects/crates-and-modules.md
@@ -1,16 +1,31 @@
 % Crates and Modules
 
 There is a new edition of the book and this is an old link.
+
+> Rust has a module system that enables the reuse of code in an organized fashion.
+> A module is a namespace that contains definitions of functions or types, and you can choose whether those definitions are visible outside their module (public) or not (private).
+>
+> A crate is a project that other people can pull into their projects as a dependency.
+
+```rust
+mod network {
+    fn connect() {
+    }
+}
+```
+
+---
+
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [In the first edition: Ch 3.25 — Crates and Modules][1]
 
-* [In the second edition: Ch 7.00 — Modules][2]
+* [In the second edition: Ch 7.01 — `mod` and the Filesystem][2]
 
-* [In the second edition: Ch 14.00 — More about Cargo][2]
+* [In the second edition: Ch 14.02 — Publishing a Crate to Crates.io][2]
 
 
 [1]: first-edition/crates-and-modules.html
-[2]: second-edition/ch07-00-modules.html
-[3]: second-edition/ch14-00-more-about-cargo.html
+[2]: second-edition/ch07-01-mod-and-the-filesystem.html
+[3]: second-edition/ch14-02-publishing-to-crates-io.html

--- a/redirects/crates-and-modules.md
+++ b/redirects/crates-and-modules.md
@@ -1,6 +1,6 @@
 % Crates and Modules
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > Rust has a module system that enables the reuse of code in an organized fashion.
 > A module is a namespace that contains definitions of functions or types, and you can choose whether those definitions are visible outside their module (public) or not (private).
@@ -16,14 +16,11 @@ mod network {
 
 ---
 
-You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+Here are the relevant sections in the new and old books:
 
-* [In the first edition: Ch 3.25 — Crates and Modules][1]
-
-* [In the second edition: Ch 7.01 — `mod` and the Filesystem][2]
-
+* **[In the second edition: Ch 7.01 — `mod` and the Filesystem][2]**
 * [In the second edition: Ch 14.02 — Publishing a Crate to Crates.io][2]
+* <small>[In the first edition: Ch 3.25 — Crates and Modules][1]</small>
 
 
 [1]: first-edition/crates-and-modules.html

--- a/redirects/crates-and-modules.md
+++ b/redirects/crates-and-modules.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Crates and Modules
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/crates-and-modules.md
+++ b/redirects/crates-and-modules.md
@@ -4,11 +4,11 @@ There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 3.25 — Crates and Modules][1]
 
-* [Related chapter about modules in the second edition of The Rust Programming Language][2]
+* [In the second edition: Ch 7.00 — Modules][2]
 
-* [Related chapter about crates in the second edition of The Rust Programming Language][3]
+* [In the second edition: Ch 14.00 — More about Cargo][2]
 
 
 [1]: first-edition/crates-and-modules.html

--- a/redirects/deref-coercions.md
+++ b/redirects/deref-coercions.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Deref coercions
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/deref-coercions.md
+++ b/redirects/deref-coercions.md
@@ -4,9 +4,9 @@ There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 3.33 — Deref coercions][1]
 
-* [Related section in the second edition of The Rust Programming Language][2]
+* [In the second edition: Ch 15.02 — Deref, section Implicit Deref coercions][2]
 
 
 [1]: first-edition/deref-coercions.html

--- a/redirects/deref-coercions.md
+++ b/redirects/deref-coercions.md
@@ -1,6 +1,6 @@
 % Deref coercions
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > Implementing the `Deref` trait allows us to customize the behavior of the _dereference operator_ `*`.
 > By implementing `Deref` in such a way that a smart pointer can be treated like a regular reference, we can write code that operates on references and use that code with smart pointers too.
@@ -20,12 +20,10 @@ impl<T> Deref for MyBox<T> {
 
 ---
 
-You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+Here are the relevant sections in the new and old books:
 
-* [In the first edition: Ch 3.33 — Deref coercions][1]
-
-* [In the second edition: Ch 15.02 — Treating Smart Pointers like Regular References with the `Deref` Trait][2]
+* **[In the second edition: Ch 15.02 — Treating Smart Pointers like Regular References with the `Deref` Trait][2]**
+* <small>[In the first edition: Ch 3.33 — Deref coercions][1]</small>
 
 
 [1]: first-edition/deref-coercions.html

--- a/redirects/deref-coercions.md
+++ b/redirects/deref-coercions.md
@@ -1,13 +1,32 @@
 % Deref coercions
 
 There is a new edition of the book and this is an old link.
+
+> Implementing the `Deref` trait allows us to customize the behavior of the _dereference operator_ `*`.
+> By implementing `Deref` in such a way that a smart pointer can be treated like a regular reference, we can write code that operates on references and use that code with smart pointers too.
+
+```rust
+use std::ops::Deref;
+
+# struct MyBox<T>(T);
+impl<T> Deref for MyBox<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+```
+
+---
+
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [In the first edition: Ch 3.33 — Deref coercions][1]
 
-* [In the second edition: Ch 15.02 — Deref, section Implicit Deref coercions][2]
+* [In the second edition: Ch 15.02 — Treating Smart Pointers like Regular References with the `Deref` Trait][2]
 
 
 [1]: first-edition/deref-coercions.html
-[2]: second-edition/ch15-02-deref.html#implicit-deref-coercions-with-functions-and-methods
+[2]: second-edition/ch15-02-deref.html

--- a/redirects/documentation.md
+++ b/redirects/documentation.md
@@ -1,6 +1,6 @@
 % Documentation
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > Documentation comments use `///` instead of `//` and support Markdown notation for formatting the text if you’d like.
 > You place documentation comments just before the item they are documenting. 
@@ -22,12 +22,10 @@ pub fn add_one(x: i32) -> i32 {
 
 ---
 
-You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+Here are the relevant sections in the new and old books:
 
-* [In the first edition: Ch 4.4 — Documentation][1]
-
-* [In the second edition: Ch 14.02 — Publishing to crates.io, section Making useful documentation][2]
+* **[In the second edition: Ch 14.02 — Publishing to crates.io, section Making useful documentation][2]**
+* <small>[In the first edition: Ch 4.4 — Documentation][1]</small>
 
 
 [1]: first-edition/documentation.html

--- a/redirects/documentation.md
+++ b/redirects/documentation.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Documentation
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/documentation.md
+++ b/redirects/documentation.md
@@ -1,6 +1,27 @@
 % Documentation
 
 There is a new edition of the book and this is an old link.
+
+> Documentation comments use `///` instead of `//` and support Markdown notation for formatting the text if you’d like.
+> You place documentation comments just before the item they are documenting. 
+
+```rust,no_run
+/// Adds one to the number given.
+///
+/// # Examples
+///
+/// ```
+/// let five = 5;
+///
+/// assert_eq!(6, my_crate::add_one(5));
+/// ```
+pub fn add_one(x: i32) -> i32 {
+    x + 1
+}
+```
+
+---
+
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 

--- a/redirects/documentation.md
+++ b/redirects/documentation.md
@@ -4,9 +4,9 @@ There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 4.4 — Documentation][1]
 
-* [Related section in the second edition of The Rust Programming Language][2]
+* [In the second edition: Ch 14.02 — Publishing to crates.io, section Making useful documentation][2]
 
 
 [1]: first-edition/documentation.html

--- a/redirects/drop.md
+++ b/redirects/drop.md
@@ -1,6 +1,6 @@
 % Drop
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > `Drop` lets us customize what happens when a value is about to go out of scope.
 
@@ -24,12 +24,10 @@ fn main() {
 
 ---
 
-You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+Here are the relevant sections in the new and old books:
 
-* [In the first edition: Ch 3.20 — Drop][1]
-
-* [In the second edition: Ch 15.03 — The `Drop` Trait Runs Code on Cleanup][2]
+* **[In the second edition: Ch 15.03 — The `Drop` Trait Runs Code on Cleanup][2]**
+* <small>[In the first edition: Ch 3.20 — Drop][1]</small>
 
 
 [1]: first-edition/drop.html

--- a/redirects/drop.md
+++ b/redirects/drop.md
@@ -1,12 +1,35 @@
 % Drop
 
 There is a new edition of the book and this is an old link.
+
+> `Drop` lets us customize what happens when a value is about to go out of scope.
+
+```rust
+struct CustomSmartPointer {
+    data: String,
+}
+
+impl Drop for CustomSmartPointer {
+    fn drop(&mut self) {
+        println!("Dropping CustomSmartPointer with data `{}`!", self.data);
+    }
+}
+
+fn main() {
+    let c = CustomSmartPointer { data: String::from("my stuff") };
+    let d = CustomSmartPointer { data: String::from("other stuff") };
+    println!("CustomSmartPointers created.");
+}
+```
+
+---
+
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [In the first edition: Ch 3.20 — Drop][1]
 
-* [In the second edition: Ch 15.03 — Drop][2]
+* [In the second edition: Ch 15.03 — The `Drop` Trait Runs Code on Cleanup][2]
 
 
 [1]: first-edition/drop.html

--- a/redirects/drop.md
+++ b/redirects/drop.md
@@ -4,9 +4,9 @@ There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 3.20 — Drop][1]
 
-* [Related page in the second edition of The Rust Programming Language][2]
+* [In the second edition: Ch 15.03 — Drop][2]
 
 
 [1]: first-edition/drop.html

--- a/redirects/drop.md
+++ b/redirects/drop.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Drop
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/effective-rust.md
+++ b/redirects/effective-rust.md
@@ -2,12 +2,15 @@
 
 There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+
+This section does not exist in [the second edition][2].
+However, the second edition encourages writing effective Rust from the start.
+It is recommended to start there.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [The second edition of The Rust Programming Language][2]
 
 
 [1]: first-edition/effective-rust.html
-[2]: second-edition/index.html
+[2]: second-edition/

--- a/redirects/effective-rust.md
+++ b/redirects/effective-rust.md
@@ -7,7 +7,7 @@ This section does not exist in [the second edition][2].
 However, the second edition encourages writing effective Rust from the start.
 It is recommended to start there.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 4 — Effective Rust][1]
 
 * [The second edition of The Rust Programming Language][2]
 

--- a/redirects/effective-rust.md
+++ b/redirects/effective-rust.md
@@ -1,15 +1,13 @@
 % Effective Rust
 
-There is a new edition of the book and this is an old link.
-You can [continue to the exact older page][1].
+<small>There is a new edition of the book and this is an old link.</small>
 
 This section does not exist in [the second edition][2].
 However, the second edition encourages writing effective Rust from the start.
 It is recommended to start there.
 
-* [In the first edition: Ch 4 — Effective Rust][1]
-
-* [The second edition of The Rust Programming Language][2]
+* **[The second edition of The Rust Programming Language][2]**
+* <small>[In the first edition: Ch 4 — Effective Rust][1]</small>
 
 
 [1]: first-edition/effective-rust.html

--- a/redirects/effective-rust.md
+++ b/redirects/effective-rust.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Effective Rust
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/enums.md
+++ b/redirects/enums.md
@@ -1,12 +1,24 @@
 % Enums
 
 There is a new edition of the book and this is an old link.
+
+> Enums allow you to define a type by enumerating its possible values.
+
+```rust
+enum IpAddrKind {
+    V4,
+    V6,
+}
+```
+
+---
+
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [In the first edition: Ch 3.13 — Enums][1]
 
-* [In the second edition: Ch 6.01 — Enums][2]
+* [In the second edition: Ch 6.01 — Defining an Enum][2]
 
 
 [1]: first-edition/enums.html

--- a/redirects/enums.md
+++ b/redirects/enums.md
@@ -4,9 +4,9 @@ There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 3.13 — Enums][1]
 
-* [Related page in the second edition of The Rust Programming Language][2]
+* [In the second edition: Ch 6.01 — Enums][2]
 
 
 [1]: first-edition/enums.html

--- a/redirects/enums.md
+++ b/redirects/enums.md
@@ -1,6 +1,6 @@
 % Enums
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > Enums allow you to define a type by enumerating its possible values.
 
@@ -13,12 +13,10 @@ enum IpAddrKind {
 
 ---
 
-You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+Here are the relevant sections in the new and old books:
 
-* [In the first edition: Ch 3.13 — Enums][1]
-
-* [In the second edition: Ch 6.01 — Defining an Enum][2]
+* **[In the second edition: Ch 6.01 — Defining an Enum][2]**
+* <small>[In the first edition: Ch 3.13 — Enums][1]</small>
 
 
 [1]: first-edition/enums.html

--- a/redirects/enums.md
+++ b/redirects/enums.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Enums
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/error-handling.md
+++ b/redirects/error-handling.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Error Handling
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/error-handling.md
+++ b/redirects/error-handling.md
@@ -4,9 +4,9 @@ There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 4.7 — Error Handling][1]
 
-* [Related chapter in the second edition of The Rust Programming Language][2]
+* [In the second edition: Ch 9.00 — Error Handling][2]
 
 
 [1]: first-edition/error-handling.html

--- a/redirects/error-handling.md
+++ b/redirects/error-handling.md
@@ -1,17 +1,15 @@
 % Error Handling
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > Rust groups errors into two major categories: _recoverable_ errors with `Result<T, E>` and _unrecoverable_ errors with `panic!`.
 
 ---
 
-You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+Here are the relevant sections in the new and old books:
 
-* [In the first edition: Ch 4.7 — Error Handling][1]
-
-* [In the second edition: Ch 9.00 — Error Handling][2]
+* **[In the second edition: Ch 9.00 — Error Handling][2]**
+* <small>[In the first edition: Ch 4.7 — Error Handling][1]</small>
 
 
 [1]: first-edition/error-handling.html

--- a/redirects/error-handling.md
+++ b/redirects/error-handling.md
@@ -1,6 +1,11 @@
 % Error Handling
 
 There is a new edition of the book and this is an old link.
+
+> Rust groups errors into two major categories: _recoverable_ errors with `Result<T, E>` and _unrecoverable_ errors with `panic!`.
+
+---
+
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 

--- a/redirects/ffi.md
+++ b/redirects/ffi.md
@@ -1,6 +1,6 @@
 % FFI
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > Sometimes, your Rust code may need to interact with code written in another language.
 > To do this, Rust has a keyword, `extern`, that facilitates creating and using a _Foreign Function Interface_ (FFI).
@@ -19,12 +19,10 @@ fn main() {
 
 ---
 
-You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+Here are the relevant sections in the new and old books:
 
-* [In the first edition: Ch 4.9 — FFI][1]
-
-* [In the second edition: Ch 19.01 — Unsafe Rust, section `extern` functions][2]
+* **[In the second edition: Ch 19.01 — Unsafe Rust, section `extern` functions][2]**
+* <small>[In the first edition: Ch 4.9 — FFI][1]</small>
 
 
 [1]: first-edition/ffi.html

--- a/redirects/ffi.md
+++ b/redirects/ffi.md
@@ -4,10 +4,10 @@ There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 4.9 — FFI][1]
 
-* [Related section in the second edition of The Rust Programming Language][2]
+* [In the second edition: Ch 19.01 — Unsafe Rust, section `extern` functions][2]
 
 
 [1]: first-edition/ffi.html
-[2]: second-edition/ch19-01-unsafe-rust.html#calling-an-unsafe-function-or-method
+[2]: second-edition/ch19-01-unsafe-rust.html#extern--functions-for-calling-external-code-are-unsafe

--- a/redirects/ffi.md
+++ b/redirects/ffi.md
@@ -1,6 +1,24 @@
 % FFI
 
 There is a new edition of the book and this is an old link.
+
+> Sometimes, your Rust code may need to interact with code written in another language.
+> To do this, Rust has a keyword, `extern`, that facilitates creating and using a _Foreign Function Interface_ (FFI).
+
+```rust
+extern "C" {
+    fn abs(input: i32) -> i32;
+}
+
+fn main() {
+    unsafe {
+        println!("Absolute value of -3 according to C: {}", abs(-3));
+    }
+}
+```
+
+---
+
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 

--- a/redirects/ffi.md
+++ b/redirects/ffi.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% FFI
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/functions.md
+++ b/redirects/functions.md
@@ -4,9 +4,9 @@ There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 3.2 — Functions][1]
 
-* [Related page in the second edition of The Rust Programming Language][2]
+* [In the second edition: Ch 3.03 — Functions][2]
 
 
 [1]: first-edition/functions.html

--- a/redirects/functions.md
+++ b/redirects/functions.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Functions
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/functions.md
+++ b/redirects/functions.md
@@ -1,6 +1,25 @@
 % Functions
 
 There is a new edition of the book and this is an old link.
+
+> Function definitions in Rust start with `fn` and have a set of parentheses after the function name.
+> The curly brackets tell the compiler where the function body begins and ends.
+> We can call any function we’ve defined by entering its name followed by a set of parentheses. 
+
+```rust
+fn main() {
+    println!("Hello, world!");
+
+    another_function();
+}
+
+fn another_function() {
+    println!("Another function.");
+}
+```
+
+---
+
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 

--- a/redirects/functions.md
+++ b/redirects/functions.md
@@ -1,6 +1,6 @@
 % Functions
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > Function definitions in Rust start with `fn` and have a set of parentheses after the function name.
 > The curly brackets tell the compiler where the function body begins and ends.
@@ -20,12 +20,10 @@ fn another_function() {
 
 ---
 
-You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+Here are the relevant sections in the new and old books:
 
-* [In the first edition: Ch 3.2 — Functions][1]
-
-* [In the second edition: Ch 3.03 — Functions][2]
+* **[In the first edition: Ch 3.2 — Functions][1]**
+* <small>[In the second edition: Ch 3.03 — Functions][2]</small>
 
 
 [1]: first-edition/functions.html

--- a/redirects/generics.md
+++ b/redirects/generics.md
@@ -1,6 +1,6 @@
 % Generics
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > Generics are abstract stand-ins for concrete types or other properties.
 
@@ -19,12 +19,10 @@ fn main() {
 
 ---
 
-You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+Here are the relevant sections in the new and old books:
 
-* [In the first edition: Ch 3.18 — Generics][1]
-
-* [In the second edition: Ch 10.00 — Generic Types, Traits, and Lifetimes][2]
+* **[In the second edition: Ch 10.00 — Generic Types, Traits, and Lifetimes][2]**
+* <small>[In the first edition: Ch 3.18 — Generics][1]</small>
 
 
 [1]: first-edition/generics.html

--- a/redirects/generics.md
+++ b/redirects/generics.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Generics
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/generics.md
+++ b/redirects/generics.md
@@ -1,12 +1,30 @@
 % Generics
 
 There is a new edition of the book and this is an old link.
+
+> Generics are abstract stand-ins for concrete types or other properties.
+
+```rust
+struct Point<T, U> {
+    x: T,
+    y: U,
+}
+
+fn main() {
+    let both_integer = Point { x: 5, y: 10 };
+    let both_float = Point { x: 1.0, y: 4.0 };
+    let integer_and_float = Point { x: 5, y: 4.0 };
+}
+```
+
+---
+
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [In the first edition: Ch 3.18 — Generics][1]
 
-* [In the second edition: Ch 10.00 — Generics][2]
+* [In the second edition: Ch 10.00 — Generic Types, Traits, and Lifetimes][2]
 
 
 [1]: first-edition/generics.html

--- a/redirects/generics.md
+++ b/redirects/generics.md
@@ -4,9 +4,9 @@ There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 3.18 — Generics][1]
 
-* [Related page in the second edition of The Rust Programming Language][2]
+* [In the second edition: Ch 10.00 — Generics][2]
 
 
 [1]: first-edition/generics.html

--- a/redirects/getting-started.md
+++ b/redirects/getting-started.md
@@ -1,12 +1,12 @@
 % Getting Started
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
+
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [In the first edition: Getting Started][1]
-
-* [In the second edition: Introduction][2]
+* **[In the second edition: Introduction][2]**
+* <small>[In the first edition: Getting Started][1]</small>
 
 
 [1]: first-edition/getting-started.html

--- a/redirects/getting-started.md
+++ b/redirects/getting-started.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Getting Started
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/getting-started.md
+++ b/redirects/getting-started.md
@@ -4,9 +4,9 @@ There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Getting Started][1]
 
-* [Related chapter in the second edition of The Rust Programming Language][2]
+* [In the second edition: Introduction][2]
 
 
 [1]: first-edition/getting-started.html

--- a/redirects/glossary.md
+++ b/redirects/glossary.md
@@ -2,12 +2,15 @@
 
 There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+
+This section does not exist in [the second edition][2].
+However, the second edition defines the terms it uses inline, rather than using a glossary.
+It is recommended to start there.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [The second edition of The Rust Programming Language][2]
 
 
 [1]: first-edition/glossary.html
-[2]: second-edition/index.html
+[2]: second-edition/

--- a/redirects/glossary.md
+++ b/redirects/glossary.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Glossary
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/glossary.md
+++ b/redirects/glossary.md
@@ -1,15 +1,13 @@
 % Glossary
 
-There is a new edition of the book and this is an old link.
-You can [continue to the exact older page][1].
+<small>There is a new edition of the book and this is an old link.</small>
 
 This section does not exist in [the second edition][2].
 However, the second edition defines the terms it uses inline, rather than using a glossary.
 It is recommended to start there.
 
-* [In the first edition: Glossary][1]
-
-* [The second edition of The Rust Programming Language][2]
+* **[The second edition of The Rust Programming Language][2]**
+* <small>[In the first edition: Glossary][1]</small>
 
 
 [1]: first-edition/glossary.html

--- a/redirects/glossary.md
+++ b/redirects/glossary.md
@@ -7,7 +7,7 @@ This section does not exist in [the second edition][2].
 However, the second edition defines the terms it uses inline, rather than using a glossary.
 It is recommended to start there.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Glossary][1]
 
 * [The second edition of The Rust Programming Language][2]
 

--- a/redirects/guessing-game.md
+++ b/redirects/guessing-game.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Tutorial: Guessing Game
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/guessing-game.md
+++ b/redirects/guessing-game.md
@@ -4,9 +4,9 @@ There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Tutorial — Guessing Game][1]
 
-* [Related chapter in second edition of The Rust Programming Language][2]
+* [In the second edition: Ch 2.00 — Guessing Game tutorial][2]
 
 
 [1]: first-edition/guessing-game.html

--- a/redirects/guessing-game.md
+++ b/redirects/guessing-game.md
@@ -1,12 +1,11 @@
 % Tutorial: Guessing Game
 
-There is a new edition of the book and this is an old link.
-You can [continue to the exact older page][1].
+<small>There is a new edition of the book and this is an old link.</small>
+
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [In the first edition: Tutorial — Guessing Game][1]
-
-* [In the second edition: Ch 2.00 — Guessing Game tutorial][2]
+* **[In the first edition: Tutorial — Guessing Game][1]**
+* <small>[In the second edition: Ch 2.00 — Guessing Game tutorial][2]</small>
 
 
 [1]: first-edition/guessing-game.html

--- a/redirects/if-let.md
+++ b/redirects/if-let.md
@@ -1,12 +1,24 @@
 % if let
 
 There is a new edition of the book and this is an old link.
+
+> The `if let` syntax lets you combine `if` and `let` into a less verbose way to handle values that match one pattern and ignore the rest.
+
+```rust
+let some_u8_value = Some(3u8);
+if let Some(3) = some_u8_value {
+    println!("three");
+}
+```
+
+---
+
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [In the first edition: Ch 3.21 — if let][1]
 
-* [In the second edition: Ch 6.03 — if let][2]
+* [In the second edition: Ch 6.03 — Concise Control Flow with `if let`][2]
 
 
 [1]: first-edition/if-let.html

--- a/redirects/if-let.md
+++ b/redirects/if-let.md
@@ -4,9 +4,9 @@ There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 3.21 — if let][1]
 
-* [Related page in the second edition of The Rust Programming Language][2]
+* [In the second edition: Ch 6.03 — if let][2]
 
 
 [1]: first-edition/if-let.html

--- a/redirects/if-let.md
+++ b/redirects/if-let.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% if let
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/if-let.md
+++ b/redirects/if-let.md
@@ -1,6 +1,6 @@
 % if let
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > The `if let` syntax lets you combine `if` and `let` into a less verbose way to handle values that match one pattern and ignore the rest.
 
@@ -13,12 +13,10 @@ if let Some(3) = some_u8_value {
 
 ---
 
-You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+Here are the relevant sections in the new and old books:
 
-* [In the first edition: Ch 3.21 — if let][1]
-
-* [In the second edition: Ch 6.03 — Concise Control Flow with `if let`][2]
+* **[In the second edition: Ch 6.03 — Concise Control Flow with `if let`][2]**
+* <small>[In the first edition: Ch 3.21 — if let][1]</small>
 
 
 [1]: first-edition/if-let.html

--- a/redirects/if.md
+++ b/redirects/if.md
@@ -1,6 +1,6 @@
 % if
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > An `if` expression allows us to branch our code depending on conditions.
 
@@ -18,12 +18,10 @@ fn main() {
 
 ---
 
-You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+Here are the relevant sections in the new and old books:
 
-* [In the first edition: Ch 3.5 — if][1]
-
-* [In the second edition: Ch 3.05 — Control flow][2]
+* **[In the second edition: Ch 3.05 — Control flow][2]**
+* <small>[In the first edition: Ch 3.5 — if][1]</small>
 
 
 [1]: first-edition/if.html

--- a/redirects/if.md
+++ b/redirects/if.md
@@ -1,6 +1,23 @@
 % if
 
 There is a new edition of the book and this is an old link.
+
+> An `if` expression allows us to branch our code depending on conditions.
+
+```rust
+fn main() {
+    let number = 3;
+
+    if number < 5 {
+        println!("condition was true");
+    } else {
+        println!("condition was false");
+    }
+}
+```
+
+---
+
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 

--- a/redirects/if.md
+++ b/redirects/if.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% if
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/if.md
+++ b/redirects/if.md
@@ -4,9 +4,9 @@ There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 3.5 — if][1]
 
-* [Related section in second edition of The Rust Programming Language][2]
+* [In the second edition: Ch 3.05 — Control flow][2]
 
 
 [1]: first-edition/if.html

--- a/redirects/iterators.md
+++ b/redirects/iterators.md
@@ -4,9 +4,9 @@ There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 4.5 — Iterators][1]
 
-* [Related page in the second edition of The Rust Programming Language][2]
+* [In the second edition: Ch 13.02 — Iterators][2]
 
 
 [1]: first-edition/iterators.html

--- a/redirects/iterators.md
+++ b/redirects/iterators.md
@@ -1,6 +1,6 @@
 % Iterators
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > The iterator pattern allows you to perform some task on a sequence of items in turn.
 > An iterator is responsible for the logic of iterating over each item and determining when the sequence has finished.
@@ -17,12 +17,10 @@ for val in v1_iter {
 
 ---
 
-You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+Here are the relevant sections in the new and old books:
 
-* [In the first edition: Ch 4.5 — Iterators][1]
-
-* [In the second edition: Ch 13.02 — Iterators][2]
+* **[In the second edition: Ch 13.02 — Iterators][2]**
+* <small>[In the first edition: Ch 4.5 — Iterators][1]</small>
 
 
 [1]: first-edition/iterators.html

--- a/redirects/iterators.md
+++ b/redirects/iterators.md
@@ -1,6 +1,22 @@
 % Iterators
 
 There is a new edition of the book and this is an old link.
+
+> The iterator pattern allows you to perform some task on a sequence of items in turn.
+> An iterator is responsible for the logic of iterating over each item and determining when the sequence has finished.
+
+```rust
+let v1 = vec![1, 2, 3];
+
+let v1_iter = v1.iter();
+
+for val in v1_iter {
+    println!("Got: {}", val);
+}
+```
+
+---
+
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 

--- a/redirects/iterators.md
+++ b/redirects/iterators.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Iterators
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/lifetimes.md
+++ b/redirects/lifetimes.md
@@ -1,6 +1,23 @@
 % Lifetimes
 
 There is a new edition of the book and this is an old link.
+
+> Every reference in Rust has a lifetime, which is the scope for which that reference is valid.
+> Most of the time lifetimes are implicit and inferred.
+
+```rust
+{
+    let x = 5;            // -----+-- 'b
+                          //      |
+    let r = &x;           // --+--+-- 'a
+                          //   |  |
+    println!("r: {}", r); //   |  |
+                          // --+  |
+}                         // -----+
+```
+
+---
+
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 

--- a/redirects/lifetimes.md
+++ b/redirects/lifetimes.md
@@ -1,6 +1,6 @@
 % Lifetimes
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > Every reference in Rust has a lifetime, which is the scope for which that reference is valid.
 > Most of the time lifetimes are implicit and inferred.
@@ -18,14 +18,11 @@ There is a new edition of the book and this is an old link.
 
 ---
 
-You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+Here are the relevant sections in the new and old books:
 
-* [In the first edition: Ch 3.10 — Lifetimes][1]
-
-* [In the second edition: Ch 10.03 — Lifetimes][2]
-
+* **[In the second edition: Ch 10.03 — Lifetimes][2]**
 * [In the second edition: Ch 19.02 — Advanced Lifetimes][3]
+* <small>[In the first edition: Ch 3.10 — Lifetimes][1]</small>
 
 
 [1]: first-edition/lifetimes.html

--- a/redirects/lifetimes.md
+++ b/redirects/lifetimes.md
@@ -4,11 +4,11 @@ There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 3.10 — Lifetimes][1]
 
-* [Related page in the second edition of The Rust Programming Language][2]
+* [In the second edition: Ch 10.03 — Lifetimes][2]
 
-* [Related page in the second edition of The Rust Programming Language (covering more advanced topics)][3]
+* [In the second edition: Ch 19.02 — Advanced Lifetimes][3]
 
 
 [1]: first-edition/lifetimes.html

--- a/redirects/lifetimes.md
+++ b/redirects/lifetimes.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Lifetimes
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/loops.md
+++ b/redirects/loops.md
@@ -1,6 +1,31 @@
 % Loops
 
 There is a new edition of the book and this is an old link.
+
+> Rust has three kinds of loops: `loop`, `while`, and `for`.
+> The `loop` keyword tells Rust to execute a block of code over and over again forever or until you explicitly tell it to stop.
+> `while` loops evaluate a block of code until a condition ceases to be true.
+> A `for` loop executes some code for each item in a collection.
+
+```rust,no_run
+loop {
+    println!("again!");
+}
+
+let mut number = 3;
+while number != 0 {
+    println!("{}!", number);
+    number = number - 1;
+}
+
+let a = [10, 20, 30, 40, 50];
+for element in a.iter() {
+    println!("the value is: {}", element);
+}
+```
+
+---
+
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 

--- a/redirects/loops.md
+++ b/redirects/loops.md
@@ -4,9 +4,9 @@ There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 3.6 — Loops][1]
 
-* [Related section in the second edition of The Rust Programming Language][2]
+* [In the second edition: Ch 3.05 — Control flow][2]
 
 
 [1]: first-edition/loops.html

--- a/redirects/loops.md
+++ b/redirects/loops.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Loops
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/loops.md
+++ b/redirects/loops.md
@@ -1,6 +1,6 @@
 % Loops
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > Rust has three kinds of loops: `loop`, `while`, and `for`.
 > The `loop` keyword tells Rust to execute a block of code over and over again forever or until you explicitly tell it to stop.
@@ -26,12 +26,10 @@ for element in a.iter() {
 
 ---
 
-You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+Here are the relevant sections in the new and old books:
 
-* [In the first edition: Ch 3.6 — Loops][1]
-
-* [In the second edition: Ch 3.05 — Control flow][2]
+* **[In the second edition: Ch 3.05 — Control flow][2]**
+* <small>[In the first edition: Ch 3.6 — Loops][1]</small>
 
 
 [1]: first-edition/loops.html

--- a/redirects/macros.md
+++ b/redirects/macros.md
@@ -2,12 +2,19 @@
 
 There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+
+This chapter does not exist yet in [the second edition][2].
+You can check out other resources that describe macros.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [This page in the second edition of The Rust Programming Language][2]
 
+* [Macros in Rust By Example][3]
+
+* [Related page in The Rust Reference][4]
 
 [1]: first-edition/macros.html
-[2]: second-edition/index.html
+[2]: second-edition/appendix-05-macros.html
+[3]: https://rustbyexample.com/macros.html
+[4]: ../reference/macros-by-example.html

--- a/redirects/macros.md
+++ b/redirects/macros.md
@@ -1,6 +1,21 @@
 % Macros
 
 There is a new edition of the book and this is an old link.
+
+> While functions and types abstract over code, macros abstract at a syntactic level.
+
+```rust
+macro_rules! five_times {
+    ($x:expr) => (5 * $x);
+}
+
+fn main() {
+    assert_eq!(25, five_times!(2 + 3));
+}
+```
+
+---
+
 You can [continue to the exact older page][1].
 
 This chapter does not exist yet in [the second edition][2].

--- a/redirects/macros.md
+++ b/redirects/macros.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Macros
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/macros.md
+++ b/redirects/macros.md
@@ -6,13 +6,13 @@ You can [continue to the exact older page][1].
 This chapter does not exist yet in [the second edition][2].
 You can check out other resources that describe macros.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 3.34 — Macros][1]
 
-* [This page in the second edition of The Rust Programming Language][2]
+* [In the second edition: (future) Appendix E — Macros][2]
 
-* [Macros in Rust By Example][3]
+* [Rust By Example: Macros][3]
 
-* [Related page in The Rust Reference][4]
+* [In the Rust Reference: Ch 3.1 — Macros by Example][4]
 
 [1]: first-edition/macros.html
 [2]: second-edition/appendix-05-macros.html

--- a/redirects/macros.md
+++ b/redirects/macros.md
@@ -1,6 +1,6 @@
 % Macros
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > While functions and types abstract over code, macros abstract at a syntactic level.
 
@@ -16,18 +16,14 @@ fn main() {
 
 ---
 
-You can [continue to the exact older page][1].
-
 This chapter does not exist yet in [the second edition][2].
 You can check out other resources that describe macros.
 
-* [In the first edition: Ch 3.34 — Macros][1]
-
-* [In the second edition: (future) Appendix E — Macros][2]
-
-* [Rust By Example: Macros][3]
-
+* **[Rust By Example: Macros][3]**
 * [In the Rust Reference: Ch 3.1 — Macros by Example][4]
+* [In the second edition: (future) Appendix E — Macros][2]
+* <small>[In the first edition: Ch 3.34 — Macros][1]</small>
+
 
 [1]: first-edition/macros.html
 [2]: second-edition/appendix-05-macros.html

--- a/redirects/match.md
+++ b/redirects/match.md
@@ -4,11 +4,11 @@ There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 3.14 — Match][1]
 
-* [Related page in the second edition of The Rust Programming Language][2]
+* [In the second edition: Ch 6.02 — Match][2]
 
-* [Related chapter in the second edition of The Rust Programming Language (covering more advanced topics)][3]
+* [In the second edition: Ch 18.00 — Patterns][3]
 
 
 [1]: first-edition/match.html

--- a/redirects/match.md
+++ b/redirects/match.md
@@ -1,12 +1,36 @@
 % Match
 
 There is a new edition of the book and this is an old link.
+
+> `match` allows us to compare a value against a series of patterns and then execute code based on which pattern matches.
+> Patterns can be made up of literal values, variable names, wildcards, and many other things.
+
+```rust
+enum Coin {
+    Penny,
+    Nickel,
+    Dime,
+    Quarter,
+}
+
+fn value_in_cents(coin: Coin) -> u32 {
+    match coin {
+        Coin::Penny => 1,
+        Coin::Nickel => 5,
+        Coin::Dime => 10,
+        Coin::Quarter => 25,
+    }
+}
+```
+
+---
+
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [In the first edition: Ch 3.14 — Match][1]
 
-* [In the second edition: Ch 6.02 — Match][2]
+* [In the second edition: Ch 6.02 — The `match` Control Flow Operator][2]
 
 * [In the second edition: Ch 18.00 — Patterns][3]
 

--- a/redirects/match.md
+++ b/redirects/match.md
@@ -1,6 +1,6 @@
 % Match
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > `match` allows us to compare a value against a series of patterns and then execute code based on which pattern matches.
 > Patterns can be made up of literal values, variable names, wildcards, and many other things.
@@ -25,14 +25,11 @@ fn value_in_cents(coin: Coin) -> u32 {
 
 ---
 
-You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+Here are the relevant sections in the new and old books:
 
-* [In the first edition: Ch 3.14 — Match][1]
-
-* [In the second edition: Ch 6.02 — The `match` Control Flow Operator][2]
-
+* **[In the second edition: Ch 6.02 — The `match` Control Flow Operator][2]**
 * [In the second edition: Ch 18.00 — Patterns][3]
+* <small>[In the first edition: Ch 3.14 — Match][1]</small>
 
 
 [1]: first-edition/match.html

--- a/redirects/match.md
+++ b/redirects/match.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Match
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/method-syntax.md
+++ b/redirects/method-syntax.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Method Syntax
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/method-syntax.md
+++ b/redirects/method-syntax.md
@@ -4,9 +4,9 @@ There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 3.16 — Method Syntax][1]
 
-* [Related page in the second edition of The Rust Programming Language][2]
+* [In the second edition: Ch 5.03 — Method Syntax][2]
 
 
 [1]: first-edition/method-syntax.html

--- a/redirects/method-syntax.md
+++ b/redirects/method-syntax.md
@@ -1,6 +1,6 @@
 % Method Syntax
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > Methods are different from functions in that they’re defined within the context of a struct, and their first parameter is always `self`, which represents the instance of the struct the method is being called on.
 
@@ -19,12 +19,10 @@ impl Rectangle {
 
 ---
 
-You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+Here are the relevant sections in the new and old books:
 
-* [In the first edition: Ch 3.16 — Method Syntax][1]
-
-* [In the second edition: Ch 5.03 — Method Syntax][2]
+* **[In the second edition: Ch 5.03 — Method Syntax][2]**
+* <small>[In the first edition: Ch 3.16 — Method Syntax][1]</small>
 
 
 [1]: first-edition/method-syntax.html

--- a/redirects/method-syntax.md
+++ b/redirects/method-syntax.md
@@ -1,6 +1,24 @@
 % Method Syntax
 
 There is a new edition of the book and this is an old link.
+
+> Methods are different from functions in that they’re defined within the context of a struct, and their first parameter is always `self`, which represents the instance of the struct the method is being called on.
+
+```rust
+# struct Rectangle {
+#     width: u32,
+#     height: u32,
+# }
+
+impl Rectangle {
+    fn area(&self) -> u32 {
+        self.width * self.height
+    }
+}
+```
+
+---
+
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 

--- a/redirects/mutability.md
+++ b/redirects/mutability.md
@@ -4,9 +4,9 @@ There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 3.11 — Mutability][1]
 
-* [Related page in second edition of The Rust Programming Language][2]
+* [In the second edition: Ch 3.01 — Variables and Mutability][2]
 
 
 [1]: first-edition/mutability.html

--- a/redirects/mutability.md
+++ b/redirects/mutability.md
@@ -1,6 +1,6 @@
 % Mutability
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > Variables are immutable only by default; we can make them mutable by adding mut in front of the variable name.
 
@@ -13,12 +13,10 @@ println!("The value of x is: {}", x);
 
 ---
 
-You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+Here are the relevant sections in the new and old books:
 
-* [In the first edition: Ch 3.11 — Mutability][1]
-
-* [In the second edition: Ch 3.01 — Variables and Mutability][2]
+* **[In the second edition: Ch 3.01 — Variables and Mutability][2]**
+* <small>[In the first edition: Ch 3.11 — Mutability][1]</small>
 
 
 [1]: first-edition/mutability.html

--- a/redirects/mutability.md
+++ b/redirects/mutability.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Mutability
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/mutability.md
+++ b/redirects/mutability.md
@@ -1,6 +1,18 @@
 % Mutability
 
 There is a new edition of the book and this is an old link.
+
+> Variables are immutable only by default; we can make them mutable by adding mut in front of the variable name.
+
+```rust
+let mut x = 5;
+println!("The value of x is: {}", x);
+x = 6;
+println!("The value of x is: {}", x);
+```
+
+---
+
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 

--- a/redirects/operators-and-overloading.md
+++ b/redirects/operators-and-overloading.md
@@ -1,6 +1,37 @@
 % Operators and Overloading
 
 There is a new edition of the book and this is an old link.
+
+> Rust does not allow you to create your own operators or overload arbitrary operators, but the operations and corresponding traits listed in `std::ops` can be overloaded by implementing the traits associated with the operator.
+
+```rust
+use std::ops::Add;
+
+#[derive(Debug,PartialEq)]
+struct Point {
+    x: i32,
+    y: i32,
+}
+
+impl Add for Point {
+    type Output = Point;
+
+    fn add(self, other: Point) -> Point {
+        Point {
+            x: self.x + other.x,
+            y: self.y + other.y,
+        }
+    }
+}
+
+fn main() {
+    assert_eq!(Point { x: 1, y: 0 } + Point { x: 2, y: 3 },
+               Point { x: 3, y: 3 });
+}
+```
+
+---
+
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
@@ -8,6 +39,8 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 
 * [In the second edition: Ch 19.03 — Advanced Traits, section Operator Overloading][2]
 
+* [In the Rust documentation: `std::ops`][3]
 
 [1]: first-edition/operators-and-overloading.html
 [2]: second-edition/ch19-03-advanced-traits.html#operator-overloading-and-default-type-parameters
+[3]: ../std/ops/

--- a/redirects/operators-and-overloading.md
+++ b/redirects/operators-and-overloading.md
@@ -1,6 +1,6 @@
 % Operators and Overloading
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > Rust does not allow you to create your own operators or overload arbitrary operators, but the operations and corresponding traits listed in `std::ops` can be overloaded by implementing the traits associated with the operator.
 
@@ -32,14 +32,11 @@ fn main() {
 
 ---
 
-You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+Here are the relevant sections in the new and old books:
 
-* [In the first edition: Ch 3.32 — Operators and Overloading][1]
-
-* [In the second edition: Ch 19.03 — Advanced Traits, section Operator Overloading][2]
-
+* **[In the second edition: Ch 19.03 — Advanced Traits, section Operator Overloading][2]**
 * [In the Rust documentation: `std::ops`][3]
+* <small>[In the first edition: Ch 3.32 — Operators and Overloading][1]</small>
 
 [1]: first-edition/operators-and-overloading.html
 [2]: second-edition/ch19-03-advanced-traits.html#operator-overloading-and-default-type-parameters

--- a/redirects/operators-and-overloading.md
+++ b/redirects/operators-and-overloading.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Operators and Overloading
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/operators-and-overloading.md
+++ b/redirects/operators-and-overloading.md
@@ -4,9 +4,9 @@ There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 3.32 — Operators and Overloading][1]
 
-* [Related section in the second edition of The Rust Programming Language][2]
+* [In the second edition: Ch 19.03 — Advanced Traits, section Operator Overloading][2]
 
 
 [1]: first-edition/operators-and-overloading.html

--- a/redirects/ownership.md
+++ b/redirects/ownership.md
@@ -1,6 +1,15 @@
 % Ownership
 
 There is a new edition of the book and this is an old link.
+
+> Ownership is Rust’s most unique feature, and it enables Rust to make memory safety guarantees without needing a garbage collector.
+>
+> 1. Each value in Rust has a variable that’s called its _owner_.
+> 2. There can only be one owner at a time.
+> 3. When the owner goes out of scope, the value will be dropped.
+
+---
+
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 

--- a/redirects/ownership.md
+++ b/redirects/ownership.md
@@ -4,9 +4,9 @@ There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 3.8 — Ownership][1]
 
-* [Related chapter in the second edition of The Rust Programming Language][2]
+* [In the second edition: Ch 4.00 — Understanding Ownership][2]
 
 
 [1]: first-edition/ownership.html

--- a/redirects/ownership.md
+++ b/redirects/ownership.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Ownership
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/ownership.md
+++ b/redirects/ownership.md
@@ -1,6 +1,6 @@
 % Ownership
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > Ownership is Rust’s most unique feature, and it enables Rust to make memory safety guarantees without needing a garbage collector.
 >
@@ -10,12 +10,10 @@ There is a new edition of the book and this is an old link.
 
 ---
 
-You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+Here are the relevant sections in the new and old books:
 
-* [In the first edition: Ch 3.8 — Ownership][1]
-
-* [In the second edition: Ch 4.00 — Understanding Ownership][2]
+* **[In the second edition: Ch 4.00 — Understanding Ownership][2]**
+* <small>[In the first edition: Ch 3.8 — Ownership][1]</small>
 
 
 [1]: first-edition/ownership.html

--- a/redirects/patterns.md
+++ b/redirects/patterns.md
@@ -1,16 +1,34 @@
 % Patterns
 
 There is a new edition of the book and this is an old link.
+
+> Patterns are a special syntax within Rust for matching against the structure of our types, complex or simple.
+> A pattern is made up of some combination of literals; destructured arrays, enums, structs, or tuples; variables, wildcards, and placeholders.
+> These pieces describe the “shape” of the data we’re working with.
+
+```rust
+let x = Some(5);
+let y = 10;
+
+match x {
+    Some(50) => println!("Got 50"),
+    Some(y) => println!("Matched, y = {:?}", y),
+    _ => println!("Default case, x = {:?}", x),
+}
+```
+
+---
+
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [In the first edition: Ch 3.15 — Patterns][1]
 
-* [In the second edition: Ch 6.02 — Match][2]
+* [In the second edition: Ch 18.03 — Patterns][2]
 
-* [In the second edition: Ch 18.03 — Pattern syntax][3]
+* [In the second edition: Ch 6.02 — Match][3]
 
 
 [1]: first-edition/patterns.html
-[2]: second-edition/ch06-02-match.html#patterns-that-bind-to-values
-[3]: second-edition/ch18-03-pattern-syntax.html
+[2]: second-edition/ch18-00-patterns.html
+[3]: second-edition/ch06-02-match.html#patterns-that-bind-to-values

--- a/redirects/patterns.md
+++ b/redirects/patterns.md
@@ -1,6 +1,6 @@
 % Patterns
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > Patterns are a special syntax within Rust for matching against the structure of our types, complex or simple.
 > A pattern is made up of some combination of literals; destructured arrays, enums, structs, or tuples; variables, wildcards, and placeholders.
@@ -19,14 +19,11 @@ match x {
 
 ---
 
-You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+Here are the relevant sections in the new and old books:
 
-* [In the first edition: Ch 3.15 — Patterns][1]
-
-* [In the second edition: Ch 18.03 — Patterns][2]
-
+* **[In the second edition: Ch 18.03 — Patterns][2]**
 * [In the second edition: Ch 6.02 — Match][3]
+* <small>[In the first edition: Ch 3.15 — Patterns][1]</small>
 
 
 [1]: first-edition/patterns.html

--- a/redirects/patterns.md
+++ b/redirects/patterns.md
@@ -4,11 +4,11 @@ There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 3.15 — Patterns][1]
 
-* [Related section in the second edition of The Rust Programming Language][2]
+* [In the second edition: Ch 6.02 — Match][2]
 
-* [Related page in the second edition of The Rust Programming Language (covering more advanced topics)][3]
+* [In the second edition: Ch 18.03 — Pattern syntax][3]
 
 
 [1]: first-edition/patterns.html

--- a/redirects/patterns.md
+++ b/redirects/patterns.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Patterns
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/primitive-types.md
+++ b/redirects/primitive-types.md
@@ -4,9 +4,9 @@ There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 3.3 — Primitive Types][1]
 
-* [Related page in the second edition of The Rust Programming Language][2]
+* [In the second edition: Ch 3.02 — Data Types][2]
 
 
 [1]: first-edition/primitive-types.html

--- a/redirects/primitive-types.md
+++ b/redirects/primitive-types.md
@@ -1,6 +1,6 @@
 % Primitive Types
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > Rust is a _statically typed_ language, which means that it must know the types of all variables at compile time.
 > The compiler can usually infer what type we want to use based on the value and how we use it.
@@ -14,12 +14,10 @@ let y: f32 = 3.0; // f32
 
 ---
 
-You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+Here are the relevant sections in the new and old books:
 
-* [In the first edition: Ch 3.3 — Primitive Types][1]
-
-* [In the second edition: Ch 3.02 — Data Types][2]
+* **[In the second edition: Ch 3.02 — Data Types][2]**
+* <small>[In the first edition: Ch 3.3 — Primitive Types][1]</small>
 
 
 [1]: first-edition/primitive-types.html

--- a/redirects/primitive-types.md
+++ b/redirects/primitive-types.md
@@ -1,6 +1,19 @@
 % Primitive Types
 
 There is a new edition of the book and this is an old link.
+
+> Rust is a _statically typed_ language, which means that it must know the types of all variables at compile time.
+> The compiler can usually infer what type we want to use based on the value and how we use it.
+> In cases when many types are possible, a _type annotation_ must be added.
+
+```rust
+let x = 2.0; // f64
+
+let y: f32 = 3.0; // f32
+```
+
+---
+
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 

--- a/redirects/primitive-types.md
+++ b/redirects/primitive-types.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Primitive Types
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/procedural-macros.md
+++ b/redirects/procedural-macros.md
@@ -1,6 +1,11 @@
 % Procedural Macros (and custom Derive)
 
 There is a new edition of the book and this is an old link.
+
+> Procedural macros allow for all sorts of advanced metaprogramming in Rust.
+
+---
+
 You can [continue to the exact older page][1].
 
 This chapter does not exist yet in [the second edition][2].

--- a/redirects/procedural-macros.md
+++ b/redirects/procedural-macros.md
@@ -1,23 +1,19 @@
 % Procedural Macros (and custom Derive)
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > Procedural macros allow for all sorts of advanced metaprogramming in Rust.
 
 ---
 
-You can [continue to the exact older page][1].
-
 This chapter does not exist yet in [the second edition][2].
 You can check out other resources that describe macros.
 
-* [In the first edition: Ch 4.13 — Procedural Macros (and custom Derive)][1]
-
-* [In the second edition: Appendix E — Macros][2]
-
+* **[In the Rust Reference: Ch 3.2 — Procedural Macros][4]**
 * [The `proc_macro` crate documentation][3]
+* [In the second edition: (future) Appendix E — Macros][2]
+* <small>[In the first edition: Ch 4.13 — Procedural Macros (and custom Derive)][1]</small>
 
-* [In the Rust Reference: Ch 3.2 — Procedural Macros][4]
 
 [1]: first-edition/procedural-macros.html
 [2]: second-edition/appendix-05-macros.html

--- a/redirects/procedural-macros.md
+++ b/redirects/procedural-macros.md
@@ -2,13 +2,19 @@
 
 There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+
+This chapter does not exist yet in [the second edition][2].
+You can check out other resources that describe macros.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [This page in the second edition of The Rust Programming Language][2]
 
+* [The `proc_macro` crate documentation][3]
 
+* [Related page in The Rust Reference][4]
 
 [1]: first-edition/procedural-macros.html
-[2]: second-edition/index.html
+[2]: second-edition/appendix-05-macros.html
+[3]: ../stable/proc_macro/index.html
+[4]: ../reference/procedural-macros.html

--- a/redirects/procedural-macros.md
+++ b/redirects/procedural-macros.md
@@ -6,13 +6,13 @@ You can [continue to the exact older page][1].
 This chapter does not exist yet in [the second edition][2].
 You can check out other resources that describe macros.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 4.13 — Procedural Macros (and custom Derive)][1]
 
-* [This page in the second edition of The Rust Programming Language][2]
+* [In the second edition: Appendix E — Macros][2]
 
 * [The `proc_macro` crate documentation][3]
 
-* [Related page in The Rust Reference][4]
+* [In the Rust Reference: Ch 3.2 — Procedural Macros][4]
 
 [1]: first-edition/procedural-macros.html
 [2]: second-edition/appendix-05-macros.html

--- a/redirects/procedural-macros.md
+++ b/redirects/procedural-macros.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Procedural Macros (and custom Derive)
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/raw-pointers.md
+++ b/redirects/raw-pointers.md
@@ -1,6 +1,6 @@
 % Raw Pointers
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > Raw pointers are allowed to ignore many of the rules that references have to follow.
 
@@ -13,12 +13,10 @@ let r2 = &mut num as *mut i32;
 
 ---
 
-You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+Here are the relevant sections in the new and old books:
 
-* [In the first edition: Ch 3.35 — Raw Pointers][1]
-
-* [In the second edition: Ch 19.01 — Unsafe Rust, section Dereferencing a Raw Pointer][2]
+* **[In the second edition: Ch 19.01 — Unsafe Rust, section Dereferencing a Raw Pointer][2]**
+* <small>[In the first edition: Ch 3.35 — Raw Pointers][1]</small>
 
 
 [1]: first-edition/raw-pointers.html

--- a/redirects/raw-pointers.md
+++ b/redirects/raw-pointers.md
@@ -4,9 +4,9 @@ There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 3.35 — Raw Pointers][1]
 
-* [Related section in the second edition of The Rust Programming Language][2]
+* [In the second edition: Ch 19.01 — Unsafe Rust, section Dereferencing a Raw Pointer][2]
 
 
 [1]: first-edition/raw-pointers.html

--- a/redirects/raw-pointers.md
+++ b/redirects/raw-pointers.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Raw Pointers
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/raw-pointers.md
+++ b/redirects/raw-pointers.md
@@ -1,6 +1,18 @@
 % Raw Pointers
 
 There is a new edition of the book and this is an old link.
+
+> Raw pointers are allowed to ignore many of the rules that references have to follow.
+
+```rust
+let mut num = 5;
+
+let r1 = &num as *const i32;
+let r2 = &mut num as *mut i32;
+```
+
+---
+
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 

--- a/redirects/references-and-borrowing.md
+++ b/redirects/references-and-borrowing.md
@@ -1,6 +1,6 @@
 % References and Borrowing
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > A reference _refers_ to a value but does not own it.
 > Because it does not own it, the value it points to will not be dropped when the reference goes out of scope.
@@ -14,12 +14,10 @@ fn calculate_length(s: &String) -> usize { // s is a reference to a String
 
 ---
 
-You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+Here are the relevant sections in the new and old books:
 
-* [In the first edition: Ch 3.9 — References and Borrowing][1]
-
-* [In the second edition: Ch 4.02 — References and Borrowing][2]
+* **[In the second edition: Ch 4.02 — References and Borrowing][2]**
+* <small>[In the first edition: Ch 3.9 — References and Borrowing][1]</small>
 
 
 [1]: first-edition/references-and-borrowing.html

--- a/redirects/references-and-borrowing.md
+++ b/redirects/references-and-borrowing.md
@@ -4,9 +4,9 @@ There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 3.9 — References and Borrowing][1]
 
-* [Related page in second edition of The Rust Programming Language][2]
+* [In the second edition: Ch 4.02 — References and Borrowing][2]
 
 
 [1]: first-edition/references-and-borrowing.html

--- a/redirects/references-and-borrowing.md
+++ b/redirects/references-and-borrowing.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% References and Borrowing
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/references-and-borrowing.md
+++ b/redirects/references-and-borrowing.md
@@ -1,6 +1,19 @@
 % References and Borrowing
 
 There is a new edition of the book and this is an old link.
+
+> A reference _refers_ to a value but does not own it.
+> Because it does not own it, the value it points to will not be dropped when the reference goes out of scope.
+
+```rust
+fn calculate_length(s: &String) -> usize { // s is a reference to a String
+    s.len()
+} // Here, s goes out of scope. But because it does not have ownership of what
+  // it refers to, nothing happens.
+```
+
+---
+
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 

--- a/redirects/release-channels.md
+++ b/redirects/release-channels.md
@@ -6,15 +6,15 @@ You can [continue to the exact older page][1].
 This chapter does not exist yet in [the second edition][2].
 You can check out other resources that describe release channels.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 4.11 — Release Channels][1]
 
-* [This page in the second edition of The Rust Programming Language][2]
+* [In the second edition: Appendix D — Nightly Rust][2]
 
-* [The Rust RFC 507][3]
+* [In the Rust RFCs: RFC 507 — Release Channels][3]
 
-* [Relevant section in the Rustup documentaion][4]
+* [In the Rustup documentation: Keeping Rust Up-to-date][4]
 
-* [‘Install Rust’ page on the official website][5]
+* [On the website: Install Rust][5]
 
 [1]: first-edition/release-channels.html
 [2]: second-edition/appendix-04-nightly-rust.html

--- a/redirects/release-channels.md
+++ b/redirects/release-channels.md
@@ -2,12 +2,23 @@
 
 There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+
+This chapter does not exist yet in [the second edition][2].
+You can check out other resources that describe release channels.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [This page in the second edition of The Rust Programming Language][2]
 
+* [The Rust RFC 507][3]
+
+* [Relevant section in the Rustup documentaion][4]
+
+* [‘Install Rust’ page on the official website][5]
 
 [1]: first-edition/release-channels.html
-[2]: second-edition/index.html
+[2]: second-edition/appendix-04-nightly-rust.html
+[3]: https://github.com/rust-lang/rfcs/blob/master/text/0507-release-channels.md
+[4]: https://github.com/rust-lang-nursery/rustup.rs/blob/master/README.md#keeping-rust-up-to-date
+[5]: https://www.rust-lang.org/en-US/install.html
+

--- a/redirects/release-channels.md
+++ b/redirects/release-channels.md
@@ -1,6 +1,6 @@
 % Release Channels
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > The Rust project uses a concept called ‘release channels’ to manage releases.
 > New nightly releases are created once a day.
@@ -8,20 +8,17 @@ There is a new edition of the book and this is an old link.
 > At that point, it will only receive patches to fix serious errors.
 > Six weeks later, the beta is promoted to ‘Stable’.
 
-You can [continue to the exact older page][1].
+---
 
 This chapter does not exist yet in [the second edition][2].
 You can check out other resources that describe release channels.
 
-* [In the first edition: Ch 4.11 — Release Channels][1]
-
-* [In the second edition: Appendix D — Nightly Rust][2]
-
-* [In the Rust RFCs: RFC 507 — Release Channels][3]
-
-* [In the Rustup documentation: Keeping Rust Up-to-date][4]
-
+* **[In the Rustup documentation: Keeping Rust Up-to-date][4]**
 * [On the website: Install Rust][5]
+* [In the Rust RFCs: RFC 507 — Release Channels][3]
+* [In the second edition: (future) Appendix D — Nightly Rust][2]
+* <small>[In the first edition: Ch 4.11 — Release Channels][1]</small>
+
 
 [1]: first-edition/release-channels.html
 [2]: second-edition/appendix-04-nightly-rust.html

--- a/redirects/release-channels.md
+++ b/redirects/release-channels.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Release Channels
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/release-channels.md
+++ b/redirects/release-channels.md
@@ -1,6 +1,13 @@
 % Release Channels
 
 There is a new edition of the book and this is an old link.
+
+> The Rust project uses a concept called ‘release channels’ to manage releases.
+> New nightly releases are created once a day.
+> Every six weeks, the latest nightly release is promoted to ‘Beta’.
+> At that point, it will only receive patches to fix serious errors.
+> Six weeks later, the beta is promoted to ‘Stable’.
+
 You can [continue to the exact older page][1].
 
 This chapter does not exist yet in [the second edition][2].

--- a/redirects/strings.md
+++ b/redirects/strings.md
@@ -1,6 +1,6 @@
 % Strings
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > A `String` is allocated on the heap and as such is able to store an amount of text that is unknown to us at compile time.
 > You can create a `String` from a string literal using the `from` function.
@@ -15,16 +15,12 @@ let world = &s[6..11];
 
 ---
 
-You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+Here are the relevant sections in the new and old books:
 
-* [In the first edition: Ch 3.17 — Strings][1]
-
-* [In second edition: Ch 8.02 — Strings][2]
-
+* **[In second edition: Ch 8.02 — Strings][2]**
 * [In second edition: Ch 4.01 — Ownership, section The String Type][3]
-
 * [In second edition: Ch 4.03 — Slices, section String Slices][4]
+* <small>[In the first edition: Ch 3.17 — Strings][1]</small>
 
 
 [1]: first-edition/strings.html

--- a/redirects/strings.md
+++ b/redirects/strings.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Strings
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/strings.md
+++ b/redirects/strings.md
@@ -1,17 +1,33 @@
 % Strings
 
 There is a new edition of the book and this is an old link.
+
+> A `String` is allocated on the heap and as such is able to store an amount of text that is unknown to us at compile time.
+> You can create a `String` from a string literal using the `from` function.
+> A _string slice_ is a reference to part of a `String`.
+
+```rust
+let s = String::from("hello world");
+
+let hello = &s[0..5];
+let world = &s[6..11];
+```
+
+---
+
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [In the first edition: Ch 3.17 — Strings][1]
 
-* [In second edition: Ch 4.03 — Slices, section String Slices][2]
+* [In second edition: Ch 8.02 — Strings][2]
 
-* [In second edition: Ch 8.02 — Strings][3]
+* [In second edition: Ch 4.01 — Ownership, section The String Type][3]
+
+* [In second edition: Ch 4.03 — Slices, section String Slices][4]
 
 
 [1]: first-edition/strings.html
-[2]: second-edition/ch04-03-slices.html#string-slices
-[3]: second-edition/ch08-02-strings.html
-
+[2]: second-edition/ch08-02-strings.html
+[3]: second-edition/ch04-01-what-is-ownership.html#the-string-type
+[4]: second-edition/ch04-03-slices.html#string-slices

--- a/redirects/strings.md
+++ b/redirects/strings.md
@@ -4,11 +4,11 @@ There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 3.17 — Strings][1]
 
-* [Related section in second edition of The Rust Programming Language][2]
+* [In second edition: Ch 4.03 — Slices, section String Slices][2]
 
-* [Related page in second edition of The Rust Programming Language  (covering more advanced topics)][3]
+* [In second edition: Ch 8.02 — Strings][3]
 
 
 [1]: first-edition/strings.html

--- a/redirects/structs.md
+++ b/redirects/structs.md
@@ -1,6 +1,6 @@
 % Structs
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > A _struct_ is a custom data type that lets us name and package together multiple related values that make up a meaningful group.
 
@@ -15,12 +15,10 @@ struct User {
 
 ---
 
-You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+Here are the relevant sections in the new and old books:
 
-* [In the first edition: Ch 3.12 — Structs][1]
-
-* [In second edition: Ch 5.00 — Structs][2]
+* **[In second edition: Ch 5.00 — Structs][2]**
+* <small>[In the first edition: Ch 3.12 — Structs][1]</small>
 
 
 [1]: first-edition/structs.html

--- a/redirects/structs.md
+++ b/redirects/structs.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Structs
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/structs.md
+++ b/redirects/structs.md
@@ -1,6 +1,20 @@
 % Structs
 
 There is a new edition of the book and this is an old link.
+
+> A _struct_ is a custom data type that lets us name and package together multiple related values that make up a meaningful group.
+
+```rust
+struct User {
+    username: String,
+    email: String,
+    sign_in_count: u64,
+    active: bool,
+}
+```
+
+---
+
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 

--- a/redirects/structs.md
+++ b/redirects/structs.md
@@ -4,9 +4,9 @@ There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 3.12 — Structs][1]
 
-* [Related chapter in second edition of The Rust Programming Language][2]
+* [In second edition: Ch 5.00 — Structs][2]
 
 
 [1]: first-edition/structs.html

--- a/redirects/syntax-and-semantics.md
+++ b/redirects/syntax-and-semantics.md
@@ -1,16 +1,14 @@
 % Syntax and Semantics
 
-There is a new edition of the book and this is an old link.
-You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+<small>There is a new edition of the book and this is an old link.</small>
 
-* [In the first edition: Ch 3 — Syntax and Semantics][1]
+Here are the relevant sections in the new and old books:
 
-* [In the second edition: Ch 3.00 — Common Programming Concepts][2]
 
+* **[In the second edition: Ch 3.00 — Common Programming Concepts][2]**
 * [In the second edition: Appendix A — Keywords][3]
-
 * [In the second edition: Appendix B — Operators][4]
+* <small>[In the first edition: Ch 3 — Syntax and Semantics][1]</small>
 
 
 [1]: first-edition/syntax-and-semantics.html

--- a/redirects/syntax-and-semantics.md
+++ b/redirects/syntax-and-semantics.md
@@ -4,11 +4,13 @@ There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 3 — Syntax and Semantics][1]
 
-* [Related chapter in the second edition of The Rust Programming Language (covering Rust syntax in general)][2]
-* [Related page in the second edition of The Rust Programming Language (covering Rust keywords)][3]
-* [Related page in the second edition of The Rust Programming Language (covering Rust operators)][4]
+* [In the second edition: Ch 3.00 — Common Programming Concepts][2]
+
+* [In the second edition: Appendix A — Keywords][3]
+
+* [In the second edition: Appendix B — Operators][4]
 
 
 [1]: first-edition/syntax-and-semantics.html

--- a/redirects/syntax-and-semantics.md
+++ b/redirects/syntax-and-semantics.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Syntax and Semantics
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/syntax-index.md
+++ b/redirects/syntax-index.md
@@ -4,11 +4,11 @@ There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 6 — Syntax Index][1]
 
-* [Keywords index in the second edition of The Rust Programming Language][2]
+* [In the second edition: Appendix A — Keywords][2]
 
-* [Operators index in the second edition of The Rust Programming Language][3]
+* [In the second edition: Appendix B — Operators][3]
 
 
 [1]: first-edition/syntax-index.html

--- a/redirects/syntax-index.md
+++ b/redirects/syntax-index.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Syntax Index
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/syntax-index.md
+++ b/redirects/syntax-index.md
@@ -6,8 +6,11 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Keywords index in the second edition of The Rust Programming Language][2]
+
+* [Operators index in the second edition of The Rust Programming Language][3]
 
 
 [1]: first-edition/syntax-index.html
-[2]: second-edition/index.html
+[2]: second-edition/appendix-01-keywords.html
+[3]: second-edition/appendix-02-operators.html

--- a/redirects/syntax-index.md
+++ b/redirects/syntax-index.md
@@ -1,14 +1,12 @@
 % Syntax Index
 
-There is a new edition of the book and this is an old link.
-You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+<small>There is a new edition of the book and this is an old link.</small>
 
-* [In the first edition: Ch 6 — Syntax Index][1]
+Here are the relevant sections in the new and old books:
 
-* [In the second edition: Appendix A — Keywords][2]
-
-* [In the second edition: Appendix B — Operators][3]
+* **[In the second edition: Appendix A — Keywords][2]**
+* **[In the second edition: Appendix B — Operators][3]**
+* <small>[In the first edition: Ch 6 — Syntax Index][1]</small>
 
 
 [1]: first-edition/syntax-index.html

--- a/redirects/testing.md
+++ b/redirects/testing.md
@@ -1,6 +1,20 @@
 % Testing
 
 There is a new edition of the book and this is an old link.
+
+> Rust includes support for writing software tests within the language itself.
+
+```rust
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+    }
+}
+```
+
+---
+
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 

--- a/redirects/testing.md
+++ b/redirects/testing.md
@@ -4,9 +4,9 @@ There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 4.2 — Testing][1]
 
-* [Related chapter in the second edition of The Rust Programming Language][2]
+* [In the second edition: Ch 11.00 — Testing][2]
 
 
 [1]: first-edition/testing.html

--- a/redirects/testing.md
+++ b/redirects/testing.md
@@ -1,6 +1,6 @@
 % Testing
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > Rust includes support for writing software tests within the language itself.
 
@@ -15,12 +15,10 @@ mod tests {
 
 ---
 
-You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+Here are the relevant sections in the new and old books:
 
-* [In the first edition: Ch 4.2 — Testing][1]
-
-* [In the second edition: Ch 11.00 — Testing][2]
+* **[In the second edition: Ch 11.00 — Testing][2]**
+* <small>[In the first edition: Ch 4.2 — Testing][1]</small>
 
 
 [1]: first-edition/testing.html

--- a/redirects/testing.md
+++ b/redirects/testing.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Testing
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/the-stack-and-the-heap.md
+++ b/redirects/the-stack-and-the-heap.md
@@ -1,6 +1,6 @@
 % The Stack and the Heap
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > Both the stack and the heap are parts of memory that is available to your code to use at runtime, but they are structured in different ways.
 > The stack stores values in the order it gets them and removes the values in the opposite order.
@@ -9,12 +9,10 @@ There is a new edition of the book and this is an old link.
 
 ---
 
-You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+Here are the relevant sections in the new and old books:
 
-* [In the first edition: Ch 4.1 — The Stack and the Heap][1]
-
-* [In the second edition: Ch 4.01 — What is Ownership, section The Stack and the Heap][2]
+* **[In the second edition: Ch 4.01 — What is Ownership, section The Stack and the Heap][2]**
+* <small>[In the first edition: Ch 4.1 — The Stack and the Heap][1]</small>
 
 
 [1]: first-edition/the-stack-and-the-heap.html

--- a/redirects/the-stack-and-the-heap.md
+++ b/redirects/the-stack-and-the-heap.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% The Stack and the Heap
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/the-stack-and-the-heap.md
+++ b/redirects/the-stack-and-the-heap.md
@@ -1,6 +1,14 @@
 % The Stack and the Heap
 
 There is a new edition of the book and this is an old link.
+
+> Both the stack and the heap are parts of memory that is available to your code to use at runtime, but they are structured in different ways.
+> The stack stores values in the order it gets them and removes the values in the opposite order.
+> All data on the stack must take up a known, fixed size.
+> For data with a size unknown to us at compile time or a size that might change, we can store data on the heap instead.
+
+---
+
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 

--- a/redirects/the-stack-and-the-heap.md
+++ b/redirects/the-stack-and-the-heap.md
@@ -4,9 +4,9 @@ There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 4.1 — The Stack and the Heap][1]
 
-* [Related section in the second edition of The Rust Programming Language][2]
+* [In the second edition: Ch 4.01 — What is Ownership, section The Stack and the Heap][2]
 
 
 [1]: first-edition/the-stack-and-the-heap.html

--- a/redirects/trait-objects.md
+++ b/redirects/trait-objects.md
@@ -1,6 +1,6 @@
 % Trait Objects
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > Trait objects combine the data made up of the pointer to a concrete object with the behavior of the methods defined in the trait.
 > A trait defines behavior that we need in a given situation.
@@ -58,12 +58,10 @@ fn main() {
 
 ---
 
-You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+Here are the relevant sections in the new and old books:
 
-* [In the first edition: Ch 3.22 — Trait Objects][1]
-
-* [In the second edition: Ch 17.02 — Trait Objects][2]
+* **[In the second edition: Ch 17.02 — Trait Objects][2]**
+* <small>[In the first edition: Ch 3.22 — Trait Objects][1]</small>
 
 
 [1]: first-edition/trait-objects.html

--- a/redirects/trait-objects.md
+++ b/redirects/trait-objects.md
@@ -1,6 +1,63 @@
 % Trait Objects
 
 There is a new edition of the book and this is an old link.
+
+> Trait objects combine the data made up of the pointer to a concrete object with the behavior of the methods defined in the trait.
+> A trait defines behavior that we need in a given situation.
+> We can then use a trait as a trait object in places where we would use a concrete type or a generic type.
+
+```rust
+pub struct InputBox {
+    pub label: String,
+}
+
+impl Draw for InputBox {
+    fn draw(&self) {
+        // Code to actually draw an input box
+    }
+}
+
+pub struct Button {
+    pub label: String,
+}
+
+impl Draw for Button {
+    fn draw(&self) {
+        // Code to actually draw a button
+    }
+}
+
+pub struct Screen<T: Draw> {
+    pub components: Vec<T>,
+}
+
+impl<T> Screen<T>
+    where T: Draw {
+    pub fn run(&self) {
+        for component in self.components.iter() {
+            component.draw();
+        }
+    }
+}
+
+fn main() {
+    let screen = Screen {
+        components: vec![
+            Box::new(InputBox {
+                label: String::from("OK"),
+            }),
+            Box::new(Button {
+                label: String::from("OK"),
+            }),
+        ],
+    };
+
+    screen.run();
+}
+```
+
+---
+
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 

--- a/redirects/trait-objects.md
+++ b/redirects/trait-objects.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Trait Objects
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/trait-objects.md
+++ b/redirects/trait-objects.md
@@ -4,9 +4,9 @@ There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 3.22 — Trait Objects][1]
 
-* [Related page in the second edition of The Rust Programming Language][2]
+* [In the second edition: Ch 17.02 — Trait Objects][2]
 
 
 [1]: first-edition/trait-objects.html

--- a/redirects/traits.md
+++ b/redirects/traits.md
@@ -1,6 +1,6 @@
 % Traits
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > Traits abstract over behavior that types can have in common.
 
@@ -12,14 +12,11 @@ pub trait Summarizable {
 
 ---
 
-You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+Here are the relevant sections in the new and old books:
 
-* [In the first edition: Ch 3.19 — Traits][1]
-
-* [In the second edition: Ch 10.02 — Traits][2]
-
+* **[In the second edition: Ch 10.02 — Traits][2]**
 * [In the second edition: Ch 19.03 — Advanced Traits][3]
+* <small>[In the first edition: Ch 3.19 — Traits][1]</small>
 
 
 [1]: first-edition/traits.html

--- a/redirects/traits.md
+++ b/redirects/traits.md
@@ -4,11 +4,11 @@ There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 3.19 — Traits][1]
 
-* [Related page in the second edition of The Rust Programming Language][2]
+* [In the second edition: Ch 10.02 — Traits][2]
 
-* [Related page in the second edition of The Rust Programming Language (covering more advanced topics)][3]
+* [In the second edition: Ch 19.03 — Advanced Traits][3]
 
 
 [1]: first-edition/traits.html

--- a/redirects/traits.md
+++ b/redirects/traits.md
@@ -1,6 +1,17 @@
 % Traits
 
 There is a new edition of the book and this is an old link.
+
+> Traits abstract over behavior that types can have in common.
+
+```rust
+pub trait Summarizable {
+    fn summary(&self) -> String;
+}
+```
+
+---
+
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 

--- a/redirects/traits.md
+++ b/redirects/traits.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Traits
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/type-aliases.md
+++ b/redirects/type-aliases.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% `type` Aliases
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/type-aliases.md
+++ b/redirects/type-aliases.md
@@ -1,6 +1,15 @@
 % `type` aliases
 
 There is a new edition of the book and this is an old link.
+
+> Rust provides the ability to declare a _type alias_ with the `type` keyword to give an existing type another name.
+
+```rust
+type Kilometers = i32;
+```
+
+---
+
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 

--- a/redirects/type-aliases.md
+++ b/redirects/type-aliases.md
@@ -1,6 +1,6 @@
 % `type` aliases
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > Rust provides the ability to declare a _type alias_ with the `type` keyword to give an existing type another name.
 
@@ -10,12 +10,10 @@ type Kilometers = i32;
 
 ---
 
-You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+Here are the relevant sections in the new and old books:
 
-* [In the first edition: Ch 3.28 — `type` aliases][1]
-
-* [In the second edition: Ch 19.04 — Advanced Types, section Type Synonyms][2]
+* **[In the second edition: Ch 19.04 — Advanced Types, section Type Synonyms][2]**
+* <small>[In the first edition: Ch 3.28 — `type` aliases][1]</small>
 
 
 [1]: first-edition/type-aliases.html

--- a/redirects/type-aliases.md
+++ b/redirects/type-aliases.md
@@ -1,12 +1,12 @@
-% `type` Aliases
+% `type` aliases
 
 There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 3.28 — `type` aliases][1]
 
-* [Related section in the second edition of The Rust Programming Language][2]
+* [In the second edition: Ch 19.04 — Advanced Types, section Type Synonyms][2]
 
 
 [1]: first-edition/type-aliases.html

--- a/redirects/ufcs.md
+++ b/redirects/ufcs.md
@@ -1,6 +1,49 @@
 % Universal Function Call Syntax
 
 There is a new edition of the book and this is an old link.
+
+> Rust cannot prevent a trait from having a method with the same name as another trait’s method, nor can it prevent us from implementing both of these traits on one type.
+> In order to be able to call each of the methods with the same name, then, we need to tell Rust which one we want to use.
+
+```rust
+trait Pilot {
+    fn fly(&self);
+}
+
+trait Wizard {
+    fn fly(&self);
+}
+
+struct Human;
+
+impl Pilot for Human {
+#     fn fly(&self) {
+#         println!("This is your captain speaking.");
+#     }
+}
+
+impl Wizard for Human {
+#     fn fly(&self) {
+#         println!("Up!");
+#     }
+}
+
+impl Human {
+#     fn fly(&self) {
+#         println!("*waving arms furiously*");
+#     }
+}
+
+fn main() {
+    let person = Human;
+    Pilot::fly(&person);
+    Wizard::fly(&person);
+    person.fly();
+}
+```
+
+---
+
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 

--- a/redirects/ufcs.md
+++ b/redirects/ufcs.md
@@ -1,6 +1,6 @@
 % Universal Function Call Syntax
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > Rust cannot prevent a trait from having a method with the same name as another trait’s method, nor can it prevent us from implementing both of these traits on one type.
 > In order to be able to call each of the methods with the same name, then, we need to tell Rust which one we want to use.
@@ -44,12 +44,10 @@ fn main() {
 
 ---
 
-You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+Here are the relevant sections in the new and old books:
 
-* [In the first edition: Ch 3.24 — Universal Function Call Syntax][1]
-
-* [In the second edition: Ch 19.03 — Advanced Traits, section Fully Qualified Syntax][2]
+* **[In the second edition: Ch 19.03 — Advanced Traits, section Fully Qualified Syntax][2]**
+* <small>[In the first edition: Ch 3.24 — Universal Function Call Syntax][1]</small>
 
 
 [1]: first-edition/ufcs.html

--- a/redirects/ufcs.md
+++ b/redirects/ufcs.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Universal Function Call Syntax
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/ufcs.md
+++ b/redirects/ufcs.md
@@ -4,9 +4,9 @@ There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 3.24 — Universal Function Call Syntax][1]
 
-* [Related section in the second edition of The Rust Programming Language][2]
+* [In the second edition: Ch 19.03 — Advanced Traits, section Fully Qualified Syntax][2]
 
 
 [1]: first-edition/ufcs.html

--- a/redirects/unsafe.md
+++ b/redirects/unsafe.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% `unsafe`
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/unsafe.md
+++ b/redirects/unsafe.md
@@ -4,10 +4,13 @@ There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 3.36 — `unsafe`][1]
 
-* [Related page in the second edition of The Rust Programming Language][2]
+* [In the second edition: Ch 19.01 — Unsafe Rust][2]
+
+* [The Rustonomicon, The Dark Arts of Advanced and Unsafe Rust Programming][3]
 
 
 [1]: first-edition/unsafe.html
 [2]: second-edition/ch19-01-unsafe-rust.html
+[3]: ../nomicon/

--- a/redirects/unsafe.md
+++ b/redirects/unsafe.md
@@ -1,6 +1,11 @@
 % `unsafe`
 
 There is a new edition of the book and this is an old link.
+
+> Rust has a second language hiding out inside of it, unsafe Rust, which does not enforce memory safety guarantees.
+
+---
+
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 

--- a/redirects/unsafe.md
+++ b/redirects/unsafe.md
@@ -1,19 +1,16 @@
 % `unsafe`
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > Rust has a second language hiding out inside of it, unsafe Rust, which does not enforce memory safety guarantees.
 
 ---
 
-You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+Here are the relevant sections in the new and old books:
 
-* [In the first edition: Ch 3.36 — `unsafe`][1]
-
-* [In the second edition: Ch 19.01 — Unsafe Rust][2]
-
+* **[In the second edition: Ch 19.01 — Unsafe Rust][2]**
 * [The Rustonomicon, The Dark Arts of Advanced and Unsafe Rust Programming][3]
+* <small>[In the first edition: Ch 3.36 — `unsafe`][1]</small>
 
 
 [1]: first-edition/unsafe.html

--- a/redirects/unsized-types.md
+++ b/redirects/unsized-types.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Unsized Types
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/unsized-types.md
+++ b/redirects/unsized-types.md
@@ -1,6 +1,6 @@
 % Unsized Types
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > Sometimes referred to as ‘DSTs’ or ‘unsized types’, these types let us talk about types whose size we can only know at runtime.
 > The `Sized` trait is automatically implemented for everything the compiler knows the size of at compile time.
@@ -14,12 +14,10 @@ fn generic<T: ?Sized>(t: &T) {
 
 ---
 
-You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+Here are the relevant sections in the new and old books:
 
-* [In the first edition: Ch 3.31 — Unsized Types][1]
-
-* [In the second edition: Ch 19.04 — Advanced Types, section Dynamically Sized Types][2]
+* **[In the second edition: Ch 19.04 — Advanced Types, section Dynamically Sized Types][2]**
+* <small>[In the first edition: Ch 3.31 — Unsized Types][1]</small>
 
 
 [1]: first-edition/unsized-types.html

--- a/redirects/unsized-types.md
+++ b/redirects/unsized-types.md
@@ -4,9 +4,9 @@ There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 3.31 — Unsized Types][1]
 
-* [Related section in the second edition of The Rust Programming Language][2]
+* [In the second edition: Ch 19.04 — Advanced Types, section Dynamically Sized Types][2]
 
 
 [1]: first-edition/unsized-types.html

--- a/redirects/unsized-types.md
+++ b/redirects/unsized-types.md
@@ -1,6 +1,19 @@
 % Unsized Types
 
 There is a new edition of the book and this is an old link.
+
+> Sometimes referred to as ‘DSTs’ or ‘unsized types’, these types let us talk about types whose size we can only know at runtime.
+> The `Sized` trait is automatically implemented for everything the compiler knows the size of at compile time.
+> A trait bound on `?Sized` is the opposite of a trait bound on `Sized`; that is, we would read this as “`T` may or may not be `Sized`”.
+
+```rust,ignore
+fn generic<T: ?Sized>(t: &T) {
+    // ...snip...
+}
+```
+
+---
+
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 

--- a/redirects/using-rust-without-the-standard-library.md
+++ b/redirects/using-rust-without-the-standard-library.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Using Rust without the Standard Library
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/using-rust-without-the-standard-library.md
+++ b/redirects/using-rust-without-the-standard-library.md
@@ -2,12 +2,14 @@
 
 There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+
+This particular chapter has moved to [a chapter in the Unstable Book][2].
+Please check it out there.
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [Related page in The Unstable Rust Book][2]
 
 
 [1]: first-edition/using-rust-without-the-standard-library.html
-[2]: second-edition/index.html
+[2]: ../unstable-book/language-features/lang-items.html#writing-an-executable-without-stdlib

--- a/redirects/using-rust-without-the-standard-library.md
+++ b/redirects/using-rust-without-the-standard-library.md
@@ -1,20 +1,16 @@
 % Using Rust without the Standard Library
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > Rust’s standard library provides a lot of useful functionality, but assumes support for various features of its host system: threads, networking, heap allocation, and others.
 > There are systems that do not have these features, however.
 
 ---
 
-You can [continue to the exact older page][1].
+This particular chapter has moved to [the Unstable Book][2].
 
-This particular chapter has moved to [a chapter in the Unstable Book][2].
-Please check it out there.
-
-* [In the first edition: Ch 4.12 — Using Rust without the Standard Library][1]
-
-* [In the Unstable Rust Book: `lang_items` — Writing an executable without stdlib][2]
+* **[In the Unstable Rust Book: `lang_items` — Writing an executable without stdlib][2]**
+* <small>[In the first edition: Ch 4.12 — Using Rust without the Standard Library][1]</small>
 
 
 [1]: first-edition/using-rust-without-the-standard-library.html

--- a/redirects/using-rust-without-the-standard-library.md
+++ b/redirects/using-rust-without-the-standard-library.md
@@ -1,6 +1,12 @@
 % Using Rust without the Standard Library
 
 There is a new edition of the book and this is an old link.
+
+> Rust’s standard library provides a lot of useful functionality, but assumes support for various features of its host system: threads, networking, heap allocation, and others.
+> There are systems that do not have these features, however.
+
+---
+
 You can [continue to the exact older page][1].
 
 This particular chapter has moved to [a chapter in the Unstable Book][2].

--- a/redirects/using-rust-without-the-standard-library.md
+++ b/redirects/using-rust-without-the-standard-library.md
@@ -6,9 +6,9 @@ You can [continue to the exact older page][1].
 This particular chapter has moved to [a chapter in the Unstable Book][2].
 Please check it out there.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 4.12 — Using Rust without the Standard Library][1]
 
-* [Related page in The Unstable Rust Book][2]
+* [In the Unstable Rust Book: `lang_items` — Writing an executable without stdlib][2]
 
 
 [1]: first-edition/using-rust-without-the-standard-library.html

--- a/redirects/variable-bindings.md
+++ b/redirects/variable-bindings.md
@@ -4,9 +4,9 @@ There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 3.1 — Variable Bindings][1]
 
-* [This page in the second edition of The Rust Programming Language][2]
+* [In the second edition: Ch 2.00 — Guessing Game Tutorial, section Variables][2]
 
 
 [1]: first-edition/variable-bindings.html

--- a/redirects/variable-bindings.md
+++ b/redirects/variable-bindings.md
@@ -1,6 +1,15 @@
 % Variable Bindings
 
 There is a new edition of the book and this is an old link.
+
+> Variable bindings bind some value to a name, so it can be used later.
+
+```rust
+let foo = 5;
+```
+
+---
+
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 

--- a/redirects/variable-bindings.md
+++ b/redirects/variable-bindings.md
@@ -1,6 +1,6 @@
 % Variable Bindings
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > Variable bindings bind some value to a name, so it can be used later.
 
@@ -10,12 +10,10 @@ let foo = 5;
 
 ---
 
-You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+Here are the relevant sections in the new and old books:
 
-* [In the first edition: Ch 3.1 — Variable Bindings][1]
-
-* [In the second edition: Ch 2.00 — Guessing Game Tutorial, section Variables][2]
+* **[In the second edition: Ch 2.00 — Guessing Game Tutorial, section Variables][2]**
+* <small>[In the first edition: Ch 3.1 — Variable Bindings][1]</small>
 
 
 [1]: first-edition/variable-bindings.html

--- a/redirects/variable-bindings.md
+++ b/redirects/variable-bindings.md
@@ -6,8 +6,8 @@ If you're trying to learn Rust, checking out [the second edition][2] might be a 
 
 * [This page in the first edition of the The Rust Programming Language][1]
 
-* [Index of the second edition of The Rust Programming Language][2]
+* [This page in the second edition of The Rust Programming Language][2]
 
 
 [1]: first-edition/variable-bindings.html
-[2]: second-edition/index.html
+[2]: second-edition/ch02-00-guessing-game-tutorial.html#storing-values-with-variables

--- a/redirects/variable-bindings.md
+++ b/redirects/variable-bindings.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Variable Bindings
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]

--- a/redirects/vectors.md
+++ b/redirects/vectors.md
@@ -1,6 +1,17 @@
 % Vectors
 
 There is a new edition of the book and this is an old link.
+
+> Vectors store more than one value in a single data structure that puts all the values next to each other in memory.
+> Vectors can only store values of the same type.
+
+```rust
+let v: Vec<i32> = Vec::new();
+let numbers = vec![1, 2, 3];
+```
+
+---
+
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 

--- a/redirects/vectors.md
+++ b/redirects/vectors.md
@@ -1,6 +1,6 @@
 % Vectors
 
-There is a new edition of the book and this is an old link.
+<small>There is a new edition of the book and this is an old link.</small>
 
 > Vectors store more than one value in a single data structure that puts all the values next to each other in memory.
 > Vectors can only store values of the same type.
@@ -12,12 +12,10 @@ let numbers = vec![1, 2, 3];
 
 ---
 
-You can [continue to the exact older page][1].
-If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
+Here are the relevant sections in the new and old books:
 
-* [In the first edition: Ch 3.7 — Vectors][1]
-
-* [In the second edition: Ch 8.01 — Vectors][2]
+* **[In the second edition: Ch 8.01 — Vectors][2]**
+* <small>[In the first edition: Ch 3.7 — Vectors][1]</small>
 
 
 [1]: first-edition/vectors.html

--- a/redirects/vectors.md
+++ b/redirects/vectors.md
@@ -4,9 +4,9 @@ There is a new edition of the book and this is an old link.
 You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
-* [This page in the first edition of the The Rust Programming Language][1]
+* [In the first edition: Ch 3.7 — Vectors][1]
 
-* [Related page in the second edition of The Rust Programming Language][2]
+* [In the second edition: Ch 8.01 — Vectors][2]
 
 
 [1]: first-edition/vectors.html

--- a/redirects/vectors.md
+++ b/redirects/vectors.md
@@ -1,6 +1,7 @@
-% There is a new edition of the book
+% Vectors
 
-This is an old link. You can [continue to the exact older page][1].
+There is a new edition of the book and this is an old link.
+You can [continue to the exact older page][1].
 If you're trying to learn Rust, checking out [the second edition][2] might be a better choice.
 
 * [This page in the first edition of the The Rust Programming Language][1]


### PR DESCRIPTION
<sup>(Following [these tweets](https://twitter.com/passcod/status/946897449091608576) with @steveklabnik.)</sup>

The general idea / guiding thought is this: redirects are where many people land (right now), and we're trying to retain their attention while pointing them elsewhere. At the same time, eventually the redirects will all but disappear as links are updated.

I think the current design does this poorly.

![A screenshot of the current design as of this writing.](https://user-images.githubusercontent.com/155787/34459554-338af45e-ee58-11e7-867e-74097e1450fe.png)

1. It is extremely generic. It is so generic that _nowhere in the actual copy_ does it say where you've landed, or where you're going, in more precise terms than "The Rust Book first or second edition".
2. Many redirect pages point people to the index, which is likely one of the least useful place to go when looking for specific information.
3. It provides no value to people beyond two links which may or may not provide the right information, which the visitor has no way of figuring out without actually clicking on.

The fact is, there is no 1:1 correspondence between 1st-ed and 2nd-ed chapters. There are a few N:1 (1st-ed to 2nd-ed), a large number of 1:N, and indeed some 1:**nowhere**. So it is impossible to automatically redirect people, which is the entire problem and why these redirects exist.

Hence, this Pull Request. I applied 5 incremental modifications to every redirect page:

### Replace the generic title with the title of the chapter in 1st-ed

and reword the blurb to include what was previously in the title. This makes it easier to see that one has arrived to the right place.

### Always go somewhere meaningful

Unless it is the correct place to go, never link to the index of the second edition as fallback. Point instead to different books, to the reference, to the API documentation, etc.

### Include the title of the link's target into its text

To make it clearer where links are going, eliminate entirely the language of "Related" or the long verbose book titles. Instead, simply prefix with "In the first/second edition" as needed, and in similar style for other resources like the reference or the Unsafe book. Additionally, include the target's title, i.e. chapter number, name, and sometimes subsection, directly to the link copy.

### Add a quick summary and code sample

To improve immediate value and reduce discard-because-not-useful factor upon arriving at a page which does not contain the content you were expecting, add a small blurb taken/adapted from the newer source (except in the case of pages that do not exist at all), optionally accompanied by a code sample describing the feature (or as relevant).

Keeping in mind that due to the transitive nature of the redirects, there must be no content there that isn't available elsewhere.

### Highlight the recommended path and "lowlight" the old path

Instead of placing the link to the recommended resource i.e. the second edition in second place, push it up to the top of the list. In fact, push the link to the first edition always at the bottom. To emphasise even more that's where new visitors should go, bolden the first link, and make the first-ed link smaller.

This provides a clear recommendation of where to go, without completely hiding the old resource (which would be detrimental as there _is_ value in the first-ed still).

### Result

![A screenshot of a redirect page with the changes applied.](https://user-images.githubusercontent.com/155787/34459595-57943760-ee59-11e7-9a62-c8ce45bf6dab.png)

_(Note that the code sample should actually be a yellow runnable syntax-highlighted Rust code block, but there is no script or means to build the redirects, so I had to do the preview by manually inserting rendered HTML into an existing page, which means it lacks the fanciness.)_