### PR TITLE
[SNIPPET] Add some crate 'import' in the beginning of a snippet.

### DIFF
--- a/2018-edition/src/ch17-03-oo-design-patterns.md
+++ b/2018-edition/src/ch17-03-oo-design-patterns.md
@@ -528,6 +528,9 @@ Let’s consider the first part of `main` in Listing 17-11:
 <span class="filename">Filename: src/main.rs</span>
 
 ```rust,ignore
+# extern crate blog;
+# use blog::Post;
+
 fn main() {
     let mut post = Post::new();
 


### PR DESCRIPTION
In the 2018 edition, I propose a tiny correction to fix a code snippet.