### PR TITLE
Fix misindent and comment text spacing on first edition's Procedural Macros page 

### DIFF
--- a/first-edition/src/procedural-macros.md
+++ b/first-edition/src/procedural-macros.md
@@ -267,8 +267,8 @@ fn impl_hello_world(ast: &syn::DeriveInput) -> quote::Tokens {
             }
         }
     } else {
-        //Nope. This is an Enum. We cannot handle these!
-       panic!("#[derive(HelloWorld)] is only defined for structs, not for enums!");
+        // Nope. This is an Enum. We cannot handle these!
+        panic!("#[derive(HelloWorld)] is only defined for structs, not for enums!");
     }
 }
 ```


### PR DESCRIPTION
Before: 
![before SS](https://user-images.githubusercontent.com/6709544/36509399-e87d5aac-175f-11e8-9df5-bb7ee4232e89.png)

After: 
![after SS](https://user-images.githubusercontent.com/6709544/36509441-0cf35d32-1760-11e8-8949-8cc587c6be74.png)

