### PR TITLE
ch09-03/ch11-01: Update  type to be i32 in Guess struct code example

### DIFF
--- a/2018-edition/src/ch09-03-to-panic-or-not-to-panic.md
+++ b/2018-edition/src/ch09-03-to-panic-or-not-to-panic.md
@@ -172,11 +172,11 @@ receives a value between 1 and 100:
 
 ```rust
 pub struct Guess {
-    value: u32,
+    value: i32,
 }
 
 impl Guess {
-    pub fn new(value: u32) -> Guess {
+    pub fn new(value: i32) -> Guess {
         if value < 1 || value > 100 {
             panic!("Guess value must be between 1 and 100, got {}.", value);
         }
@@ -186,7 +186,7 @@ impl Guess {
         }
     }
 
-    pub fn value(&self) -> u32 {
+    pub fn value(&self) -> i32 {
         self.value
     }
 }
@@ -196,11 +196,11 @@ impl Guess {
 values between 1 and 100</span>
 
 First, we define a struct named `Guess` that has a field named `value` that
-holds a `u32`. This is where the number will be stored.
+holds a `i32`. This is where the number will be stored.
 
 Then we implement an associated function named `new` on `Guess` that creates
 instances of `Guess` values. The `new` function is defined to have one
-parameter named `value` of type `u32` and to return a `Guess`. The code in the
+parameter named `value` of type `i32` and to return a `Guess`. The code in the
 body of the `new` function tests `value` to make sure it’s between 1 and 100.
 If `value` doesn’t pass this test, we make a `panic!` call, which will alert
 the programmer who is writing the calling code that they have a bug they need
@@ -213,7 +213,7 @@ of a `panic!` in the API documentation that you create in Chapter 14. If
 to the `value` parameter and return the `Guess`.
 
 Next, we implement a method named `value` that borrows `self`, doesn’t have any
-other parameters, and returns a `u32`. This kind of method is sometimes called
+other parameters, and returns a `i32`. This kind of method is sometimes called
 a *getter*, because its purpose is to get some data from its fields and return
 it. This public method is necessary because the `value` field of the `Guess`
 struct is private. It’s important that the `value` field be private so code
@@ -224,7 +224,7 @@ hasn’t been checked by the conditions in the `Guess::new` function.
 
 A function that has a parameter or returns only numbers between 1 and 100 could
 then declare in its signature that it takes or returns a `Guess` rather than a
-`u32` and wouldn’t need to do any additional checks in its body.
+`i32` and wouldn’t need to do any additional checks in its body.
 
 ## Summary
 

--- a/2018-edition/src/ch11-01-writing-tests.md
+++ b/2018-edition/src/ch11-01-writing-tests.md
@@ -619,11 +619,11 @@ happen when we expect them to:
 ```rust
 # fn main() {}
 pub struct Guess {
-    value: u32,
+    value: i32,
 }
 
 impl Guess {
-    pub fn new(value: u32) -> Guess {
+    pub fn new(value: i32) -> Guess {
         if value < 1 || value > 100 {
             panic!("Guess value must be between 1 and 100, got {}.", value);
         }
@@ -666,13 +666,13 @@ that the `new` function will panic if the value is greater than 100:
 ```rust
 # fn main() {}
 # pub struct Guess {
-#     value: u32,
+#     value: i32,
 # }
 #
 // --snip--
 
 impl Guess {
-    pub fn new(value: u32) -> Guess {
+    pub fn new(value: i32) -> Guess {
         if value < 1  {
             panic!("Guess value must be between 1 and 100, got {}.", value);
         }
@@ -716,13 +716,13 @@ different messages depending on whether the value is too small or too large:
 ```rust
 # fn main() {}
 # pub struct Guess {
-#     value: u32,
+#     value: i32,
 # }
 #
 // --snip--
 
 impl Guess {
-    pub fn new(value: u32) -> Guess {
+    pub fn new(value: i32) -> Guess {
         if value < 1 {
             panic!("Guess value must be greater than or equal to 1, got {}.",
                    value);


### PR DESCRIPTION
Chapter 9 section 3 talks about how using `i32` instead of `u32` as the type for `value` would be more appropriate as it allows validation against negative numbers. However, the example later in that section still uses `u32`.

This PR updates the example and the following paragraphs to use `i32`.