### PR TITLE
Trivial Rectangle::can_hold fix

### DIFF
--- a/2018-edition/src/ch05-03-method-syntax.md
+++ b/2018-edition/src/ch05-03-method-syntax.md
@@ -181,7 +181,7 @@ impl Rectangle {
     }
 
     fn can_hold(&self, other: &Rectangle) -> bool {
-        self.width > other.width && self.height > other.height
+        self.width >= other.width && self.height >= other.height
     }
 }
 ```


### PR DESCRIPTION
A rectangle can technically hold another rectangle of the same size.

This changes the comparison operators used from `>` to `>=`.
