### PR TITLE
Add 'dictionary' as an alternate name example for HashMap

### DIFF
--- a/2018-edition/src/ch08-03-hash-maps.md
+++ b/2018-edition/src/ch08-03-hash-maps.md
@@ -4,8 +4,8 @@ The last of our common collections is the *hash map*. The type `HashMap<K, V>`
 stores a mapping of keys of type `K` to values of type `V`. It does this via a
 *hashing function*, which determines how it places these keys and values into
 memory. Many programming languages support this kind of data structure, but
-they often use a different name, such as hash, map, object, hash table, or
-associative array, just to name a few.
+they often use a different name, such as hash, map, object, hash table,
+dictionary, or associative array, just to name a few.
 
 Hash maps are useful when you want to look up data not by using an index, as
 you can with vectors, but by using a key that can be of any type. For example,


### PR DESCRIPTION
Python, C#, Julia, and Erlang all use Dict/Dictionary as a name for
HashMap, which makes it common enough to warrant being
listed explicitly.