### PR TITLE
Fix borrow checker diagram

### DIFF
--- a/second-edition/src/ch10-03-lifetime-syntax.md
+++ b/second-edition/src/ch10-03-lifetime-syntax.md
@@ -81,16 +81,16 @@ Listing 10-18 with annotations showing the lifetimes of the variables:
 
 ```rust,ignore
 {
-    let r;         // -------+-- 'a
-                   //        |
-    {              //        |
-        let x = 5; // -+-----+-- 'b
-        r = &x;    //  |     |
-    }              // -+     |
-                   //        |
-    println!("r: {}", r); // |
-                   //        |
-                   // -------+
+    let r;                // -------+-- 'a
+                          //        |
+    {                     //        |
+        let x = 5;        // -+-----+-- 'b
+        r = &x;           //  |     |
+    }                     // -+     |
+                          //        |
+    println!("r: {}", r); //        |
+                          //        |
+                          // -------+
 }
 ```
 

--- a/second-edition/src/ch10-03-lifetime-syntax.md
+++ b/second-edition/src/ch10-03-lifetime-syntax.md
@@ -89,9 +89,7 @@ Listing 10-18 with annotations showing the lifetimes of the variables:
     }                     // -+     |
                           //        |
     println!("r: {}", r); //        |
-                          //        |
-                          // -------+
-}
+}                         // -------+
 ```
 
 <span class="caption">Listing 10-19: Annotations of the lifetimes of `r` and


### PR DESCRIPTION
Improved legibility of the first borrow checker diagram. Makes the spacing/style consistent with the second diagram.