### PR TITLE
Remove unnecessary use statement

### DIFF
--- a/2018-edition/src/ch09-02-recoverable-errors-with-result.md
+++ b/2018-edition/src/ch09-02-recoverable-errors-with-result.md
@@ -451,7 +451,6 @@ shorter:
 
 ```rust
 use std::io;
-use std::io::Read;
 use std::fs;
 
 fn read_username_from_file() -> Result<String, io::Error> {


### PR DESCRIPTION
I don't know whether this change is a good idea, but it does demonstrate how little is required to read the contents of a file.