### PR TITLE
fix no '$ ls' in PowerShell

### DIFF
--- a/2018-edition/src/ch01-02-hello-world.md
+++ b/2018-edition/src/ch01-02-hello-world.md
@@ -169,7 +169,6 @@ main  main.rs
 With PowerShell on Windows, you can use `ls` as well, but you'll see three files:
 
 ```text
-$ls
 > ls
 
 


### PR DESCRIPTION
`$ ls` just in Linux and macOS, not in PowerShell.