### PR TITLE
fix UB in from_raw_parts_mut example

### DIFF
--- a/2018-edition/src/ch19-01-unsafe-rust.md
+++ b/2018-edition/src/ch19-01-unsafe-rust.md
@@ -338,7 +338,7 @@ use std::slice;
 let address = 0x01234usize;
 let r = address as *mut i32;
 
-let slice = unsafe {
+let slice : &[i32] = unsafe {
     slice::from_raw_parts_mut(r, 10000)
 };
 ```

--- a/2018-edition/src/ch19-01-unsafe-rust.md
+++ b/2018-edition/src/ch19-01-unsafe-rust.md
@@ -335,7 +335,7 @@ location and creates a slice 10,000 items long.
 ```rust
 use std::slice;
 
-let address = 0x012345usize;
+let address = 0x01234usize;
 let r = address as *mut i32;
 
 let slice = unsafe {
@@ -348,7 +348,11 @@ location</span>
 
 We don’t own the memory at this arbitrary location, and there is no guarantee
 that the slice this code creates contains valid `i32` values. Attempting to use
-`slice` as though it’s a valid slice results in undefined behavior.
+`slice` as though it’s a valid slice results in undefined behavior. If we would
+not have taken care to align `address` to 4 (the alignment of `i32`), then even
+just calling `slice::from_raw_parts_mut` would already be undefined behavior --
+slices must always be aligned, even if they are not used (and even if they are
+empty).
 
 #### Using `extern` Functions to Call External Code
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ contributions should be to this edition.
 
 ### Second Edition
 
-The second edition is frozen, and is not accepting any changes at this time.
+No Starch Press has brought the second edition to print. Pull requests fixing
+factual errors will be accepted and documented as errata; pull requests changing
+wording or other small corrections should be made against the 2018 edition instead.
 
 ### First Edition
 

--- a/second-edition/src/ch19-01-unsafe-rust.md
+++ b/second-edition/src/ch19-01-unsafe-rust.md
@@ -335,7 +335,7 @@ location and creates a slice 10,000 items long.
 ```rust
 use std::slice;
 
-let address = 0x012345usize;
+let address = 0x01234usize;
 let r = address as *mut i32;
 
 let slice = unsafe {


### PR DESCRIPTION
This fixes fallout from https://github.com/rust-lang/rust/pull/52972.

It also updates the README to match what the issue template says about the second edition.