### PR TITLE
Added info on Windows installation dependencies (2nd ed)

### DIFF
--- a/second-edition/src/ch01-01-installation.md
+++ b/second-edition/src/ch01-01-installation.md
@@ -73,7 +73,9 @@ the instructions for installing Rust. At some point in the installation, you’l
 receive a message explaining that you’ll also need the C++ build tools for
 Visual Studio 2013 or later. The easiest way to acquire the build tools is to
 install [Build Tools for Visual Studio 2017][visualstudio]. The tools are in
-the Other Tools and Frameworks section.
+the Other Tools and Frameworks section. Make sure to install 
+`Visual C++ 2015 toolset for desktop`; as of the time of writing, the Rust
+compiler canot use VC++ 17, thus you need the 2015 version.
 
 [install]: https://www.rust-lang.org/install.html
 [visualstudio]: https://www.visualstudio.com/downloads/


### PR DESCRIPTION
Currently, if you follow the installation instructions, you vaguely get instructed to install VC++. If you only install VC++ 17 (on Windows 10 at least), `rustc` can't find a proper linker ([see here](https://github.com/rust-lang-nursery/rustup.rs/issues/1003#issuecomment-289827271))

There is a number of issues with the rust compiler not being able to find a linker on Windows, for the Hello World tutorial ([example 1](https://github.com/rust-lang-nursery/rustup.rs/issues/1455), [example 2](https://github.com/rust-lang-nursery/rustup.rs/issues/1363), [example 3](https://github.com/rust-lang/rust/issues/43039)). Maybe this clarification will help.

## What to expect when you open a pull request here

### 2018 Edition

The 2018 is a "living" edition; it's not scheduled for in-print publication at
this time, and so is able to be updated at any time. We'd love pull requests to
fix issues with this edition, but we're not interested in extremely large
changes without discussing them first. If you'd like to make a big change,
please open an issue first! We'd hate for you to do some hard work that we
ultimately wouldn't accept.

### Second edition

No Starch Press has brought the second edition to print. Pull requests fixing
factual errors will be accepted and documented as errata; pull requests changing
wording or other small corrections should be made against the 2018 edition instead.

### First edition

The first edition is frozen, and no longer accepting changes. Pull requests
made against it will be closed.


Thank you for reading, you may now delete this text!
