### PR TITLE
DOT: Fix overlapping of texts and shapes

### DIFF
--- a/second-edition/dot/trpl04-01.dot
+++ b/second-edition/dot/trpl04-01.dot
@@ -1,5 +1,6 @@
 digraph {
     rankdir=LR;
+    overlap=false;
     dpi=300.0;
     node [shape="plaintext"];
 

--- a/second-edition/dot/trpl04-02.dot
+++ b/second-edition/dot/trpl04-02.dot
@@ -1,5 +1,6 @@
 digraph {
     rankdir=LR;
+    overlap=false;
     dpi=300.0;
     node [shape="plaintext"];
 

--- a/second-edition/dot/trpl04-03.dot
+++ b/second-edition/dot/trpl04-03.dot
@@ -1,5 +1,6 @@
 digraph {
     rankdir=LR;
+    overlap=false;
     dpi=300.0;
     node [shape="plaintext"];
 

--- a/second-edition/dot/trpl04-04.dot
+++ b/second-edition/dot/trpl04-04.dot
@@ -1,5 +1,6 @@
 digraph {
     rankdir=LR;
+    overlap=false;
     dpi=300.0;
     node [shape="plaintext"];
 

--- a/second-edition/dot/trpl04-05.dot
+++ b/second-edition/dot/trpl04-05.dot
@@ -1,5 +1,6 @@
 digraph {
     rankdir=LR;
+    overlap=false;
     dpi=300.0;
     node [shape="plaintext"];
 

--- a/second-edition/dot/trpl04-06.dot
+++ b/second-edition/dot/trpl04-06.dot
@@ -1,5 +1,6 @@
 digraph {
     rankdir=LR;
+    overlap=false;
     dpi=300.0;
     node [shape="plaintext"];
 

--- a/second-edition/dot/trpl15-01.dot
+++ b/second-edition/dot/trpl15-01.dot
@@ -1,5 +1,6 @@
 digraph {
     rankdir=LR;
+    overlap=false;
     dpi=300.0;
     node [shape="plaintext"];
 

--- a/second-edition/dot/trpl15-02.dot
+++ b/second-edition/dot/trpl15-02.dot
@@ -1,5 +1,6 @@
 digraph {
     rankdir=LR;
+    overlap=false;
     dpi=300.0;
     node [shape="plaintext"];
 

--- a/second-edition/dot/trpl15-03.dot
+++ b/second-edition/dot/trpl15-03.dot
@@ -1,5 +1,6 @@
 digraph {
     rankdir=LR;
+    overlap=false;
     dpi=300.0;
     node [shape="plaintext"];
 


### PR DESCRIPTION
Texts in dot graphs for chapters 4 and 15 overlap with their parent frames.
See, for example, this figure from chapter 4.1:
<img src="https://doc.rust-lang.org/stable/book/second-edition/img/trpl04-02.svg" height=360px>

After a quick search I found `overlap=false`, which prevents the overlapping.


![trpl04-02](https://user-images.githubusercontent.com/15898292/35184388-32da6394-fdf5-11e7-8d4e-c09c579ecf31.png)


Since I dont know how the final SVG is renderd on your end, I only included the modified dot files. If need be, I can update the SVG files as well