### PR TITLE
Removes 'main{' and '}' from listing 11-12 so it compiles.

### DIFF
--- a/2018-edition/src/ch11-03-test-organization.md
+++ b/2018-edition/src/ch11-03-test-organization.md
@@ -66,7 +66,9 @@ Consider the code in Listing 11-12 with the private function `internal_adder`:
 
 <span class="filename">Filename: src/lib.rs</span>
 
-```rust,ignore
+```rust
+# fn main() {}
+
 pub fn add_two(a: i32) -> i32 {
     internal_adder(a, 2)
 }

--- a/2018-edition/src/ch11-03-test-organization.md
+++ b/2018-edition/src/ch11-03-test-organization.md
@@ -66,7 +66,7 @@ Consider the code in Listing 11-12 with the private function `internal_adder`:
 
 <span class="filename">Filename: src/lib.rs</span>
 
-```rust
+```rust,ignore
 pub fn add_two(a: i32) -> i32 {
     internal_adder(a, 2)
 }


### PR DESCRIPTION
Code snipet was not marked as " ```rust,ignore", then when copied it was surrounded with a "main {}" block which prevented it fom compiling.