### PR TITLE
Fix link in introduction of 2018 edition

### DIFF
--- a/2018-edition/src/ch00-00-introduction.md
+++ b/2018-edition/src/ch00-00-introduction.md
@@ -187,4 +187,4 @@ doesn’t compile.
 The source files from which this book is generated can be found on
 [GitHub][book].
 
-[book]: https://github.com/rust-lang/book/tree/master/second-edition/src
+[book]: https://github.com/rust-lang/book/tree/master/2018-edition/src


### PR DESCRIPTION
Fixes #1466

Use `https://github.com/rust-lang/book/tree/master/2018-edition/src` instead of `https://github.com/rust-lang/book/tree/master/second-edition/src` for 2018 edition book.