### PR TITLE
index.md: more prominent link to second edition

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,7 +1,7 @@
 # The Rust Programming Language
 
-The current edition of "The Rust Programming Language" is the second
-edition, which you can [read here](second-edition/index.html).
+[The second edition of "The Rust Programming Language"](second-edition/index.html)
+is the current edition.
 
 The source for all editions lives [on GitHub](https://github.com/rust-lang/book).
 Please open issues with any questions, concerns, or tweaks.


### PR DESCRIPTION
https://doc.rust-lang.org/ links to https://doc.rust-lang.org/book/. From there, most people looking for the book’s content likely want to find the link to the second edition. This is hopefully more obvious than "read here" at the end of a paragraph.