### PR TITLE
Fix cargo command for Hello World example

### DIFF
--- a/2018-edition/src/ch01-03-hello-cargo.md
+++ b/2018-edition/src/ch01-03-hello-cargo.md
@@ -33,7 +33,7 @@ wherever you decided to store your code). Then, on any operating system, run
 the following:
 
 ```text
-$ cargo new hello_cargo
+$ cargo new hello_cargo --bin
 $ cd hello_cargo
 ```
 


### PR DESCRIPTION
Added `--bin` parameter to `cargo new`, because the following lines assume an existing `main.rs`.