### PR TITLE
fix dot should out side of `Default`

### DIFF
--- a/2018-edition/src/appendix-03-derivable-traits.md
+++ b/2018-edition/src/appendix-03-derivable-traits.md
@@ -160,7 +160,7 @@ The `Default` trait allows you to create a default value for a type. Deriving
 `Default` implements the `default` function. The derived implementation of the
 `default` function calls the `default` function on each part of the type,
 meaning all fields or values in the type must also implement `Default` to
-derive `Default.`
+derive `Default`.
 
 The `Default::default` function is commonly used in combination with the struct
 update syntax discussed in the “Creating Instances From Other Instances With

--- a/2018-edition/src/ch10-02-traits.md
+++ b/2018-edition/src/ch10-02-traits.md
@@ -369,7 +369,7 @@ needing to write out a really long type.
 This only works if you have a single type that you're returning, however.
 For example, this would *not* work:
 
-```rust
+```rust,ignore
 fn returns_summarizable(switch: bool) -> impl Summary {
     if switch {
         NewsArticle {


### PR DESCRIPTION
fix dot should out side of `Default`