### PR TITLE
Removing references to `--bin` option when referencing `cargo new`

### DIFF
--- a/2018-edition/src/appendix-04-macros.md
+++ b/2018-edition/src/appendix-04-macros.md
@@ -463,7 +463,7 @@ allocation by converting `#name` to a string literal at compile time.
 At this point, `cargo build` should complete successfully in both `hello_macro`
 and `hello_macro_derive`. Let’s hook up these crates to the code in Listing D-2
 to see the procedural macro in action! Create a new binary project in your
-*projects* directory using `cargo new --bin pancakes`. We need to add
+*projects* directory using `cargo new pancakes`. We need to add
 `hello_macro` and `hello_macro_derive` as dependencies in the `pancakes`
 crate’s *Cargo.toml*. If you’re publishing your versions of `hello_macro` and
 `hello_macro_derive` to *https://crates.io/*, they would be regular

--- a/2018-edition/src/ch01-03-hello-cargo.md
+++ b/2018-edition/src/ch01-03-hello-cargo.md
@@ -33,14 +33,13 @@ wherever you decided to store your code). Then, on any operating system, run
 the following:
 
 ```text
-$ cargo new hello_cargo --bin
+$ cargo new hello_cargo
 $ cd hello_cargo
 ```
 
-The first command creates a new binary executable called *hello_cargo*. The
-`--bin` argument passed to `cargo new` makes an executable application (often
-just called a *binary*) as opposed to a library. We’ve named our project
-*hello_cargo*, and Cargo creates its files in a directory of the same name.
+The first command creates a new binary executable called *hello_cargo*.
+We’ve named our project *hello_cargo*, and Cargo creates its files in a directory 
+of the same name.
 
 Go into the *hello_cargo* directory and list the files. You’ll see that Cargo
 has generated two files and one directory for us: a *Cargo.toml* file and a

--- a/2018-edition/src/ch02-00-guessing-game-tutorial.md
+++ b/2018-edition/src/ch02-00-guessing-game-tutorial.md
@@ -18,13 +18,12 @@ To set up a new project, go to the *projects* directory that you created in
 Chapter 1 and make a new project using Cargo, like so:
 
 ```text
-$ cargo new guessing_game --bin
+$ cargo new guessing_game
 $ cd guessing_game
 ```
 
 The first command, `cargo new`, takes the name of the project (`guessing_game`)
-as the first argument. The `--bin` flag tells Cargo to make a binary project,
-like the one in Chapter 1. The second command changes to the new project’s
+as the first argument. The second command changes to the new project’s
 directory.
 
 Look at the generated *Cargo.toml* file:

--- a/2018-edition/src/ch03-01-variables-and-mutability.md
+++ b/2018-edition/src/ch03-01-variables-and-mutability.md
@@ -9,7 +9,7 @@ out.
 
 When a variable is immutable, once a value is bound to a name, you can’t change
 that value. To illustrate this, let’s generate a new project called *variables*
-in your *projects* directory by using `cargo new --bin variables`.
+in your *projects* directory by using `cargo new variables`.
 
 Then, in your new *variables* directory, open *src/main.rs* and replace its
 code with the following code that won’t compile just yet:

--- a/2018-edition/src/ch07-01-mod-and-the-filesystem.md
+++ b/2018-edition/src/ch07-01-mod-and-the-filesystem.md
@@ -10,7 +10,7 @@ We’ll create a skeleton of a library that provides some general networking
 functionality; we’ll concentrate on the organization of the modules and
 functions, but we won’t worry about what code goes in the function bodies.
 We’ll call our library `communicator`. To create a library, pass the `--lib`
-option instead of `--bin`:
+option:
 
 ```text
 $ cargo new communicator --lib
@@ -32,8 +32,7 @@ mod tests {
 }
 ```
 
-Cargo creates an example test to help us get our library started, rather than
-the “Hello, world!” binary that we get when we use the `--bin` option. We’ll
+Cargo creates an example test to help us get our library started. We’ll
 look at the `#[]` and `mod tests` syntax in the “Using `super` to Access a
 Parent Module” section later in this chapter, but for now, leave this code at
 the bottom of *src/lib.rs*.

--- a/2018-edition/src/ch12-01-accepting-command-line-arguments.md
+++ b/2018-edition/src/ch12-01-accepting-command-line-arguments.md
@@ -5,7 +5,7 @@ Let’s create a new project with, as always, `cargo new`. We’ll call our proj
 on your system.
 
 ```text
-$ cargo new --bin minigrep
+$ cargo new minigrep
      Created binary (application) `minigrep` project
 $ cd minigrep
 ```

--- a/2018-edition/src/ch14-03-cargo-workspaces.md
+++ b/2018-edition/src/ch14-03-cargo-workspaces.md
@@ -44,7 +44,7 @@ Next, we’ll create the `adder` binary crate by running `cargo new` within the
 *add* directory:
 
 ```text
-$ cargo new --bin adder
+$ cargo new adder
      Created binary (application) `adder` project
 ```
 

--- a/2018-edition/src/ch20-01-single-threaded.md
+++ b/2018-edition/src/ch20-01-single-threaded.md
@@ -26,7 +26,7 @@ we’ll work on. The standard library offers a `std::net` module that lets us do
 this. Let’s make a new project in the usual fashion:
 
 ```text
-$ cargo new hello --bin
+$ cargo new hello
      Created binary (application) `hello` project
 $ cd hello
 ```


### PR DESCRIPTION
Reflecting changes made in Rust 1.25 since flag `--bin` is now the
default behavior for `cargo new`

I'm a new rust user using the nightly edition as a reference book. With the Rust 1.25 release I thought updating the book to reflect the `cargo new` default to binary change would be useful for other readers.

## What to expect when you open a pull request here

### 2018 Edition

The 2018 is a "living" edition; it's not scheduled for in-print publication at
this time, and so is able to be updated at any time. We'd love pull requests to
fix issues with this edition, but we're not interested in extremely large
changes without discussing them first. If you'd like to make a big change,
please open an issue first! We'd hate for you to do some hard work that we
ultimately wouldn't accept.

### Second edition

For the second edition, we are currently working with No Starch Press to bring
it to print. Chapters go through a number of stages in the editing process, and
once they've gotten to the layout stage, they're effectively frozen.

For chapters that have gotten to the layout stage, we will likely only be
accepting changes that correct factual errors or major problems and not, for
example, minor wording changes.

Scroll all the way to the right on https://github.com/rust-lang/book/projects/1
to see which chapters have been frozen.

Please see CONTRIBUTING.md for more details.

### First edition

The first edition is frozen, and no longer accepting changes. Pull requests
made against it will be closed.


Thank you for reading, you may now delete this text!
