### PR TITLE
Correct CJK `ideographs` to CJK `characters`

### DIFF
--- a/2018-edition/src/ch03-02-data-types.md
+++ b/2018-edition/src/ch03-02-data-types.md
@@ -191,7 +191,7 @@ fn main() {
 
 Rust’s `char` type represents a Unicode Scalar Value, which means it can
 represent a lot more than just ASCII. Accented letters; Chinese, Japanese, and
-Korean ideographs; emoji; and zero-width spaces are all valid `char` values in
+Korean characters; emoji; and zero-width spaces are all valid `char` values in
 Rust. Unicode Scalar Values range from `U+0000` to `U+D7FF` and `U+E000` to
 `U+10FFFF` inclusive. However, a “character” isn’t really a concept in Unicode,
 so your human intuition for what a “character” is may not match up with what a


### PR DESCRIPTION
See #1327. It changes only 2018 edition.