### PR TITLE
fix typo, improve wording

### DIFF
--- a/2018-edition/src/ch02-00-guessing-game-tutorial.md
+++ b/2018-edition/src/ch02-00-guessing-game-tutorial.md
@@ -155,11 +155,11 @@ line. Notice that this is a `let` statement, which is used to create a
 let foo = bar;
 ```
 
-This line creates a new variable named `foo` and bind it to the value `bar`. In
-Rust, variables are immutable by default. We’ll be discussing this concept in
-detail in the “Variables and Mutability” section in Chapter 3. The following
-example shows how to use `mut` before the variable name to make a variable
-mutable:
+This line creates a new variable named `foo` and binds it to the value of the
+`bar` variable. In Rust, variables are immutable by default. We’ll be
+discussing this concept in detail in the “Variables and Mutability” section in
+Chapter 3. The following example shows how to use `mut` before the variable
+name to make a variable mutable:
 
 ```rust,ignore
 let foo = 5; // immutable


### PR DESCRIPTION
This PR fixes a typo `bind/binds` and clarifies that the `foo` variable is bound the value of the `bar` variable, not to the value `bar`.

Thanks