### PR TITLE
Minor correction: number => digit

### DIFF
--- a/second-edition/src/ch08-02-strings.md
+++ b/second-edition/src/ch08-02-strings.md
@@ -286,7 +286,7 @@ let len = String::from("Hola").len();
 In this case, `len` will be 4, which means the vector storing the string “Hola”
 is 4 bytes long. Each of these letters takes 1 byte when encoded in UTF-8. But
 what about the following line? (Note that this line begins with the capital
-Cyrillic letter Ze, not the Arabic number 3.)
+Cyrillic letter Ze, not the Arabic digit 3.)
 
 ```rust
 let len = String::from("Здравствуйте").len();


### PR DESCRIPTION
Just a tiny nitpick. Numbers are mathematical entities, like pi or a googolplex; the glyphs used to represent them are digits. :)

It seems this chapter is already way past freeze; I'm submitting this because of @carols10cents's [remark][1] about future revisions.

[1]: https://github.com/rust-lang/book/pull/1235#issuecomment-374954232
