### PR TITLE
[Appendix D] Fix incorrect dependencies declaration

### DIFF
--- a/second-edition/dictionary.txt
+++ b/second-edition/dictionary.txt
@@ -171,6 +171,7 @@ HashMap
 HashSet
 Haskell
 hasn
+HelloMacro
 helloworld
 HelloWorld
 HelloWorldName

--- a/second-edition/src/appendix-04-macros.md
+++ b/second-edition/src/appendix-04-macros.md
@@ -465,8 +465,8 @@ if not, you can specify them as `path` dependencies as follows:
 
 ```toml
 [dependencies]
-hello_world = { path = "../hello-world" }
-hello_world_derive = { path = "../hello-world/hello-world-derive" }
+hello-world = { path = "../hello-world" }
+hello-world-derive = { path = "../hello-world/hello-world-derive" }
 ```
 
 Put the code from Listing A4-1 into *src/main.rs*, and executing `cargo run`

--- a/second-edition/src/appendix-04-macros.md
+++ b/second-edition/src/appendix-04-macros.md
@@ -176,13 +176,13 @@ code as declarative macros do. Today, the only thing you can define procedural
 macros for is to allow your traits to be implemented on a type by specifying
 the trait name in a `derive` annotation.
 
-Let’s create a crate named `hello-world` that defines a trait named
-`HelloWorld` with one associated function named `hello_world`. Rather than
-making users of our crate implement the `HelloWorld` trait for each of their
+Let’s create a crate named `hello_macro` that defines a trait named
+`HelloMacro` with one associated function named `hello_macro`. Rather than
+making users of our crate implement the `HelloMacro` trait for each of their
 types, we’d like users to be able to annotate their type with
-`#[derive(HelloWorld)]` to get a default implementation of the `hello_world`
+`#[derive(HelloMacro)]` to get a default implementation of the `hello_macro`
 function associated with their type. The default implementation will print
-`Hello world, my name is TypeName!` where `TypeName` is the name of the type on
+`Hello, Macro! My name is TypeName!` where `TypeName` is the name of the type on
 which this trait has been defined.
 
 In other words, we’re going to write a crate that enables another programmer to
@@ -191,39 +191,39 @@ write code that looks like Listing A4-1 using our crate:
 <span class="filename">Filename: src/main.rs</span>
 
 ```rust,ignore
-extern crate hello_world;
+extern crate hello_macro;
 #[macro_use]
-extern crate hello_world_derive;
+extern crate hello_macro_derive;
 
-use hello_world::HelloWorld;
+use hello_macro::HelloMacro;
 
-#[derive(HelloWorld)]
+#[derive(HelloMacro)]
 struct Pancakes;
 
 fn main() {
-    Pancakes::hello_world();
+    Pancakes::hello_macro();
 }
 ```
 
 <span class="caption">Listing A4-1: The code a user of our crate will be able
 to write when we’ve written the procedural macro</span>
 
-This code will print `Hello world, my name is Pancakes!` when we’re done. Let’s
+This code will print `Hello, Macro! My name is Pancakes!` when we’re done. Let’s
 get started!
 
 Let’s make a new library crate:
 
 ```text
-$ cargo new hello-world
+$ cargo new hello_macro
 ```
 
-First, we’ll define the `HelloWorld` trait and associated function:
+First, we’ll define the `HelloMacro` trait and associated function:
 
 <span class="filename">Filename: src/lib.rs</span>
 
 ```rust
-pub trait HelloWorld {
-    fn hello_world();
+pub trait HelloMacro {
+    fn hello_macro();
 }
 ```
 
