### PR TITLE
avoid warning: pattern is redundant

### DIFF
--- a/second-edition/src/ch18-03-pattern-syntax.md
+++ b/second-edition/src/ch18-03-pattern-syntax.md
@@ -334,7 +334,7 @@ fn main() {
         Message::Quit => {
             println!("The Quit variant has no data to destructure.")
         },
-        Message::Move { x: x, y: y } => {
+        Message::Move { x, y } => {
             println!(
                 "Move in the x direction {} and in the y direction {}",
                 x,


### PR DESCRIPTION
The restructuring of the `Move` variant uses the long form, and rustc v1.21 warns about it:

      --> src/main.rs:50:25
       |
    50 |         Message::Move { x: x, y: y } => {
       |                         ^^^^
       |
       = note: #[warn(non_shorthand_field_patterns)] on by default

Since `struct` shorthand destructing have been introduced above, this warning can go away.

If the intention was for this to be an educational experience, this should be kept, but in the case this is an oversight, this PR is here to fix it.