### PR TITLE
Multithreaded web server: explain unexpected browser behavior

### DIFF
--- a/2018-edition/src/ch20-02-multithreaded.md
+++ b/2018-edition/src/ch20-02-multithreaded.md
@@ -1126,6 +1126,11 @@ overloaded if the server receives a lot of requests. If we make a request to
 */sleep*, the server will be able to serve other requests by having another
 thread run them.
 
+Note that if you open */sleep* in multiple browser windows simultaneously, they
+might load 5 seconds apart from each other, because some web browsers execute
+multiple instances of the same request sequentially for caching reasons. This
+limitation is not caused by our web server.
+
 After learning about the `while let` loop in Chapter 18, you might be wondering
 why we didn’t write the worker thread code as shown in Listing 20-22.
 


### PR DESCRIPTION
When experimenting with the multithreaded web server, I got quite confused as to why `/sleep` requests started at seconds 0/1 received responses at seconds 5/10 as opposed to seconds 5/6.

Turns out that [Chrome waits for the result of one request before requesting the same resource again](https://stackoverflow.com/questions/27513994/chrome-stalls-when-making-multiple-requests-to-same-resource).
This behavior was not observed using Firefox or cURL.

The added paragraph could save others from spending time trying to figure out what is wrong with their server when it was really their client causing the weird behavior. I'm open to suggestions how to put this even more clearly - without writing a huge paragraph explaining all the details of why this is happening, which would be overkill for a side note like this.