@@ -231,28 +231,28 @@ At this point, a user of our crate could implement the trait themselves to
 achieve the functionality we wanted to enable, like so:
 
 ```rust,ignore
-extern crate hello_world;
+extern crate hello_macro;
 
-use hello_world::HelloWorld;
+use hello_macro::HelloMacro;
 
 struct Pancakes;
 
-impl HelloWorld for Pancakes {
-    fn hello_world() {
-        println!("Hello world, my name is Pancakes!");
+impl HelloMacro for Pancakes {
+    fn hello_macro() {
+        println!("Hello, Macro! My name is Pancakes!");
     }
 }
 
 fn main() {
-    Pancakes::hello_world();
+    Pancakes::hello_macro();
 }
 ```
 
 However, they would need to write out the implementation block for each type
-they wanted to be able to use with `hello_world`; we’d like to make using our
+they wanted to be able to use with `hello_macro`; we’d like to make using our
 trait more convenient for other programmers by saving them this work.
 
-Additionally, we can’t provide a default implementation for the `hello_world`
+Additionally, we can’t provide a default implementation for the `hello_macro`
 function that has the behavior we want of printing out the name of the type the
 trait is implemented on: Rust doesn’t have reflection capabilities, so we can’t
 look up the type’s name at runtime. We need a macro to generate code at compile
@@ -264,30 +264,30 @@ The next step is to define the procedural macro. At the moment, procedural
 macros need to be in their own crate. Eventually, this restriction may be
 lifted, but for now, it’s required. As such, there’s a convention: for a crate
 named `foo`, a custom derive procedural macro crate is called `foo-derive`.
-Let’s start a new crate called `hello-world-derive` inside our `hello-world`
+Let’s start a new crate called `hello_macro_derive` inside our `hello_macro`
 project:
 
 ```text
-$ cargo new hello-world-derive
+$ cargo new hello_macro_derive
 ```
 
 We’ve chosen to create the procedural macro crate within the directory of our
-`hello-world` crate because the two crates are tightly related: if we change
-the trait definition in `hello-world`, we’ll have to change the implementation
-of the procedural macro in `hello-world-derive` as well. The two crates will
+`hello_macro` crate because the two crates are tightly related: if we change
+the trait definition in `hello_macro`, we’ll have to change the implementation
+of the procedural macro in `hello_macro_derive` as well. The two crates will
 need to be published separately, and programmers using these crates will need
 to add both as dependencies and bring them both into scope. It’s possible to
-have the `hello-world` crate use `hello-world-derive` as a dependency and
+have the `hello_macro` crate use `hello_macro_derive` as a dependency and
 re-export the procedural macro code, but structuring the project this way makes
 it possible for programmers to easily decide they only want to use
-`hello-world` if they don’t want the `derive` functionality.
+`hello_macro` if they don’t want the `derive` functionality.
 
-We need to declare that the `hello-world-derive` crate is a procedural macro
+We need to declare that the `hello_macro_derive` crate is a procedural macro
 crate. We also need to add dependencies on the `syn` and `quote` crates to get
 useful functionality for operating on Rust code. To do these two things, add
-the following to the *Cargo.toml* for `hello-world-derive`:
+the following to the *Cargo.toml* for `hello_macro_derive`:
 
-<span class="filename">Filename: hello-world-derive/Cargo.toml</span>
+<span class="filename">Filename: hello_macro_derive/Cargo.toml</span>
 
 ```toml
 [lib]
@@ -299,15 +299,15 @@ quote = "0.3.15"
 ```
 
 To start defining the procedural macro, place the code from Listing A4-2 in
-*src/lib.rs* for the `hello-world-derive` crate. Note that this won’t compile
-until we add a definition for the `impl_hello_world` function. We’ve split the
+*src/lib.rs* for the `hello_macro_derive` crate. Note that this won’t compile
+until we add a definition for the `impl_hello_macro` function. We’ve split the
 code into functions in this way because the code in Listing A4-2 will be the
 same for almost every procedural macro crate; it’s code that makes writing a
 procedural macro more convenient. What you choose to do in the place where the
-`impl_hello_world` function is called will be different and depend on the
+`impl_hello_macro` function is called will be different and depend on the
 purpose of your procedural macro.
 
