### PR TITLE
Entire String slice is not necessary.

### DIFF
--- a/2018-edition/src/ch04-03-slices.md
+++ b/2018-edition/src/ch04-03-slices.md
@@ -347,7 +347,7 @@ without losing any functionality:
 fn main() {
     let my_string = String::from("hello world");
 
-    // first_word works on slices of `String`s
+    // first_word works on references of `String`s
     let word = first_word(&my_string);
 
     let my_string_literal = "hello world";

--- a/2018-edition/src/ch04-03-slices.md
+++ b/2018-edition/src/ch04-03-slices.md
@@ -326,7 +326,7 @@ fn first_word(s: &str) -> &str {
 ```
 
 If we have a string slice, we can pass that directly. If we have a `String`, we
-can pass a slice of the entire `String`. Defining a function to take a string
+can pass the entire `String` reference. Defining a function to take a string
 slice instead of a reference to a `String` makes our API more general and useful
 without losing any functionality:
 
@@ -348,7 +348,7 @@ fn main() {
     let my_string = String::from("hello world");
 
     // first_word works on slices of `String`s
-    let word = first_word(&my_string[..]);
+    let word = first_word(&my_string);
 
     let my_string_literal = "hello world";
 


### PR DESCRIPTION
Didn't test the same for second edition because I don't use Rust 1.21.0 (but I'm reading second edition).