### PR TITLE
Update mdbook to what rust-lang/rust is using

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,6 @@ addons:
       - aspell
       - aspell-en
 before_script:
-  - (cargo install mdbook --vers 0.1.0 --force || true)
+  - (cargo install mdbook --vers 0.1.2 --force || true)
 script:
   - bash ci/build.sh


### PR DESCRIPTION
https://github.com/rust-lang/rust/blame/27a046e9338fb0455c33b13e8fe28da78212dedc/src/Cargo.lock#L1076

that is, 1.2.0

I'll merge once travis passes