### PR TITLE
Fix off-by-one error in slice example

### DIFF
--- a/second-edition/src/ch04-03-slices.md
+++ b/second-edition/src/ch04-03-slices.md
@@ -159,7 +159,7 @@ in the slice and `ending_index` is one more than the last position in the
 slice. Internally, the slice data structure stores the starting position and
 the length of the slice, which corresponds to `ending_index` minus
 `starting_index`. So in the case of `let world = &s[6..11];`, `world` would be
-a slice that contains a pointer to the 6th byte of `s` with a length value of 5.
+a slice that contains a pointer to the 7th byte of `s` with a length value of 5.
 
 Figure 4-6 shows this in a diagram.
 


### PR DESCRIPTION
Using 0-based indexing, &s[6..11] would start _after_ the 6th byte of `s`, and the first element of the slice would contain the 7th byte of `s`.  For example, &s[0] references the 1st byte of `s`.