### PR TITLE
ch02-00: Replace 'package' with 'collection...' to resolve the ambiguity

### DIFF
--- a/2018-edition/src/ch02-00-guessing-game-tutorial.md
+++ b/2018-edition/src/ch02-00-guessing-game-tutorial.md
@@ -360,9 +360,10 @@ library. However, the Rust team does provide a [`rand` crate][randcrate].
 
 ### Using a Crate to Get More Functionality
 
-Remember that a crate is a package of Rust code. The project we’ve been
-building is a *binary crate*, which is an executable. The `rand` crate is a
-*library crate*, which contains code intended to be used in other programs.
+Remember that a crate is a collection of Rust source code files.
+The project we’ve been building is a *binary crate*, which is an executable.
+The `rand` crate is a *library crate*, which contains code intended to be
+used in other programs.
 
 Cargo’s use of external crates is where it really shines. Before we can write
 code that uses `rand`, we need to modify the *Cargo.toml* file to include the


### PR DESCRIPTION
I suggest changing the word "package" in ch07-02 to "project" to remove the ambiguity.
"Our package now contains two crates" and "Remember that a crate is a package of Rust code" are kinda conflicting and [can confuse newbies](https://gitter.im/ruRust/general?at=5b9cb83854587954f9a63979).