### PR TITLE
Fix typo

### DIFF
--- a/2018-edition/src/ch12-03-improving-error-handling-and-modularity.md
+++ b/2018-edition/src/ch12-03-improving-error-handling-and-modularity.md
@@ -607,7 +607,7 @@ compile until we modify *src/main.rs* in the listing after this one.
 
 ```rust,ignore
 use std::error::Error;
-use std::fs::File;
+use std::fs;
 use std::io::prelude::*;
 
 pub struct Config {


### PR DESCRIPTION
In Chapter 12.3, Listing 12-13, I think at here should use `std::fs;` instead of `std::fs::File;` since we are using fs::read_to_string in function run. 

```rust
use std::error::Error;
use std::fs::File;  // <--- this one should be using std::fs; since we are using fs::read_to_string() in run function
use std::io::prelude::*;

pub struct Config {
    pub query: String,
    pub filename: String,
}

impl Config {
    pub fn new(args: &[String]) -> Result<Config, &'static str> {
        // --snip--
    }
}

pub fn run(config: Config) -> Result<(), Box<dyn Error>> {
    // --snip--
}
```