### PR TITLE
Chapter 13.3 Cleaned up example 13-27

### DIFF
--- a/second-edition/src/ch13-03-improving-our-io-project.md
+++ b/second-edition/src/ch13-03-improving-our-io-project.md
@@ -131,7 +131,7 @@ Listing 12-23 to use the `next` method:
 <span class="filename">Filename: src/lib.rs</span>
 
 ```rust
-#fn main() {}
+# fn main() {}
 # use std::env;
 #
 # struct Config {

--- a/second-edition/src/ch13-03-improving-our-io-project.md
+++ b/second-edition/src/ch13-03-improving-our-io-project.md
@@ -131,6 +131,7 @@ Listing 12-23 to use the `next` method:
 <span class="filename">Filename: src/lib.rs</span>
 
 ```rust
+#fn main() {}
 # use std::env;
 #
 # struct Config {


### PR DESCRIPTION
Example is in src/lib.rs and does not need main()
line 134- Added # fn main() {}
Hidden fn main is here to disable the automatic wrapping in fn main that
doc tests do

