### PR TITLE
Update ch14-03-cargo-workspaces.md

### DIFF
--- a/2018-edition/src/ch14-03-cargo-workspaces.md
+++ b/2018-edition/src/ch14-03-cargo-workspaces.md
@@ -92,7 +92,7 @@ members = [
 Then generate a new library crate named `add-one`:
 
 ```text
-$ cargo new add-one
+$ cargo new add-one --lib
      Created library `add-one` project
 ```
 


### PR DESCRIPTION
```
➜  ~ cargo new add-one
     Created binary (application) `add-one` project
```

Will not produce a library as expected by the author and as required by the example.