-<span class="filename">Filename: hello-world-derive/src/lib.rs</span>
+<span class="filename">Filename: hello_macro_derive/src/lib.rs</span>
 
 ```rust,ignore
 extern crate proc_macro;
@@ -317,8 +317,8 @@ extern crate quote;
 
 use proc_macro::TokenStream;
 
-#[proc_macro_derive(HelloWorld)]
-pub fn hello_world_derive(input: TokenStream) -> TokenStream {
+#[proc_macro_derive(HelloMacro)]
+pub fn hello_macro_derive(input: TokenStream) -> TokenStream {
     // Construct a string representation of the type definition
     let s = input.to_string();
 
@@ -326,7 +326,7 @@ pub fn hello_world_derive(input: TokenStream) -> TokenStream {
     let ast = syn::parse_derive_input(&s).unwrap();
 
     // Build the impl
-    let gen = impl_hello_world(&ast);
+    let gen = impl_hello_macro(&ast);
 
     // Return the generated impl
     gen.parse().unwrap()
@@ -348,18 +348,18 @@ to handle: writing a full parser for Rust code is no simple task.
 [`syn`]: https://crates.io/crates/syn
 [`quote`]: https://crates.io/crates/quote
 
-The `hello_world_derive` function is the code that will get called when a user
-of our library specifies the `#[derive(HelloWorld)]` annotation on a type
-because we’ve annotated the `hello_world_derive` function here with
-`proc_macro_derive` and specified the same name, `HelloWorld`. This name
-matches our trait named `HelloWorld`; that’s the convention most procedural
+The `hello_macro_derive` function is the code that will get called when a user
+of our library specifies the `#[derive(HelloMacro)]` annotation on a type
+because we’ve annotated the `hello_macro_derive` function here with
+`proc_macro_derive` and specified the same name, `HelloMacro`. This name
+matches our trait named `HelloMacro`; that’s the convention most procedural
 macros follow.
 
 The first thing this function does is convert the `input` from a `TokenStream`
 to a `String` by calling `to_string`. This `String` is a string representation
-of the Rust code for which we are deriving `HelloWorld`. In the example in
+of the Rust code for which we are deriving `HelloMacro`. In the example in
 Listing A4-1, `s` will have the `String` value `struct Pancakes;` because
-that’s the Rust code we added the `#[derive(HelloWorld)]` annotation to.
+that’s the Rust code we added the `#[derive(HelloMacro)]` annotation to.
 
 At the moment, the only thing you can do with a `TokenStream` is convert it to
 a string. A richer API will exist in the future.
@@ -391,10 +391,10 @@ API docs for `DeriveInput`][syn-docs] for more information.
 
 [syn-docs]: https://docs.rs/syn/0.11.11/syn/struct.DeriveInput.html
 
-We haven’t defined the `impl_hello_world` function; that’s where we’ll build
+We haven’t defined the `impl_hello_macro` function; that’s where we’ll build
 the new Rust code we want to include. Before we get to that, the last part of
-this `hello_world_derive` function is using the `quote` crate’s `parse`
-function to turn the output of the `impl_hello_world` function back into a
+this `hello_macro_derive` function is using the `quote` crate’s `parse`
+function to turn the output of the `impl_hello_macro` function back into a
 `TokenStream`. The returned `TokenStream` is added to the code that users of
 our crate write so that when they compile their crate, they get extra
 functionality we provide.
@@ -410,18 +410,18 @@ using `expect` or `panic!`.
 
 Now that we have the code to turn the annotated Rust code from a `TokenStream`
 into a `String` and into a `DeriveInput` instance, let’s write the code that
-will generate the code implementing the `HelloWorld` trait on the annotated
+will generate the code implementing the `HelloMacro` trait on the annotated
 type:
 
