### PR TITLE
Remove chapter title to prevent duplicate

### DIFF
--- a/second-edition/theme/index.hbs
+++ b/second-edition/theme/index.hbs
@@ -2,7 +2,7 @@
 <html lang="{{ language }}">
     <head>
         <meta charset="UTF-8">
-        <title>{{ chapter_title }} - {{ title }}</title>
+        <title>{{ title }}</title>
         <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
         <meta name="description" content="{{ description }}">
         <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
Fixes #1091

[mdBook](https://github.com/rust-lang-nursery/mdBook/) as of v0.0.24 and above automatically appends chapter title (from [SUMMARY.md](https://github.com/rust-lang/book/blob/master/second-edition/src/SUMMARY.md)). This PR removes the chapter title explicitly mentioned in [index.hbs](https://github.com/rust-lang/book/blob/83896fa600cd331cfe7abd483ad89b891d1a3747/second-edition/theme/index.hbs#L5) to prevent duplicates.