### PR TITLE
Update 2018-edition/src/ch03-01-variables-and-mutability.md to explain the underscore in '100_000'

### DIFF
--- a/2018-edition/src/ch03-01-variables-and-mutability.md
+++ b/2018-edition/src/ch03-01-variables-and-mutability.md
@@ -127,7 +127,8 @@ computed at runtime.
 
 Here’s an example of a constant declaration where the constant’s name is
 `MAX_POINTS` and its value is set to 100,000. (Rust’s constant naming
-convention is to use all uppercase with underscores between words):
+convention is to use all uppercase with underscores between words,
+and underscores can be inserted in numeric literals to improve readability):
 
 ```rust
 const MAX_POINTS: u32 = 100_000;


### PR DESCRIPTION
Reading [this page](https://doc.rust-lang.org/book/second-edition/ch03-01-variables-and-mutability.html#differences-between-variables-and-constants) in the book, it took me longer than I'd like to admit to figure out whether the underscore in "100_000" in the code sample was a required rust formatting thing or just a stylistic preference. 

I feel like it would be useful for newcomers to explain this a bit (or maybe just link to the [literals page](https://doc.rust-lang.org/stable/rust-by-example/primitives/literals.html) at this point).