### PR TITLE
Immutable empty vector

### DIFF
--- a/second-edition/src/ch08-01-vectors.md
+++ b/second-edition/src/ch08-01-vectors.md
@@ -12,7 +12,7 @@ To create a new, empty vector, we can call the `Vec::new` function, as shown in
 Listing 8-1.
 
 ```rust
-let v: Vec<i32> = Vec::new();
+let mut v: Vec<i32> = Vec::new();
 ```
 
 <span class="caption">Listing 8-1: Creating a new, empty vector to hold values


### PR DESCRIPTION
In the first example:
let v: Vec<i32> = Vec::new();
The empty vector is immutable. Nothing can be pushed into it. Would there ever be any reason to create an immutable empty vector? I propose making it mutable.

## What to expect when you open a pull request here

### 2018 Edition

The 2018 is a "living" edition; it's not scheduled for in-print publication at
this time, and so is able to be updated at any time. We'd love pull requests to
fix issues with this edition, but we're not interested in extremely large
changes without discussing them first. If you'd like to make a big change,
please open an issue first! We'd hate for you to do some hard work that we
ultimately wouldn't accept.

### Second edition

No Starch Press has brought the second edition to print. Pull requests fixing
factual errors will be accepted and documented as errata; pull requests changing
wording or other small corrections should be made against the 2018 edition instead.

### First edition

The first edition is frozen, and no longer accepting changes. Pull requests
made against it will be closed.


Thank you for reading, you may now delete this text!
