### PR TITLE
Fix a typo

### DIFF
--- a/2018-edition/src/appendix-07-nightly-rust.md
+++ b/2018-edition/src/appendix-07-nightly-rust.md
@@ -164,7 +164,7 @@ nightly toolchain as the one `rustup` should use when you’re in that directory
 
 ```text
 $ cd ~/projects/needs-nightly
-$ rustup override add nightly
+$ rustup override set nightly
 ```
 
 Now, every time you call `rustc` or `cargo` inside of


### PR DESCRIPTION
A subcommand that sets the toolchain for a directory is `set`.

```
$ rustup override -h
...
SUBCOMMANDS:
    list     List directory toolchain overrides
    set      Set the override toolchain for a directory
    unset    Remove the override toolchain for a directory
    help     Prints this message or the help of the given subcommand(s)
```

Strictly speaking, `add` also works, but is not listed in the help message or [`rustup`'s documentation](https://github.com/rust-lang-nursery/rustup.rs/blob/master/README.md).