### PR TITLE
ch15-04-rc: use self::List

### DIFF
--- a/second-edition/src/ch15-04-rc.md
+++ b/second-edition/src/ch15-04-rc.md
@@ -56,7 +56,7 @@ enum List {
     Nil,
 }
 
-use List::{Cons, Nil};
+use self::List::{Cons, Nil};
 
 fn main() {
     let a = Cons(5,
@@ -115,7 +115,7 @@ enum List {
     Nil,
 }
 
-use List::{Cons, Nil};
+use self::List::{Cons, Nil};
 use std::rc::Rc;
 
 fn main() {
@@ -166,7 +166,7 @@ type also has a `weak_count`; we’ll see what `weak_count` is used for in the
 #     Nil,
 # }
 #
-# use List::{Cons, Nil};
+# use self::List::{Cons, Nil};
 # use std::rc::Rc;
 #
 fn main() {


### PR DESCRIPTION
I was trying to compile the code example, but was getting errors about "Unresolved import List". Instead the compiler suggested we use `self::List`. This PR reflects those suggestions in the example code. Thanks!
