### PR TITLE
Use new `rustup override set` instead of `... add`

### DIFF
--- a/2018-edition/src/appendix-07-nightly-rust.md
+++ b/2018-edition/src/appendix-07-nightly-rust.md
@@ -167,7 +167,7 @@ nightly toolchain as the one `rustup` should use when you’re in that directory
 
 ```text
 $ cd ~/projects/needs-nightly
-$ rustup override add nightly
+$ rustup override set nightly
 ```
 
 Now, every time you call `rustc` or `cargo` inside of


### PR DESCRIPTION
Since rustup version 0.1.10, `rustup override set` has replaced
`rustup override add`, with `add` left as a synonym for backwards
compatibility. Consequently, readers who want to dig into
the command might run `rustup override help` and notice
that `add` is not mentioned anywhere in the help.

Fixes #1156 
