### PR TITLE
fixed unnecessary apostrophe in section 19-03

### DIFF
--- a/2018-edition/src/ch19-03-advanced-traits.md
+++ b/2018-edition/src/ch19-03-advanced-traits.md
@@ -513,7 +513,7 @@ implementation you want to call.
 ### Using Supertraits to Require One Trait’s Functionality Within Another Trait
 
 Sometimes, you might need one trait to use another trait’s functionality. In
-this case, you need to rely on the dependent trait’s also being implemented.
+this case, you need to rely on the dependent traits also being implemented.
 The trait you rely on is a *supertrait* of the trait you’re implementing.
 
 For example, let’s say we want to make an `OutlinePrint` trait with an


### PR DESCRIPTION
Original: 

> Sometimes, you might need one trait to use another trait’s functionality. In this case, you need to rely on the dependent **trait’s** also being implemented. The trait you rely on is a *supertrait* of the trait you’re implementing.

Fixed:

> Sometimes, you might need one trait to use another trait’s functionality. In this case, you need to rely on the dependent **traits** also being implemented. The trait you rely on is a *supertrait* of the trait you’re implementing.

It could be that I am misinterpreting the sentence though.