### PR TITLE
Fixup: std::env::var is a function (not a method)

### DIFF
--- a/second-edition/src/ch12-05-working-with-environment-variables.md
+++ b/second-edition/src/ch12-05-working-with-environment-variables.md
@@ -198,7 +198,7 @@ pub fn run(config: Config) -> Result<(), Box<Error>> {
 Finally, we need to check for the environment variable. The functions for
 working with environment variables are in the `env` module in the standard
 library, so we want to bring that module into scope with a `use std::env;` line
-at the top of *src/lib.rs*. Then we’ll use the `var` method from the `env`
+at the top of *src/lib.rs*. Then we’ll use the `var` function from the `env`
 module to check for an environment variable named `CASE_INSENSITIVE`, as shown
 in Listing 12-23:
 
@@ -235,7 +235,7 @@ impl Config {
 
 Here, we create a new variable `case_sensitive`. To set its value, we call the
 `env::var` function and pass it the name of the `CASE_INSENSITIVE` environment
-variable. The `env::var` method returns a `Result` that will be the successful
+variable. The `env::var` function returns a `Result` that will be the successful
 `Ok` variant that contains the value of the environment variable if the
 environment variable is set. It will return the `Err` variant if the
 environment variable is not set.


### PR DESCRIPTION
[Function `std::env::var`](https://doc.rust-lang.org/std/env/fn.var.html)