### PR TITLE
Remove type definition in a way to let it crash

### DIFF
--- a/second-edition/src/ch03-02-data-types.md
+++ b/second-edition/src/ch03-02-data-types.md
@@ -13,7 +13,7 @@ converted a `String` to a numeric type using `parse` in Chapter 2, we must add
 a type annotation, like this:
 
 ```rust
-let guess: u32 = "42".parse().expect("Not a number!");
+let guess = "42".parse().expect("Not a number!");
 ```
 
 If we don’t add the type annotation here, Rust will display the following


### PR DESCRIPTION
__Description__

This PR is just removing the `u32` type definition for the variable in the first example about data type. Effectively, from what i understood, the goal of this exercise was to let the compiler complain about an error we've made. 

To let the compiler complain, we need to remove the type definition.

At the same time, I might be wrong, maybe the goal was to have a correct syntax right away and to let people change their code to provoke the failure. 

You tell me :)
