### PR TITLE
ch20-02-multithreaded.md listing 20-21: deleting 'dyn' for call_box

### DIFF
--- a/2018-edition/src/ch20-02-multithreaded.md
+++ b/2018-edition/src/ch20-02-multithreaded.md
@@ -1020,11 +1020,11 @@ shown in Listing 20-21.
 
 ```rust,ignore
 trait FnBox {
-    fn call_box(self: Box<dyn Self>);
+    fn call_box(self: Box<Self>);
 }
 
 impl<F: FnOnce()> FnBox for F {
-    fn call_box(self: Box<dyn F>) {
+    fn call_box(self: Box<F>) {
         (*self)()
     }
 }


### PR DESCRIPTION
Issue: #1459 

2018 edition
chapter 20-02-multithreaded.md listing 20-21
does not compile because of 'dyn' keyword.