### PR TITLE
Annotate variable type rather than using turbofish

### DIFF
--- a/second-edition/src/ch09-03-to-panic-or-not-to-panic.md
+++ b/second-edition/src/ch09-03-to-panic-or-not-to-panic.md
@@ -50,7 +50,7 @@ example:
 ```rust
 use std::net::IpAddr;
 
-let home = "127.0.0.1".parse::<IpAddr>().unwrap();
+let home: IpAddr = "127.0.0.1".parse().unwrap();
 ```
 
 We’re creating an `IpAddr` instance by parsing a hardcoded string. We can see


### PR DESCRIPTION
Turbofish, as far as I know, hasn't been introduced yet. Throwing unknown syntax at readers can be confusing. It might be more prudent to explain Turbofish in the explanation following the code example or just explain in the next chapter (see: #385)

  