### PR TITLE
Remove public/private ambiguity from ch12 search function

### DIFF
--- a/2018-edition/src/ch12-04-testing-the-librarys-functionality.md
+++ b/2018-edition/src/ch12-04-testing-the-librarys-functionality.md
@@ -81,7 +81,7 @@ containing the line `"safe, fast, productive."`
 <span class="filename">Filename: src/lib.rs</span>
 
 ```rust
-pub fn search<'a>(query: &str, contents: &'a str) -> Vec<&'a str> {
+fn search<'a>(query: &str, contents: &'a str) -> Vec<&'a str> {
     vec![]
 }
 ```
@@ -110,7 +110,7 @@ get this error:
 error[E0106]: missing lifetime specifier
  --> src/lib.rs:5:51
   |
-5 | pub fn search(query: &str, contents: &str) -> Vec<&str> {
+5 | fn search(query: &str, contents: &str) -> Vec<&str> {
   |                                                   ^ expected lifetime
 parameter
   |
@@ -182,7 +182,7 @@ won’t compile yet:
 <span class="filename">Filename: src/lib.rs</span>
 
 ```rust,ignore
-pub fn search<'a>(query: &str, contents: &'a str) -> Vec<&'a str> {
+fn search<'a>(query: &str, contents: &'a str) -> Vec<&'a str> {
     for line in contents.lines() {
         // do something with line
     }
@@ -207,7 +207,7 @@ Listing 12-18. Note this still won’t compile yet:
 <span class="filename">Filename: src/lib.rs</span>
 
 ```rust,ignore
-pub fn search<'a>(query: &str, contents: &'a str) -> Vec<&'a str> {
+fn search<'a>(query: &str, contents: &'a str) -> Vec<&'a str> {
     for line in contents.lines() {
         if line.contains(query) {
             // do something with line
@@ -229,7 +229,7 @@ shown in Listing 12-19:
 <span class="filename">Filename: src/lib.rs</span>
 
 ```rust,ignore
-pub fn search<'a>(query: &str, contents: &'a str) -> Vec<&'a str> {
+fn search<'a>(query: &str, contents: &'a str) -> Vec<&'a str> {
     let mut results = Vec::new();
 
     for line in contents.lines() {


### PR DESCRIPTION
This change is to clarify some confusing issues around chapter 12's `search` and `search_case_insensitive` functions.

When they are both initially specified, `search` is public and `search_case_insensitive` is private. In `src/main.rs` as specified, the `search` function is not needed to be public and it is also not necessary for testing in the `src/lib.rs` file. This helps reinforce the idea of private functions being testable from a submodule (`mod tests`).