### PR TITLE
Ch12-03: Import run from lib.rs to main.rs

### DIFF
--- a/second-edition/src/ch12-03-improving-error-handling-and-modularity.md
+++ b/second-edition/src/ch12-03-improving-error-handling-and-modularity.md
@@ -649,7 +649,7 @@ extern crate minigrep;
 use std::env;
 use std::process;
 
-use minigrep::Config;
+use minigrep::{Config, run};
 
 fn main() {
     // --snip--


### PR DESCRIPTION
Since `run` was moved earlier to `lib.rs`, it needs to be imported along with `Config` to be able to correctly run the `minigrep` project in chapter 12.