### PR TITLE
Fix some operator syntax in Appendix B

### DIFF
--- a/second-edition/src/appendix-02-operators.md
+++ b/second-edition/src/appendix-02-operators.md
@@ -45,12 +45,12 @@ overload that operator is listed.
 * `<<` (`expr << expr`): left-shift. Overloadable (`Shl`).
 * `<<=` (`var <<= expr`): left-shift and assignment. Overloadable (`ShlAssign`).
 * `<` (`expr < expr`): less-than comparison. Overloadable (`PartialOrd`).
-* `<=` (`var <= expr`): less-than or equal-to comparison. Overloadable (`PartialOrd`).
+* `<=` (`expr <= expr`): less-than or equal-to comparison. Overloadable (`PartialOrd`).
 * `=` (`var = expr`, `ident = type`): assignment/equivalence.
-* `==` (`var == expr`): equality comparison. Overloadable (`PartialEq`).
+* `==` (`expr == expr`): equality comparison. Overloadable (`PartialEq`).
 * `=>` (`pat => expr`): part of match arm syntax.
 * `>` (`expr > expr`): greater-than comparison. Overloadable (`PartialOrd`).
-* `>=` (`var >= expr`): greater-than or equal-to comparison. Overloadable (`PartialOrd`).
+* `>=` (`expr >= expr`): greater-than or equal-to comparison. Overloadable (`PartialOrd`).
 * `>>` (`expr >> expr`): right-shift. Overloadable (`Shr`).
 * `>>=` (`var >>= expr`): right-shift and assignment. Overloadable (`ShrAssign`).
 * `@` (`ident @ pat`): pattern binding.


### PR DESCRIPTION
Appendix B erroneously treats the "<=", "==", and ">=" operators as if
they were compound assignments.  However, they are comparison
operators and the left-hand-side of each is an "expr", not a "var".
