### PR TITLE
Remove unused codes from ch12-04

### DIFF
--- a/2018-edition/src/ch12-04-testing-the-librarys-functionality.md
+++ b/2018-edition/src/ch12-04-testing-the-librarys-functionality.md
@@ -277,8 +277,6 @@ will print each line returned from `search`:
 
 ```rust,ignore
 pub fn run(config: Config) -> Result<(), Box<dyn Error>> {
-    let mut f = File::open(config.filename)?;
-
     let contents = fs::read_to_string(config.filename)?;
 
     for line in search(&config.query, &contents) {


### PR DESCRIPTION
Remove unused codes from Chapter 12.4, the code example for src/lib.rs after Listing 12-19. 

```rust,ignore
pub fn run(config: Config) -> Result<(), Box<dyn Error>> {
    let mut f = File::open(config.filename)?;  // <--- this line of code is unnecessary and will cause the config.filename move into the method makes the next line of code can't pass config.filename into the method

    let contents = fs::read_to_string(config.filename)?;

    for line in search(&config.query, &contents) {
        println!("{}", line);
    }

    Ok(())
}
```