### PR TITLE
Specify that literals use quotes and not types

### DIFF
--- a/second-edition/src/ch03-02-data-types.md
+++ b/second-edition/src/ch03-02-data-types.md
@@ -176,8 +176,8 @@ section.
 
 So far we’ve worked only with numbers, but Rust supports letters too. Rust’s
 `char` type is the language’s most primitive alphabetic type, and the following
-code shows one way to use it. (Note that the `char` type is specified with
-single quotes, as opposed to strings, which use double quotes.)
+code shows one way to use it. (Note that the `char` literal is specified with
+single quotes, as opposed to string literals, which use double quotes.)
 
 <span class="filename">Filename: src/main.rs</span>
 


### PR DESCRIPTION
It is incorrect to say that the char type uses single quotes; it is the
char literal that uses single quotes.

## What to expect when you open a pull request here

### 2018 Edition

The 2018 is a "living" edition; it's not scheduled for in-print publication at
this time, and so is able to be updated at any time. We'd love pull requests to
fix issues with this edition, but we're not interested in extremely large
changes without discussing them first. If you'd like to make a big change,
please open an issue first! We'd hate for you to do some hard work that we
ultimately wouldn't accept.

### Second edition

No Starch Press has brought the second edition to print. Pull requests fixing
factual errors will be accepted and documented as errata; pull requests changing
wording or other small corrections should be made against the 2018 edition instead.

### First edition

The first edition is frozen, and no longer accepting changes. Pull requests
made against it will be closed.


Thank you for reading, you may now delete this text!
