### PR TITLE
Fix Incorrect Example

### DIFF
--- a/second-edition/src/ch11-01-writing-tests.md
+++ b/second-edition/src/ch11-01-writing-tests.md
@@ -474,7 +474,7 @@ functions that assert two values are equal are called `expected` and `actual`,
 and the order in which we specify the arguments matters. However, in Rust,
 they’re called `left` and `right`, and the order in which we specify the value
 we expect and the value that the code under test produces doesn’t matter. We
-could write the assertion in this test as `assert_eq!(add_two(2), 4)`, which
+could write the assertion in this test as `assert_eq!(add_two(3), 4)`, which
 would result in a failure message that displays `` assertion failed: `(left ==
 right)` `` and that `left` was `5` and `right` was `4`.
 


### PR DESCRIPTION
examples shows assert_eq!(shows add_two(2),4) would result in left = 5 and right = 4. Updated numbers to match this conclusion.

## What to expect when you open a pull request here

### 2018 Edition

The 2018 is a "living" edition; it's not scheduled for in-print publication at
this time, and so is able to be updated at any time. We'd love pull requests to
fix issues with this edition, but we're not interested in extremely large
changes without discussing them first. If you'd like to make a big change,
please open an issue first! We'd hate for you to do some hard work that we
ultimately wouldn't accept.

### Second edition

For the second edition, we are currently working with No Starch Press to bring
it to print. Chapters go through a number of stages in the editing process, and
once they've gotten to the layout stage, they're effectively frozen.

For chapters that have gotten to the layout stage, we will likely only be
accepting changes that correct factual errors or major problems and not, for
example, minor wording changes.

Scroll all the way to the right on https://github.com/rust-lang/book/projects/1
to see which chapters have been frozen.

Please see CONTRIBUTING.md for more details.

### First edition

The first edition is frozen, and no longer accepting changes. Pull requests
made against it will be closed.


Thank you for reading, you may now delete this text!
