### PR TITLE
Correcting wrong example in ch10-02-traits.md.

### DIFF
--- a/2018-edition/src/ch10-02-traits.md
+++ b/2018-edition/src/ch10-02-traits.md
@@ -301,11 +301,15 @@ say we wanted to take two things that implement `Summary`:
 
 ```rust,ignore
 pub fn notify(item1: impl Summary, item2: impl Summary) {
-pub fn notify<T: Summary>(item1: T, item2: T) {
 ```
 
-The version with the bound is a bit easier. In general, you should use whatever
-form makes your code the most understandable.
+This would work well if `item1` and `item2` were allowed to have diferent types
+(as long as both implement `Summary`). But what if you wanted to force both to
+have the exact same type? That is only possible if you use a trait bound:
+
+```rust,ignore
+pub fn notify<T: Summary>(item1: T, item2: T) {
+```
 
 ##### Multiple trait bounds with `+`
 


### PR DESCRIPTION
The current example wrongly implies that the two function declarations behave the same.  They actually behave differently: the first one allows two different types as long as both implement `Summary`; the latter forces both parameters to be the same type.

 Fixing this would resolve #1504 