### PR TITLE
[Appendix E] Edit Ukrainian item

### DIFF
--- a/second-edition/src/appendix-05-translation.md
+++ b/second-edition/src/appendix-05-translation.md
@@ -9,7 +9,7 @@ For resources in languages other than English. Most are still in progress; see
 - [Português](https://github.com/nunojesus/rust-book-pt-pt) (PT)
 - [Tiếng việt](https://github.com/hngnaig/rust-lang-book/tree/vi-VN)
 - [简体中文](http://www.broadview.com.cn/article/144), [alternate](https://github.com/KaiserY/trpl-zh-cn)
-- [українська мова](https://github.com/pavloslav/rust-book-uk-ua)
+- [Українська](https://github.com/pavloslav/rust-book-uk-ua)
 - [Español](https://github.com/thecodix/book)
 - [Italiano](https://github.com/CodelessFuture/trpl2-it)
 - [Русский](https://github.com/iDeBugger/rust-book-ru)


### PR DESCRIPTION
- _"українська мова"_ literally stands for _"Ukrainian language"_. Since other items do not use _"language"_ word it is better to do same for the edited one.

- Ukrainian language does not have requirement to capitalize language names (same for Russian orthographic rules). Nevertheless in the context of other language names being capitalized it is better to capitalize the edited one as well.