-<span class="filename">Filename: hello-world-derive/src/lib.rs</span>
+<span class="filename">Filename: hello_macro_derive/src/lib.rs</span>
 
 ```rust,ignore
-fn impl_hello_world(ast: &syn::DeriveInput) -> quote::Tokens {
+fn impl_hello_macro(ast: &syn::DeriveInput) -> quote::Tokens {
     let name = &ast.ident;
     quote! {
-        impl HelloWorld for #name {
-            fn hello_world() {
-                println!("Hello, World! My name is {}", stringify!(#name));
+        impl HelloMacro for #name {
+            fn hello_macro() {
+                println!("Hello, Macro! My name is {}", stringify!(#name));
             }
         }
     }
@@ -442,10 +442,10 @@ crate’s docs][quote-docs] for a thorough introduction.
 [quote-docs]: https://docs.rs/quote
 
 What we want to do for our procedural macro is generate an implementation of
-our `HelloWorld` trait for the type the user of our crate has annotated, which
+our `HelloMacro` trait for the type the user of our crate has annotated, which
 we can get by using `#name`. The trait implementation has one function,
-`hello_world`, and the function body contains the functionality we want to
-provide: printing `Hello, World! My name is` and then the name of the type the
+`hello_macro`, and the function body contains the functionality we want to
+provide: printing `Hello, Macro! My name is` and then the name of the type the
 user of our crate has annotated. The `stringify!` macro used here is built into
 Rust. It takes a Rust expression, such as `1 + 2`, and at compile time turns
 the expression into a string literal, such as `"1 + 2"`. This is different than
@@ -454,25 +454,25 @@ into a `String`. There’s a possibility that `#name` would be an expression tha
 we would want to print out literally, and `stringify!` also saves an allocation
 by converting `#name` to a string literal at compile time.
 
-At this point, `cargo build` should complete successfully in both `hello-world`
-and `hello-world-derive`. Let’s hook these crates up to the code in Listing
+At this point, `cargo build` should complete successfully in both `hello_macro`
+and `hello_macro_derive`. Let’s hook these crates up to the code in Listing
 A4-1 to see it in action! Create a new binary project in your `projects`
-directory with `cargo new --bin pancakes`. We need to add both `hello-world`
-and `hello-world-derive` as dependencies in the `pancakes` crate’s
-*Cargo.toml*. If you’ve chosen to publish your versions of `hello-world` and
-`hello-world-derive` to *https://crates.io* they would be regular dependencies;
+directory with `cargo new --bin pancakes`. We need to add both `hello_macro`
+and `hello_macro_derive` as dependencies in the `pancakes` crate’s
+*Cargo.toml*. If you’ve chosen to publish your versions of `hello_macro` and
+`hello_macro_derive` to *https://crates.io* they would be regular dependencies;
 if not, you can specify them as `path` dependencies as follows:
 
 ```toml
 [dependencies]
-hello-world = { path = "../hello-world" }
-hello-world-derive = { path = "../hello-world/hello-world-derive" }
+hello_macro = { path = "../hello_macro" }
+hello_macro_derive = { path = "../hello_macro/hello_macro_derive" }
 ```
 
 Put the code from Listing A4-1 into *src/main.rs*, and executing `cargo run`
-should print `Hello, World! My name is Pancakes`! The implementation of the
-`HelloWorld` trait from the procedural macro was included without the
-`pancakes` crate needing to implement it; the `#[derive(HelloWorld)]` took care
+should print `Hello, Macro! My name is Pancakes`! The implementation of the
+`HelloMacro` trait from the procedural macro was included without the
+`pancakes` crate needing to implement it; the `#[derive(HelloMacro)]` took care
 of adding the trait implementation.
 
 ## The Future of Macros


### PR DESCRIPTION
The appendix declares packages creation using hyphens in the packages'
names (`cargo new hello-world` and `cargo new hello-world-derive`).
Since that the correct import in the `pancakes` project have to be as
provided in this commit.