### PR TITLE
Duplicated word (Rust’s stability guarantees ensure that)

### DIFF
--- a/2018-edition/src/ch01-01-installation.md
+++ b/2018-edition/src/ch01-01-installation.md
@@ -8,7 +8,7 @@ an internet connection for the download.
 > installation page](https://www.rust-lang.org/install.html) for other options.
 
 The following steps install the latest stable version of the Rust compiler.
-Rust’s stability guarantees ensure that all the examples in the book that
+Rust’s stability guarantees that all the examples in the book that
 compile will continue to compile with newer Rust versions. The output might
 differ slightly between versions, because Rust often improves error messages
 and warnings. In other words, any newer, stable version of Rust you install


### PR DESCRIPTION
Duplicated word (emphasis mine):

> Rust’s stability **guarantees ensure** that

becomes

> Rust’s stability **guarantees** that

Note that this may be intentional in the book, with **guarantees** maybe being a noun and not a verb as I understood it on first read. If so, just discard this PR :)