### PR TITLE
String variable should be mutable in Listing 4-6

### DIFF
--- a/2018-edition/src/ch04-02-references-and-borrowing.md
+++ b/2018-edition/src/ch04-02-references-and-borrowing.md
@@ -85,7 +85,7 @@ Listing 4-6. Spoiler alert: it doesn’t work!
 
 ```rust,ignore
 fn main() {
-    let s = String::from("hello");
+    let mut s = String::from("hello");
 
     change(&s);
 }


### PR DESCRIPTION
The aim of Listing 4-6 is to demonstrate that a String passed by reference cannot be modified, however, as the example code is written the string could not be modified anyway because it is immutable. The proposed change is to make it mutable so that the only problem in the example code has to do with modifying a borrowed object. (I've only been writing Rust code for 48 hours so please take that into consideration when evaluating this edit.)

## What to expect when you open a pull request here

### 2018 Edition

The 2018 is a "living" edition; it's not scheduled for in-print publication at
this time, and so is able to be updated at any time. We'd love pull requests to
fix issues with this edition, but we're not interested in extremely large
changes without discussing them first. If you'd like to make a big change,
please open an issue first! We'd hate for you to do some hard work that we
ultimately wouldn't accept.

### Second edition

No Starch Press has brought the second edition to print. Pull requests fixing
factual errors will be accepted and documented as errata; pull requests changing
wording or other small corrections should be made against the 2018 edition instead.

### First edition

The first edition is frozen, and no longer accepting changes. Pull requests
made against it will be closed.


Thank you for reading, you may now delete this text!
