### PR TITLE
Fix an unused import warning in minigrep

### DIFF
--- a/2018-edition/src/ch12-02-reading-a-file.md
+++ b/2018-edition/src/ch12-02-reading-a-file.md
@@ -33,7 +33,6 @@ shown in Listing 12-4:
 ```rust,should_panic
 use std::env;
 use std::fs;
-use std::io::prelude::*;
 
 fn main() {
 #     let args: Vec<String> = env::args().collect();
@@ -55,14 +54,8 @@ fn main() {
 <span class="caption">Listing 12-4: Reading the contents of the file specified
 by the second argument</span>
 
-First, we add some more `use` statements to bring in relevant parts of the
-standard library: we need `std::fs` to handle files, and
-`std::io::prelude::*` contains various useful traits for doing I/O, including
-file I/O. In the same way that Rust has a general prelude that brings certain
-types and functions into scope automatically, the `std::io` module has its
-own prelude of common types and functions you’ll need when working with I/O.
-Unlike with the default prelude, we must explicitly add a `use` statement for
-the prelude from `std::io`.
+First, we add another `use` statement to bring in a relevant part of the
+standard library: we need `std::fs` to handle files.
 
 In `main`, we’ve added a new statement: `fs::read_to_string` will take the
 `filename`, open that file, and then produce a new `String` with its contents.

--- a/2018-edition/src/ch12-03-improving-error-handling-and-modularity.md
+++ b/2018-edition/src/ch12-03-improving-error-handling-and-modularity.md
@@ -12,11 +12,11 @@ without breaking one of its parts. It’s best to separate functionality so each
 function is responsible for one task.
 
 This issue also ties into the second problem: although `query` and `filename`
-are configuration variables to our program, variables like `f` and `contents`
-are used to perform the program’s logic. The longer `main` becomes, the more
-variables we’ll need to bring into scope; the more variables we have in scope,
-the harder it will be to keep track of the purpose of each. It’s best to group
-the configuration variables into one structure to make their purpose clear.
+are configuration variables to our program, variables like `contents` are used
+to perform the program’s logic. The longer `main` becomes, the more variables
+we’ll need to bring into scope; the more variables we have in scope, the harder
+it will be to keep track of the purpose of each. It’s best to group the
+configuration variables into one structure to make their purpose clear.
 
 The third problem is that we’ve used `expect` to print an error message when
 opening the file fails, but the error message just prints `file not found`.
@@ -608,7 +608,6 @@ compile until we modify *src/main.rs* in the listing after this one.
 ```rust,ignore
 use std::error::Error;
 use std::fs;
-use std::io::prelude::*;
 
 pub struct Config {
     pub query: String,


### PR DESCRIPTION
This change is for the 2018 edition.

The io prelude seems to be unnecessary now for the example, and the reference on the next page to the `f` variable refers to an older version of the code.

Running the [example](https://doc.rust-lang.org/book/2018-edition/ch12-02-reading-a-file.html) on the website produces:

```
   Compiling playground v0.0.1 (file:///playground)
warning: unused import: `std::io::prelude::*`
 --> src/main.rs:3:5
  |
3 | use std::io::prelude::*;
  |     ^^^^^^^^^^^^^^^^^^^
  |
  = note: #[warn(unused_imports)] on by default
```