### PR TITLE
Tweak description of ? operator

### DIFF
--- a/2018-edition/src/ch09-02-recoverable-errors-with-result.md
+++ b/2018-edition/src/ch09-02-recoverable-errors-with-result.md
@@ -379,12 +379,12 @@ The `?` placed after a `Result` value is defined to work in almost the same way
 as the `match` expressions we defined to handle the `Result` values in Listing
 9-6. If the value of the `Result` is an `Ok`, the value inside the `Ok` will
 get returned from this expression, and the program will continue. If the value
-is an `Err`, the value inside the `Err` will be returned from the whole
-function as if we had used the `return` keyword so the error value gets
-propagated to the calling code.
+is an `Err`, the `Err` will be returned from the whole function as if we had
+used the `return` keyword so the error value gets propagated to the calling
+code.
 
 There is a difference between what the `match` expression from Listing 9-6 and
-`?` do: error values used with `?` go through the `from` function, defined in
+`?` do: error values taken by `?` go through the `from` function, defined in
 the `From` trait in the standard library, which is used to convert errors from
 one type into another. When `?` calls the `from` function, the error type
 received is converted into the error type defined in the return type of the


### PR DESCRIPTION
Amends the description of the ? operator's behaviour: if Ok, returns the value inside the Ok; if Err, returns the whole Err, not just the value inside.

Clarifies the para following.  'used with' is imprecise.  The user 'uses' the ? operator with error values generally, but it's not clear whether the error value parameter or the returned error value of ? is the subject of the sentence.  Operators do not generally 'use' parameters.  More precisely, the error value 'taken by' ? goes through `from` before being returned.