### PR TITLE
Fixed output text for cargo check

### DIFF
--- a/2018-edition/src/ch01-03-hello-cargo.md
+++ b/2018-edition/src/ch01-03-hello-cargo.md
@@ -169,7 +169,7 @@ your code to make sure it compiles but doesn’t produce an executable:
 
 ```text
 $ cargo check
-   Compiling hello_cargo v0.1.0 (file:///projects/hello_cargo)
+   Checking hello_cargo v0.1.0 (file:///projects/hello_cargo)
     Finished dev [unoptimized + debuginfo] target(s) in 0.32 secs
 ```
 


### PR DESCRIPTION
The output of cargo check seems to start with "Checking ..." as opposed to "Compiling..." as it is listed in the book.

## What to expect when you open a pull request here

### 2018 Edition

The 2018 is a "living" edition; it's not scheduled for in-print publication at
this time, and so is able to be updated at any time. We'd love pull requests to
fix issues with this edition, but we're not interested in extremely large
changes without discussing them first. If you'd like to make a big change,
please open an issue first! We'd hate for you to do some hard work that we
ultimately wouldn't accept.

### Second edition

No Starch Press has brought the second edition to print. Pull requests fixing
factual errors will be accepted and documented as errata; pull requests changing
wording or other small corrections should be made against the 2018 edition instead.

### First edition

The first edition is frozen, and no longer accepting changes. Pull requests
made against it will be closed.


Thank you for reading, you may now delete this text!
