### PR TITLE
Listing 15-16 does not use std::mem::drop (copy & paste error)

### DIFF
--- a/second-edition/src/ch15-03-drop.md
+++ b/second-edition/src/ch15-03-drop.md
@@ -153,7 +153,7 @@ an argument. The function is in the prelude, so we can modify `main` in Listing
 fn main() {
     let c = CustomSmartPointer { data: String::from("some data") };
     println!("CustomSmartPointer created.");
-    drop(c);
+    std::mem::drop(c);
     println!("CustomSmartPointer dropped before the end of main.");
 }
 ```


### PR DESCRIPTION
Hi,

Expected:
> Filename: src/main.rs
>
> ```rust
>  fn main() {
>     let c = CustomSmartPointer { data: String::from("some data") };
>     println!("CustomSmartPointer created.");
>     std::mem::drop(c);
>     println!("CustomSmartPointer dropped before the end of main.");
> }
> ```
> Listing 15-16: Calling std::mem::drop to explicitly drop a value before it goes out of scope

Actual via https://doc.rust-lang.org/book/second-edition/ch15-03-drop.html
> Filename: src/main.rs
>
> ```rust
> fn main() {
>     let c = CustomSmartPointer { data: String::from("some data") };
>     println!("CustomSmartPointer created.");
>     drop(c);
>     println!("CustomSmartPointer dropped before the end of main.");
> }
> ```
> Listing 15-16: Calling std::mem::drop to explicitly drop a value before it goes out of scope

Why did this happen? Copy-paste from Listing 15-15.

thanks for providing the rust book!