### PR TITLE
Fix unit abbreviation

### DIFF
--- a/first-edition/src/the-stack-and-the-heap.md
+++ b/first-edition/src/the-stack-and-the-heap.md
@@ -240,7 +240,7 @@ like this:
 | 1                    | y    | 42                     |
 | 0                    | x    | → (2<sup>30</sup>) - 1 |
 
-We have (2<sup>30</sup>) addresses in our hypothetical computer with 1GB of RAM. And since
+We have (2<sup>30</sup>) addresses in our hypothetical computer with 1GiB of RAM. And since
 our stack grows from zero, the easiest place to allocate memory is from the
 other end. So our first value is at the highest place in memory. And the value
 of the struct at `x` has a [raw pointer][rawpointer] to the place we’ve


### PR DESCRIPTION
Correction to first edition. The unit symbol for the gibibyte is GiB. 