### PR TITLE
initial pass at automating references

### DIFF
--- a/2018-edition/src/appendix-03-derivable-traits.md
+++ b/2018-edition/src/appendix-03-derivable-traits.md
@@ -110,7 +110,9 @@ a data structure that stores data based on the sort order of the values.
 
 The `Clone` trait allows you to explicitly create a deep copy of a value, and
 the duplication process might involve running arbitrary code and copying heap
-data. See the “Ways Variables and Data Interact: Clone” section in Chapter 4
+data. See the [“Ways Variables and Data Interact: Clone”]
+[ways-variables-and-data-interact-clone]
+section in Chapter 4
 for more information on `Clone`.
 
 Deriving `Clone` implements the `clone` method, which when implemented for the
@@ -123,7 +125,8 @@ returned from `to_vec` will need to own its instances, so `to_vec` calls
 `clone` on each item. Thus, the type stored in the slice must implement `Clone`.
 
 The `Copy` trait allows you to duplicate a value by only copying bits stored on
-the stack; no arbitrary code is necessary. See the “Stack-Only Data: Copy”
+the stack; no arbitrary code is necessary. See the [“Stack-Only Data: Copy”]
+[stack-only-data-copy]
 section in Chapter 4 for more information on `Copy`.
 
 The `Copy` trait doesn’t define any methods to prevent programmers from
@@ -163,8 +166,10 @@ meaning all fields or values in the type must also implement `Default` to
 derive `Default`.
 
 The `Default::default` function is commonly used in combination with the struct
-update syntax discussed in the “Creating Instances From Other Instances With
-Struct Update Syntax” section in Chapter 5. You can customize a few fields of a
+update syntax discussed in the [“Creating Instances From Other Instances With
+Struct Update Syntax”]
+[creating-instances-from-other-instances-with-struct-update-syntax]
+section in Chapter 5. You can customize a few fields of a
 struct and then set and use a default value for the rest of the fields by using
 `..Default::default()`.
 
@@ -172,3 +177,10 @@ The `Default` trait is required when you use the method `unwrap_or_default` on
 `Option<T>` instances, for example. If the `Option<T>` is `None`, the method
 `unwrap_or_default` will return the result of `Default::default` for the type
 `T` stored in the `Option<T>`.
+
+[creating-instances-from-other-instances-with-struct-update-syntax]:
+ch05-01-defining-structs.html#creating-instances-from-other-instances-with-struct-update-syntax
+[stack-only-data-copy]:
+ch04-01-what-is-ownership.html#stack-only-data-copy
+[ways-variables-and-data-interact-clone]:
+ch04-01-what-is-ownership.html#ways-variables-and-data-interact-clone

--- a/2018-edition/src/appendix-06-nightly-rust.md
+++ b/2018-edition/src/appendix-06-nightly-rust.md
@@ -191,7 +191,8 @@ If the feature is accepted, an issue is opened on the Rust repository, and
 someone can implement it. The person who implements it very well may not be the
 person who proposed the feature in the first place! When the implementation is
 ready, it lands on the `master` branch behind a feature gate, as we discussed
-in the “Unstable Features” section.
+in the [“Unstable Features”](#unstable-features)
+section.
 
 After some time, once Rust developers who use nightly releases have been able
 to try out the new feature, team members will discuss the feature, how it’s
@@ -199,3 +200,5 @@ worked out on nightly, and decide if it should make it into stable Rust or not.
 If the decision is to move forward, the feature gate is removed, and the
 feature is now considered stable! It rides the trains into a new stable release
 of Rust.
+
+

--- a/2018-edition/src/ch01-02-hello-world.md
+++ b/2018-edition/src/ch01-02-hello-world.md
@@ -86,7 +86,8 @@ Hello, world!
 ```
 
 Regardless of your operating system, the string `Hello, world!` should print to
-the terminal. If you don’t see this output, refer back to the “Troubleshooting”
+the terminal. If you don’t see this output, refer back to the [“Troubleshooting”]
+[troubleshooting]
 part of the Installation section for ways to get help.
 
 If `Hello, world!` did print, congratulations! You’ve officially written a Rust
@@ -216,3 +217,6 @@ Just compiling with `rustc` is fine for simple programs, but as your project
 grows, you’ll want to manage all the options and make it easy to share your
 code. Next, we’ll introduce you to the Cargo tool, which will help you write
 real-world Rust programs.
+
+[troubleshooting]:
+ch01-01-installation.html#troubleshooting

--- a/2018-edition/src/ch01-03-hello-cargo.md
+++ b/2018-edition/src/ch01-03-hello-cargo.md
@@ -13,7 +13,9 @@ using Cargo, adding dependencies will be much easier to do.
 
 Because the vast majority of Rust projects use Cargo, the rest of this book
 assumes that you’re using Cargo too. Cargo comes installed with Rust if you
-used the official installers discussed in the “Installation” section. If you
+used the official installers discussed in the [“Installation”]
+[installation]
+section. If you
 installed Rust through some other means, check whether Cargo is installed by
 entering the following into your terminal:
 
@@ -243,3 +245,6 @@ This is a great time to build a more substantial program to get used to reading
 and writing Rust code. So, in Chapter 2, we’ll build a guessing game program.
 If you would rather start by learning how common programming concepts work in
 Rust, see Chapter 3 and then return to Chapter 2.
+
+[installation]:
+ch01-01-installation.html#installation

--- a/2018-edition/src/ch02-00-guessing-game-tutorial.md
+++ b/2018-edition/src/ch02-00-guessing-game-tutorial.md
@@ -156,7 +156,9 @@ let foo = bar;
 
 This line creates a new variable named `foo` and binds it to the value of the
 `bar` variable. In Rust, variables are immutable by default. We’ll be
-discussing this concept in detail in the “Variables and Mutability” section in
+discussing this concept in detail in the [“Variables and Mutability”]
+[variables-and-mutability]
+section in
 Chapter 3. The following example shows how to use `mut` before the variable
 name to make a variable mutable:
 
@@ -829,8 +831,9 @@ It doesn’t seem like the user can quit!
 
 The user could always halt the program by using the keyboard shortcut <span
 class="keystroke">ctrl-c</span>. But there’s another way to escape this
-insatiable monster, as mentioned in the `parse` discussion in “Comparing the
-Guess to the Secret Number”: if the user enters a non-number answer, the
+insatiable monster, as mentioned in the `parse` discussion in [“Comparing the
+Guess to the Secret Number”](#comparing-the-guess-to-the-secret-number)
+: if the user enters a non-number answer, the
 program will crash. The user can take advantage of that in order to quit, as
 shown here:
 
@@ -1009,3 +1012,6 @@ variables, data types, and functions, and shows how to use them in Rust.
 Chapter 4 explores ownership, a feature that makes Rust different from other
 languages. Chapter 5 discusses structs and method syntax, and Chapter 6
 explains how enums work.
+
+[variables-and-mutability]:
+ch03-01-variables-and-mutability.html#variables-and-mutability

--- a/2018-edition/src/ch03-01-variables-and-mutability.md
+++ b/2018-edition/src/ch03-01-variables-and-mutability.md
@@ -147,7 +147,9 @@ hardcoded value needed to be updated in the future.
 
 ### Shadowing
 
-As you saw in the “Comparing the Guess to the Secret Number” section in Chapter
+As you saw in the [“Comparing the Guess to the Secret Number”]
+[comparing-the-guess-to-the-secret-number]
+section in Chapter
 2, you can declare a new variable with the same name as a previous variable,
 and the new variable shadows the previous variable. Rustaceans say that the
 first variable is *shadowed* by the second, which means that the second
@@ -227,3 +229,6 @@ error[E0308]: mismatched types
 
 Now that we’ve explored how variables work, let’s look at more data types they
 can have.
+
+[comparing-the-guess-to-the-secret-number]:
+ch02-00-guessing-game-tutorial.html#comparing-the-guess-to-the-secret-number

--- a/2018-edition/src/ch03-02-data-types.md
+++ b/2018-edition/src/ch03-02-data-types.md
@@ -8,7 +8,9 @@ Keep in mind that Rust is a *statically typed* language, which means that it
 must know the types of all variables at compile time. The compiler can usually
 infer what type we want to use based on the value and how we use it. In cases
 when many types are possible, such as when we converted a `String` to a numeric
-type using `parse` in the “Comparing the Guess to the Secret Number” section in
+type using `parse` in the [“Comparing the Guess to the Secret Number”]
+[comparing-the-guess-to-the-secret-number]
+section in
 Chapter 2, we must add a type annotation, like this:
 
 ```rust
@@ -185,7 +187,8 @@ fn main() {
 ```
 
 The main way to consume Boolean values is through conditionals, such as an `if`
-expression. We’ll cover how `if` expressions work in Rust in the “Control Flow”
+expression. We’ll cover how `if` expressions work in Rust in the [“Control Flow”]
+[control-flow]
 section.
 
 Booleans are one byte in size.
@@ -396,3 +399,8 @@ low-level languages, this kind of check is not done, and when you provide an
 incorrect index, invalid memory can be accessed. Rust protects you against this
 kind of error by immediately exiting instead of allowing the memory access and
 continuing. Chapter 9 discusses more of Rust’s error handling.
+
+[comparing-the-guess-to-the-secret-number]:
+ch02-00-guessing-game-tutorial.html#comparing-the-guess-to-the-secret-number
+[control-flow]:
+ch03-05-control-flow.html#control-flow

--- a/2018-edition/src/ch03-05-control-flow.md
+++ b/2018-edition/src/ch03-05-control-flow.md
@@ -37,7 +37,9 @@ condition. In this case, the condition checks whether or not the variable
 condition is true is placed immediately after the condition inside curly
 brackets. Blocks of code associated with the conditions in `if` expressions are
 sometimes called *arms*, just like the arms in `match` expressions that we
-discussed in the “Comparing the Guess to the Secret Number” section of
+discussed in the [“Comparing the Guess to the Secret Number”]
+[comparing-the-guess-to-the-secret-number]
+section of
 Chapter 2.
 
 Optionally, we can also include an `else` expression, which we chose
@@ -306,7 +308,9 @@ depending on where the code was in the loop when it received the halt signal.
 Fortunately, Rust provides another, more reliable way to break out of a loop.
 You can place the `break` keyword within the loop to tell the program when to
 stop executing the loop. Recall that we did this in the guessing game in the
-“Quitting After a Correct Guess” section of Chapter 2 to exit the
+[“Quitting After a Correct Guess”]
+[quitting-after-a-correct-guess]
+section of Chapter 2 to exit the
 program when the user won the game by guessing the correct number.
 
 
@@ -484,3 +488,8 @@ taking advantage of the repetition in the song.
 
 When you’re ready to move on, we’ll talk about a concept in Rust that *doesn’t*
 commonly exist in other programming languages: ownership.
+
+[comparing-the-guess-to-the-secret-number]:
+ch02-00-guessing-game-tutorial.html#comparing-the-guess-to-the-secret-number
+[quitting-after-a-correct-guess]:
+ch02-00-guessing-game-tutorial.html#quitting-after-a-correct-guess

--- a/2018-edition/src/ch04-01-what-is-ownership.md
+++ b/2018-edition/src/ch04-01-what-is-ownership.md
@@ -136,7 +136,9 @@ understanding by introducing the `String` type.
 ### The `String` Type
 
 To illustrate the rules of ownership, we need a data type that is more complex
-than the ones we covered in the “Data Types” section of Chapter 3. The types
+than the ones we covered in the [“Data Types”]
+[data-types]
+section of Chapter 3. The types
 covered previously are all stored on the stack and popped off the stack when
 their scope is over, but we want to look at data that is stored on the heap and
 explore how Rust knows when to clean up that data.
@@ -162,8 +164,10 @@ let s = String::from("hello");
 
 The double colon (`::`) is an operator that allows us to namespace this
 particular `from` function under the `String` type rather than using some sort
-of name like `string_from`. We’ll discuss this syntax more in the “Method
-Syntax” section of Chapter 5 and when we talk about namespacing with modules in
+of name like `string_from`. We’ll discuss this syntax more in the [“Method
+Syntax”]
+[method-syntax]
+section of Chapter 5 and when we talk about namespacing with modules in
 “Module Definitions” in Chapter 7.
 
 This kind of string *can* be mutated:
@@ -414,8 +418,10 @@ usable after assignment. Rust won’t let us annotate a type with the `Copy`
 trait if the type, or any of its parts, has implemented the `Drop` trait. If
 the type needs something special to happen when the value goes out of scope and
 we add the `Copy` annotation to that type, we’ll get a compile time error. To
-learn about how to add the `Copy` annotation to your type, see “Derivable
-Traits” in Appendix C.
+learn about how to add the `Copy` annotation to your type, see [“Derivable
+Traits”]
+[derivable-traits]
+in Appendix C.
 
 So what types are `Copy`? You can check the documentation for the given type to
 be sure, but as a general rule, any group of simple scalar values can be
@@ -550,3 +556,10 @@ fn calculate_length(s: String) -> (String, usize) {
 But this is too much ceremony and a lot of work for a concept that should be
 common. Luckily for us, Rust has a feature for this concept, called
 *references*.
+
+[data-types]:
+ch03-02-data-types.html#data-types
+[derivable-traits]:
+appendix-03-derivable-traits.html#derivable-traits
+[method-syntax]:
+ch05-03-method-syntax.html#method-syntax

--- a/2018-edition/src/ch05-02-example-structs.md
+++ b/2018-edition/src/ch05-02-example-structs.md
@@ -51,7 +51,9 @@ The `area` function is supposed to calculate the area of one rectangle, but the
 function we wrote has two parameters. The parameters are related, but that’s
 not expressed anywhere in our program. It would be more readable and more
 manageable to group width and height together. We’ve already discussed one way
-we might do that in “The Tuple Type” section of Chapter 3: by using tuples.
+we might do that in [“The Tuple Type”]
+[the-tuple-type]
+section of Chapter 3: by using tuples.
 
 ### Refactoring with Tuples
 
@@ -262,3 +264,6 @@ It would be helpful to tie this behavior more closely to our `Rectangle`
 struct, because it won’t work with any other type. Let’s look at how we can
 continue to refactor this code by turning the `area` function into an `area`
 *method* defined on our `Rectangle` type.
+
+[the-tuple-type]:
+ch03-02-data-types.html#the-tuple-type

--- a/2018-edition/src/ch08-03-hash-maps.md
+++ b/2018-edition/src/ch08-03-hash-maps.md
@@ -100,7 +100,9 @@ they’ve been moved into the hash map with the call to `insert`.
 If we insert references to values into the hash map, the values won’t be moved
 into the hash map. The values that the references point to must be valid for at
 least as long as the hash map is valid. We’ll talk more about these issues in
-the “Validating References with Lifetimes” section in Chapter 10.
+the [“Validating References with Lifetimes”]
+[validating-references-with-lifetimes]
+section in Chapter 10.
 
 ### Accessing Values in a Hash Map
 
@@ -299,3 +301,6 @@ and hash maps have that will be helpful for these exercises!
 
 We’re getting into more complex programs in which operations can fail, so, it’s
 a perfect time to discuss error handling. We’ll do that next!
+
+[validating-references-with-lifetimes]:
+ch10-03-lifetime-syntax.html#validating-references-with-lifetimes

--- a/2018-edition/src/ch09-01-unrecoverable-errors-with-panic.md
+++ b/2018-edition/src/ch09-01-unrecoverable-errors-with-panic.md
@@ -186,6 +186,11 @@ you’ll need to figure out what action the code is taking with what values to
 cause the panic and what the code should do instead.
 
 We’ll come back to `panic!` and when we should and should not use `panic!` to
-handle error conditions in the “To `panic!` or Not to `panic!`” section later
+handle error conditions in the [“To `panic!` or Not to `panic!`”]
+[to-panic-or-not-to-panic]
+section later
 in this chapter. Next, we’ll look at how to recover from an error using
 `Result`.
+
+[to-panic-or-not-to-panic]:
+ch09-03-to-panic-or-not-to-panic.html#to-panic-or-not-to-panic

--- a/2018-edition/src/ch10-01-syntax.md
+++ b/2018-edition/src/ch10-01-syntax.md
@@ -142,7 +142,9 @@ to compare values of type `T` in the body, we can only use types whose values
 can be ordered. To enable comparisons, the standard library has the
 `std::cmp::PartialOrd` trait that you can implement on types (see Appendix C
 for more on this trait). You’ll learn how to specify that a generic type has a
-particular trait in the “Trait Bounds” section, but let’s first explore other
+particular trait in the [“Trait Bounds”]
+[trait-bounds]
+section, but let’s first explore other
 ways of using generic type parameters.
 
 ### In Struct Definitions
@@ -460,3 +462,6 @@ instance, we pay no runtime cost for using generics. When the code runs, it
 performs just as it would if we had duplicated each definition by hand. The
 process of monomorphization makes Rust’s generics extremely efficient at
 runtime.
+
+[trait-bounds]:
+ch10-02-traits.html#trait-bounds

--- a/2018-edition/src/ch10-02-traits.md
+++ b/2018-edition/src/ch10-02-traits.md
@@ -458,7 +458,8 @@ error[E0507]: cannot move out of borrowed content
 
 The key line in this error is `cannot move out of type [T], a non-copy slice`.
 With our non-generic versions of the `largest` function, we were only trying to
-find the largest `i32` or `char`. As discussed in the “Stack-Only Data: Copy”
+find the largest `i32` or `char`. As discussed in the [“Stack-Only Data: Copy”]
+[stack-only-data-copy]
 section in Chapter 4, types like `i32` and `char` that have a known size can be
 stored on the stack, so they implement the `Copy` trait. But when we made the
 `largest` function generic, it became possible for the `list` parameter to have
@@ -599,3 +600,6 @@ Another kind of generic that we’ve already been using is called *lifetimes*.
 Rather than ensuring that a type has the behavior we want, lifetimes ensure
 that references are valid as long as we need them to be. Let’s look at how
 lifetimes do that.
+
+[stack-only-data-copy]:
+ch04-01-what-is-ownership.html#stack-only-data-copy

--- a/2018-edition/src/ch10-03-lifetime-syntax.md
+++ b/2018-edition/src/ch10-03-lifetime-syntax.md
@@ -1,6 +1,8 @@
 ## Validating References with Lifetimes
 
-One detail we didn’t discuss in the “References and Borrowing” section in
+One detail we didn’t discuss in the [“References and Borrowing”]
+[references-and-borrowing]
+section in
 Chapter 4 is that every reference in Rust has a *lifetime*, which is the scope
 for which that reference is valid. Most of the time, lifetimes are implicit and
 inferred, just like most of the time, types are inferred. We must annotate types
@@ -13,7 +15,9 @@ The concept of lifetimes is somewhat different from tools in other programming
 languages, arguably making lifetimes Rust’s most distinctive feature. Although
 we won’t cover lifetimes in their entirety in this chapter, we’ll discuss
 common ways you might encounter lifetime syntax so you can become familiar with
-the concepts. See the “Advanced Lifetimes” section in Chapter 19 for more
+the concepts. See the [“Advanced Lifetimes”]
+[advanced-lifetimes]
+section in Chapter 19 for more
 detailed information.
 
 ### Preventing Dangling References with Lifetimes
@@ -156,7 +160,9 @@ parameters. We want to allow the function to accept slices of a `String` (the
 type stored in the variable `string1`) as well as string literals (which is
 what variable `string2` contains).
 
-Refer to the “String Slices as Parameters” section in Chapter 4 for more
+Refer to the [“String Slices as Parameters”]
+[string-slices-as-parameters]
+section in Chapter 4 for more
 discussion about why the parameters we use in Listing 10-20 are the ones we
 want.
 
@@ -771,3 +777,10 @@ this chapter: Chapter 17 discusses trait objects, which are another way to use
 traits. Chapter 19 covers more complex scenarios involving lifetime annotations
 as well as some advanced type system features. But next, you’ll learn how to
 write tests in Rust so you can make sure your code is working the way it should.
+
+[advanced-lifetimes]:
+ch19-02-advanced-lifetimes.html#advanced-lifetimes
+[references-and-borrowing]:
+ch04-02-references-and-borrowing.html#references-and-borrowing
+[string-slices-as-parameters]:
+ch04-03-slices.html#string-slices-as-parameters

--- a/2018-edition/src/ch11-01-writing-tests.md
+++ b/2018-edition/src/ch11-01-writing-tests.md
@@ -209,7 +209,9 @@ on line 10 in the *src/lib.rs* file. The next section lists just the names of
 all the failing tests, which is useful when there are lots of tests and lots of
 detailed failing test output. We can use the name of a failing test to run just
 that test to more easily debug it; we’ll talk more about ways to run tests in
-the “Controlling How Tests Are Run” section.
+the [“Controlling How Tests Are Run”]
+[controlling-how-tests-are-run]
+section.
 
 The summary line displays at the end: overall, our test result is `FAILED`.
 We had one test pass and one test fail.
@@ -505,8 +507,10 @@ You can also add a custom message to be printed with the failure message as
 optional arguments to the `assert!`, `assert_eq!`, and `assert_ne!` macros. Any
 arguments specified after the one required argument to `assert!` or the two
 required arguments to `assert_eq!` and `assert_ne!` are passed along to the
-`format!` macro (discussed in Chapter 8 in the “Concatenation with the `+`
-Operator or the `format!` Macro” section), so you can pass a format string that
+`format!` macro (discussed in Chapter 8 in the [“Concatenation with the `+`
+Operator or the `format!` Macro”]
+[concatenation-with-the--operator-or-the-format-macro]
+section), so you can pass a format string that
 contains `{}` placeholders and values to go in those placeholders. Custom
 messages are useful to document what an assertion means; when a test fails,
 you’ll have a better idea of what the problem is with the code.
@@ -830,3 +834,8 @@ of these functions; you should have it be returning an `Err` instead!
 Now that you know several ways to write tests, let’s look at what is happening
 when we run our tests and explore the different options we can use with `cargo
 test`.
+
+[concatenation-with-the--operator-or-the-format-macro]:
+ch08-02-strings.html#concatenation-with-the--operator-or-the-format-macro
+[controlling-how-tests-are-run]:
+ch11-02-running-tests.html#controlling-how-tests-are-run

--- a/2018-edition/src/ch12-03-improving-error-handling-and-modularity.md
+++ b/2018-edition/src/ch12-03-improving-error-handling-and-modularity.md
@@ -369,8 +369,10 @@ impl Config {
 `Config::new`</span>
 
 Our `new` function now returns a `Result` with a `Config` instance in the
-success case and a `&'static str` in the error case. Recall from “The Static
-Lifetime” section in Chapter 10 that `&'static str` is the type of string
+success case and a `&'static str` in the error case. Recall from [“The Static
+Lifetime”]
+[the-static-lifetime]
+section in Chapter 10 that `&'static str` is the type of string
 literals, which is our error message type for now.
 
 We’ve made two changes in the body of the `new` function: instead of calling
@@ -444,8 +446,9 @@ Great! This output is much friendlier for our users.
 ### Extracting Logic from `main`
 
 Now that we’ve finished refactoring the configuration parsing, let’s turn to
-the program’s logic. As we stated in “Separation of Concerns for Binary
-Projects”, we’ll extract a function named `run` that will hold all the logic
+the program’s logic. As we stated in [“Separation of Concerns for Binary
+Projects”](#separation-of-concerns-for-binary-projects)
+, we’ll extract a function named `run` that will hold all the logic
 currently in the `main` function that isn’t involved with setting up
 configuration or handling errors. When we’re done, `main` will be concise and
 easy to verify by inspection, and we’ll be able to write tests for all the
@@ -670,3 +673,5 @@ modular. Almost all of our work will be done in *src/lib.rs* from here on out.
 Let’s take advantage of this newfound modularity by doing something that would
 have been difficult with the old code but is easy with the new code: we’ll
 write some tests!
+[the-static-lifetime]:
+ch10-03-lifetime-syntax.html#the-static-lifetime

--- a/2018-edition/src/ch12-04-testing-the-librarys-functionality.md
+++ b/2018-edition/src/ch12-04-testing-the-librarys-functionality.md
@@ -125,8 +125,10 @@ argument that should be connected to the return value using the lifetime syntax.
 
 Other programming languages don’t require you to connect arguments to return
 values in the signature. So although this might seem strange, it will get
-easier over time. You might want to compare this example with the “Validating
-References with Lifetimes” section in Chapter 10.
+easier over time. You might want to compare this example with the [“Validating
+References with Lifetimes”]
+[validating-references-with-lifetimes]
+section in Chapter 10.
 
 Now let’s run the test:
 
@@ -327,3 +329,6 @@ and output, lifetimes, testing, and command line parsing.
 To round out this project, we’ll briefly demonstrate how to work with
 environment variables and how to print to standard error, both of which are
 useful when you’re writing command line programs.
+
+[validating-references-with-lifetimes]:
+ch10-03-lifetime-syntax.html#validating-references-with-lifetimes

--- a/2018-edition/src/ch13-01-closures.md
+++ b/2018-edition/src/ch13-01-closures.md
@@ -438,8 +438,9 @@ we use generics and trait bounds, as we discussed in Chapter 10.
 
 The `Fn` traits are provided by the standard library. All closures implement at
 least one of the traits: `Fn`, `FnMut`, or `FnOnce`. We’ll discuss the
-difference between these traits in the “Capturing the Environment with
-Closures” section; in this example, we can use the `Fn` trait.
+difference between these traits in the [“Capturing the Environment with
+Closures”](#capturing-the-environment-with-closures)
+section; in this example, we can use the `Fn` trait.
 
 We add types to the `Fn` trait bound to represent the types of the parameters
 and return values the closures must have to match this trait bound. In this
@@ -821,3 +822,5 @@ on what happens in the closure body.
 
 To illustrate situations where closures that can capture their environment are
 useful as function parameters, let’s move on to our next topic: iterators.
+
+

--- a/2018-edition/src/ch15-01-box.md
+++ b/2018-edition/src/ch15-01-box.md
@@ -16,8 +16,9 @@ either. You’ll use them most often in these situations:
 * When you want to own a value and you care only that it’s a type that
   implements a particular trait rather than being of a specific type
 
-We’ll demonstrate the first situation in the “Enabling Recursive Types with
-Boxes” section. In the second case, transferring ownership of a large amount of
+We’ll demonstrate the first situation in the [“Enabling Recursive Types with
+Boxes”](#enabling-recursive-types-with-boxes)
+section. In the second case, transferring ownership of a large amount of
 data can take a long time because the data is copied around on the stack. To
 improve performance in this situation, we can store the large amount of data on
 the heap in a box. Then, only the small amount of pointer data is copied around
@@ -278,3 +279,5 @@ up as well because of the `Drop` trait implementation. Let’s explore these two
 traits in more detail. These two traits will be even more important to the
 functionality provided by the other smart pointer types we’ll discuss in the
 rest of this chapter.
+
+

--- a/2018-edition/src/ch15-05-interior-mutability.md
+++ b/2018-edition/src/ch15-05-interior-mutability.md
@@ -455,7 +455,9 @@ can both refer to `a`, which is what we did in Listing 15-18.
 After we’ve created the lists in `a`, `b`, and `c`, we add 10 to the value in
 `value`. We do this by calling `borrow_mut` on `value`, which uses the
 automatic dereferencing feature we discussed in Chapter 5 (see the section
-“Where’s the `->` Operator?”) to dereference the `Rc<T>` to the inner
+[“Where’s the `->` Operator?”]
+[wheres-the---operator]
+) to dereference the `Rc<T>` to the inner
 `RefCell<T>` value. The `borrow_mut` method returns a `RefMut<T>` smart
 pointer, and we use the dereference operator on it and change the inner value.
 
@@ -481,3 +483,6 @@ inner value, the value is copied in and out of the `Cell<T>`. There’s also
 `Mutex<T>`, which offers interior mutability that’s safe to use across threads;
 we’ll discuss its use in Chapter 16. Check out the standard library docs for
 more details on the differences between these types.
+
+[wheres-the---operator]:
+ch05-03-method-syntax.html#wheres-the---operator

--- a/2018-edition/src/ch16-04-extensible-concurrency-sync-and-send.md
+++ b/2018-edition/src/ch16-04-extensible-concurrency-sync-and-send.md
@@ -42,7 +42,8 @@ The smart pointer `Rc<T>` is also not `Sync` for the same reasons that it’s no
 family of related `Cell<T>` types are not `Sync`. The implementation of borrow
 checking that `RefCell<T>` does at runtime is not thread-safe. The smart
 pointer `Mutex<T>` is `Sync` and can be used to share access with multiple
-threads as you saw in the “Sharing a `Mutex<T>` Between Multiple Threads”
+threads as you saw in the [“Sharing a `Mutex<T>` Between Multiple Threads”]
+[sharing-a-mutext-between-multiple-threads]
 section.
 
 ### Implementing `Send` and `Sync` Manually Is Unsafe
@@ -85,3 +86,6 @@ go forth and make your programs concurrent, fearlessly!
 Next, we’ll talk about idiomatic ways to model problems and structure solutions
 as your Rust programs get bigger. In addition, we’ll discuss how Rust’s idioms
 relate to those you might be familiar with from object-oriented programming.
+
+[sharing-a-mutext-between-multiple-threads]:
+ch16-03-shared-state.html#sharing-a-mutext-between-multiple-threads

--- a/2018-edition/src/ch17-02-trait-objects.md
+++ b/2018-edition/src/ch17-02-trait-objects.md
@@ -332,7 +332,9 @@ didn’t mean to pass and we should pass a different type or we should implement
 
 ### Trait Objects Perform Dynamic Dispatch
 
-Recall in the “Performance of Code Using Generics” section in Chapter 10 our
+Recall in the [“Performance of Code Using Generics”]
+[performance-of-code-using-generics]
+section in Chapter 10 our
 discussion on the monomorphization process performed by the compiler when we
 use trait bounds on generics: the compiler generates nongeneric implementations
 of functions and methods for each concrete type that we use in place of a
@@ -419,3 +421,6 @@ This error means you can’t use this trait as a trait object in this way. If
 you’re interested in more details on object safety, see [Rust RFC 255].
 
 [Rust RFC 255]: https://github.com/rust-lang/rfcs/blob/master/text/0255-object-safety.md
+
+[performance-of-code-using-generics]:
+ch10-01-syntax.html#performance-of-code-using-generics

--- a/2018-edition/src/ch18-01-all-the-places-for-patterns.md
+++ b/2018-edition/src/ch18-01-all-the-places-for-patterns.md
@@ -28,7 +28,9 @@ value can never fail and thus covers every remaining case.
 A particular pattern `_` will match anything, but it never binds to a variable,
 so it’s often used in the last match arm. The `_` pattern can be useful when
 you want to ignore any value not specified, for example. We’ll cover the `_`
-pattern in more detail in the “Ignoring Values in a Pattern” section later in
+pattern in more detail in the [“Ignoring Values in a Pattern”]
+[ignoring-values-in-a-pattern]
+section later in
 this chapter.
 
 ### Conditional `if let` Expressions
@@ -229,7 +231,9 @@ error[E0308]: mismatched types
 ```
 
 If we wanted to ignore one or more of the values in the tuple, we could use `_`
-or `..`, as you’ll see in the “Ignoring Values in a Pattern” section. If the
+or `..`, as you’ll see in the [“Ignoring Values in a Pattern”]
+[ignoring-values-in-a-pattern]
+section. If the
 problem is that we have too many variables in the pattern, the solution is to
 make the types match by removing variables so the number of variables equals
 the number of elements in the tuple.
@@ -280,3 +284,6 @@ At this point, you’ve seen several ways of using patterns, but patterns don’
 work the same in every place we can use them. In some places, the patterns must
 be irrefutable; in other circumstances, they can be refutable. We’ll discuss
 these two concepts next.
+
+[ignoring-values-in-a-pattern]:
+ch18-03-pattern-syntax.html#ignoring-values-in-a-pattern

--- a/2018-edition/src/ch18-03-pattern-syntax.md
+++ b/2018-edition/src/ch18-03-pattern-syntax.md
@@ -81,8 +81,9 @@ the inner `y`. The last `println!` produces `at the end: x = Some(5), y = 10`.
 
 To create a `match` expression that compares the values of the outer `x` and
 `y`, rather than introducing a shadowed variable, we would need to use a match
-guard conditional instead. We’ll talk about match guards later in the “Extra
-Conditionals with Match Guards” section.
+guard conditional instead. We’ll talk about match guards later in the [“Extra
+Conditionals with Match Guards”](#extra-conditionals-with-match-guards)
+section.
 
 ### Multiple Patterns
 
@@ -949,3 +950,5 @@ variables. We can create simple or complex patterns to suit our needs.
 
 Next, for the penultimate chapter of the book, we’ll look at some advanced
 aspects of a variety of Rust’s features.
+
+

--- a/2018-edition/src/ch19-01-unsafe-rust.md
+++ b/2018-edition/src/ch19-01-unsafe-rust.md
@@ -65,7 +65,9 @@ some abstractions that provide a safe interface to unsafe code.
 
 ### Dereferencing a Raw Pointer
 
-In Chapter 4, in the “Dangling References” section, we mentioned that the
+In Chapter 4, in the [“Dangling References”]
+[dangling-references]
+section, we mentioned that the
 compiler ensures references are always valid. Unsafe Rust has two new types
 called *raw pointers* that are similar to references. As with references, raw
 pointers can be immutable or mutable and are written as `*const T` and `*mut
@@ -297,7 +299,9 @@ fn split_at_mut(slice: &mut [i32], mid: usize) -> (&mut [i32], &mut [i32]) {
 <span class="caption">Listing 19-6: Using unsafe code in the implementation of
 the `split_at_mut` function</span>
 
-Recall from “The Slice Type” section in Chapter 4 that slices are a pointer to
+Recall from [“The Slice Type”]
+[the-slice-type]
+section in Chapter 4 that slices are a pointer to
 some data and the length of the slice. We use the `len` method to get the
 length of a slice and the `as_mut_ptr` method to access the raw pointer of a
 slice. In this case, because we have a mutable slice to `i32` values,
@@ -440,7 +444,9 @@ fn main() {
 variable</span>
 
 Static variables are similar to constants, which we discussed in the
-“Differences Between Variables and Constants” section in Chapter 3. The names
+[“Differences Between Variables and Constants”]
+[differences-between-variables-and-constants]
+section in Chapter 3. The names
 of static variables are in `SCREAMING_SNAKE_CASE` by convention, and we *must*
 annotate the variable’s type, which is `&'static str` in this example. Static
 variables can only store references with the `'static` lifetime, which means
@@ -517,7 +523,9 @@ By using `unsafe impl`, we’re promising that we’ll uphold the invariants tha
 the compiler can’t verify.
 
 As an example, recall the `Sync` and `Send` marker traits we discussed in the
-“Extensible Concurrency with the `Sync` and `Send` Traits” section in Chapter
+[“Extensible Concurrency with the `Sync` and `Send` Traits”]
+[extensible-concurrency-with-the-sync-and-send-traits]
+section in Chapter
 16: the compiler implements these traits automatically if our types are
 composed entirely of `Send` and `Sync` types. If we implement a type that
 contains a type that is not `Send` or `Sync`, such as raw pointers, and we want
@@ -533,3 +541,12 @@ isn’t wrong or even frowned upon. But it is trickier to get `unsafe` code
 correct because the compiler can’t help uphold memory safety. When you have a
 reason to use `unsafe` code, you can do so, and having the explicit `unsafe`
 annotation makes it easier to track down the source of problems if they occur.
+
+[dangling-references]:
+ch04-02-references-and-borrowing.html#dangling-references
+[differences-between-variables-and-constants]:
+ch03-01-variables-and-mutability.html#differences-between-variables-and-constants
+[extensible-concurrency-with-the-sync-and-send-traits]:
+ch16-04-extensible-concurrency-sync-and-sen.html#extensible-concurrency-with-the-sync-and-send-traits
+[the-slice-type]:
+ch04-03-slices.html#the-slice-type

--- a/2018-edition/src/ch19-02-advanced-lifetimes.md
+++ b/2018-edition/src/ch19-02-advanced-lifetimes.md
@@ -1,6 +1,8 @@
 ## Advanced Lifetimes
 
-In Chapter 10 in the “Validating References with Lifetimes” section, you
+In Chapter 10 in the [“Validating References with Lifetimes”]
+[validating-references-with-lifetimes]
+section, you
 learned how to annotate references with lifetime parameters to tell Rust how
 lifetimes of different references relate. You saw how every reference has a
 lifetime, but most of the time, Rust will let you elide lifetimes. Now we’ll
@@ -63,8 +65,10 @@ lifetimes involved.
 To get this code to compile, we need to fill in the lifetime parameters for the
 string slice in `Context` and the reference to the `Context` in `Parser`. The
 most straightforward way to do this is to use the same lifetime name
-everywhere, as shown in Listing 19-13. Recall from the “Lifetime Annotations in
-Struct Definitions” section in Chapter 10 that each of `struct Context<'a>`,
+everywhere, as shown in Listing 19-13. Recall from the [“Lifetime Annotations in
+Struct Definitions”]
+[lifetime-annotations-in-struct-definitions]
+section in Chapter 10 that each of `struct Context<'a>`,
 `struct Parser<'a>`, and `impl<'a>` is declaring a new lifetime parameter.
 While their names happen to all be the same, the three lifetime parameters
 declared in this example aren’t related.
@@ -303,13 +307,16 @@ refer to something and give it the necessary lifetime.
 
 ### Lifetime Bounds on References to Generic Types
 
-In the “Trait Bounds” section in Chapter 10, we discussed using trait bounds on
+In the [“Trait Bounds”]
+[trait-bounds]
+section in Chapter 10, we discussed using trait bounds on
 generic types. We can also add lifetime parameters as constraints on generic
 types; these are called *lifetime bounds*. Lifetime bounds help Rust verify
 that references in generic types won’t outlive the data they’re referencing.
 
 As an example, consider a type that is a wrapper over references. Recall the
-`RefCell<T>` type from the “`RefCell<T>` and the Interior Mutability Pattern”
+`RefCell<T>` type from the [“`RefCell<T>` and the Interior Mutability Pattern”]
+[refcellt-and-the-interior-mutability-pattern]
 section in Chapter 15: its `borrow` and `borrow_mut` methods return the types
 `Ref` and `RefMut`, respectively. These types are wrappers over references that
 keep track of the borrowing rules at runtime. The definition of the `Ref`
@@ -392,8 +399,10 @@ a reference has a shorter lifetime than what it refers to.
 
 ### Inference of Trait Object Lifetimes
 
-In Chapter 17 in the “Using Trait Objects that Allow for Values of Different
-Types” section, we discussed trait objects, consisting of a trait behind a
+In Chapter 17 in the [“Using Trait Objects that Allow for Values of Different
+Types”]
+[using-trait-objects-that-allow-for-values-of-different-types]
+section, we discussed trait objects, consisting of a trait behind a
 reference, that allow us to use dynamic dispatch. We haven’t yet discussed what
 happens if the type implementing the trait in the trait object has a lifetime
 of its own. Consider Listing 19-19 where we have a trait `Red` and a struct
@@ -485,3 +494,14 @@ impl fmt::Debug for StrWrap<'_> {
 ```
 
 Next, let’s look at some other advanced features that manage traits.
+
+[lifetime-annotations-in-struct-definitions]:
+ch10-03-lifetime-syntax.html#lifetime-annotations-in-struct-definitions
+[refcellt-and-the-interior-mutability-pattern]:
+ch15-05-interior-mutability.html#refcellt-and-the-interior-mutability-pattern
+[trait-bounds]:
+ch10-02-traits.html#trait-bounds
+[using-trait-objects-that-allow-for-values-of-different-types]:
+ch17-02-trait-objects.html#using-trait-objects-that-allow-for-values-of-different-types
+[validating-references-with-lifetimes]:
+ch10-03-lifetime-syntax.html#validating-references-with-lifetimes

--- a/2018-edition/src/ch19-03-advanced-traits.md
+++ b/2018-edition/src/ch19-03-advanced-traits.md
@@ -1,6 +1,8 @@
 ## Advanced Traits
 
-We first covered traits in the “Traits: Defining Shared Behavior” section of
+We first covered traits in the [“Traits: Defining Shared Behavior”]
+[traits-defining-shared-behavior]
+section of
 Chapter 10, but as with lifetimes, we didn’t discuss the more advanced details.
 Now that you know more about Rust, we can get into the nitty-gritty.
 
@@ -21,7 +23,9 @@ the other features discussed in this chapter.
 One example of a trait with an associated type is the `Iterator` trait that the
 standard library provides. The associated type is named `Item` and stands in
 for the type of the values the type implementing the `Iterator` trait is
-iterating over. In “The `Iterator` Trait and the `next` Method” section of
+iterating over. In [“The `Iterator` Trait and the `next` Method”]
+[the-iterator-trait-and-the-next-method]
+section of
 Chapter 13, we mentioned that the definition of the `Iterator` trait is as
 shown in Listing 19-20.
 
@@ -619,7 +623,9 @@ it within an outline of asterisks.
 
 ### Using the Newtype Pattern to Implement External Traits on External Types
 
-In Chapter 10 in the “Implementing a Trait on a Type” section, we mentioned the
+In Chapter 10 in the [“Implementing a Trait on a Type”]
+[implementing-a-trait-on-a-type]
+section, we mentioned the
 orphan rule that states we’re allowed to implement a trait on a type as long as
 either the trait or the type are local to our crate. It’s possible to get
 around this restriction using the *newtype pattern*, which involves creating a
@@ -678,3 +684,10 @@ methods we do want manually.
 Now you know how the newtype pattern is used in relation to traits; it’s also a
 useful pattern even when traits are not involved. Let’s switch focus and look
 at some advanced ways to interact with Rust’s type system.
+
+[implementing-a-trait-on-a-type]:
+ch10-02-traits.html#implementing-a-trait-on-a-type
+[the-iterator-trait-and-the-next-method]:
+ch13-02-iterators.html#the-iterator-trait-and-the-next-method
+[traits-defining-shared-behavior]:
+ch10-02-traits.html#traits-defining-shared-behavior

--- a/2018-edition/src/ch19-04-advanced-types.md
+++ b/2018-edition/src/ch19-04-advanced-types.md
@@ -30,8 +30,10 @@ associated with their name. Code using `People` would only interact with the
 public API we provide, such as a method to add a name string to the `People`
 collection; that code wouldn’t need to know that we assign an `i32` ID to names
 internally. The newtype pattern is a lightweight way to achieve encapsulation
-to hide implementation details, which we discussed in the “Encapsulation that
-Hides Implementation Details” section of Chapter 17.
+to hide implementation details, which we discussed in the [“Encapsulation that
+Hides Implementation Details”]
+[encapsulation-that-hides-implementation-details]
+section of Chapter 17.
 
 ### Creating Type Synonyms with Type Aliases
 
@@ -197,8 +199,10 @@ let guess: u32 = match guess.trim().parse() {
 <span class="caption">Listing 19-34: A `match` with an arm that ends in
 `continue`</span>
 
-At the time, we skipped over some details in this code. In Chapter 6 in “The
-`match` Control Flow Operator” section, we discussed that `match` arms must all
+At the time, we skipped over some details in this code. In Chapter 6 in [“The
+`match` Control Flow Operator”]
+[the-match-control-flow-operator]
+section, we discussed that `match` arms must all
 return the same type. So, for example, the following code doesn’t work:
 
 ```rust,ignore,does_not_compile
@@ -286,8 +290,10 @@ storage and `s2` needs 15. This is why it’s not possible to create a variable
 holding a dynamically sized type.
 
 So what do we do? In this case, you already know the answer: we make the types
-of `s1` and `s2` a `&str` rather than a `str`. Recall that in the “String
-Slices” section of Chapter 4, we said the slice data structure stores the
+of `s1` and `s2` a `&str` rather than a `str`. Recall that in the [“String
+Slices”]
+[string-slices]
+section of Chapter 4, we said the slice data structure stores the
 starting position and the length of the slice.
 
 So although a `&T` is a single value that stores the memory address of where
@@ -303,8 +309,10 @@ types behind a pointer of some kind.
 We can combine `str` with all kinds of pointers: for example, `Box<str>` or
 `Rc<str>`. In fact, you’ve seen this before but with a different dynamically
 sized type: traits. Every trait is a dynamically sized type we can refer to by
-using the name of the trait. In Chapter 17 in the “Using Trait Objects that
-Allow for Values of Different Types” section, we mentioned that to use traits
+using the name of the trait. In Chapter 17 in the [“Using Trait Objects that
+Allow for Values of Different Types”]
+[using-trait-objects-that-allow-for-values-of-different-types]
+section, we mentioned that to use traits
 as trait objects, we must put them behind a pointer, such as `&dyn Trait` or
 `Box<dyn Trait>` (`Rc<dyn Trait>` would work too).
 
@@ -347,3 +355,12 @@ Because the type might not be `Sized`, we need to use it behind some kind of
 pointer. In this case, we’ve chosen a reference.
 
 Next, we’ll talk about functions and closures!
+
+[encapsulation-that-hides-implementation-details]:
+ch17-01-what-is-oo.html#encapsulation-that-hides-implementation-details
+[string-slices]:
+ch04-03-slices.html#string-slices
+[the-match-control-flow-operator]:
+ch06-02-match.html#the-match-control-flow-operator
+[using-trait-objects-that-allow-for-values-of-different-types]:
+ch17-02-trait-objects.html#using-trait-objects-that-allow-for-values-of-different-types

--- a/2018-edition/src/ch19-05-advanced-functions-and-closures.md
+++ b/2018-edition/src/ch19-05-advanced-functions-and-closures.md
@@ -78,7 +78,9 @@ let list_of_strings: Vec<String> = list_of_numbers
 ```
 
 Note that we must use the fully qualified syntax that we talked about earlier
-in the “Advanced Traits” section because there are multiple functions available
+in the [“Advanced Traits”]
+[advanced-traits]
+section because there are multiple functions available
 named `to_string`. Here, we’re using the `to_string` function defined in the
 `ToString` trait, which the standard library has implemented for any type that
 implements `Display`.
@@ -163,3 +165,6 @@ you to solutions.
 
 Next, we’ll put everything we’ve discussed throughout the book into practice
 and do one more project!
+
+[advanced-traits]:
+ch19-03-advanced-traits.html#advanced-traits

--- a/2018-edition/src/ch20-02-multithreaded.md
+++ b/2018-edition/src/ch20-02-multithreaded.md
@@ -284,7 +284,9 @@ impl ThreadPool {
 We chose `usize` as the type of the `size` parameter, because we know that a
 negative number of threads doesn’t make any sense. We also know we’ll use this
 4 as the number of elements in a collection of threads, which is what the
-`usize` type is for, as discussed in the “Integer Types” section of Chapter 3.
+`usize` type is for, as discussed in the [“Integer Types”]
+[integer-types]
+section of Chapter 3.
 
 Let’s check the code again:
 
@@ -309,14 +311,17 @@ error[E0599]: no method named `execute` found for type `hello::ThreadPool` in th
 
 Now we get a warning and an error. Ignoring the warning for a moment, the error
 occurs because we don’t have an `execute` method on `ThreadPool`. Recall from
-the “Creating a Similar Interface for a Finite Number of Threads” section that
+the [“Creating a Similar Interface for a Finite Number of Threads”](#creating-a-similar-interface-for-a-finite-number-of-threads)
+section that
 we decided our thread pool should have an interface similar to `thread::spawn`.
 In addition, we’ll implement the `execute` function so it takes the closure
 it’s given and gives it to an idle thread in the pool to run.
 
 We’ll define the `execute` method on `ThreadPool` to take a closure as a
-parameter. Recall from the “Storing Closures Using Generic Parameters and the
-`Fn` Traits” section in Chapter 13 that we can take closures as parameters with
+parameter. Recall from the [“Storing Closures Using Generic Parameters and the
+`Fn` Traits”]
+[storing-closures-using-generic-parameters-and-the-fn-traits]
+section in Chapter 13 that we can take closures as parameters with
 three different traits: `Fn`, `FnMut`, and `FnOnce`. We need to decide which
 kind of closure to use here. We know we’ll end up doing something similar to
 the standard library `thread::spawn` implementation, so we can look at what
@@ -876,8 +881,10 @@ With these changes, the code compiles! We’re getting there!
 
 Let’s finally implement the `execute` method on `ThreadPool`. We’ll also change
 `Job` from a struct to a type alias for a trait object that holds the type of
-closure that `execute` receives. As discussed in the “Creating Type Synonyms
-with Type Aliases” section of Chapter 19, type aliases allow us to make long
+closure that `execute` receives. As discussed in the [“Creating Type Synonyms
+with Type Aliases”]
+[creating-type-synonyms-with-type-aliases]
+section of Chapter 19, type aliases allow us to make long
 types shorter. Look at Listing 20-19.
 
 <span class="filename">Filename: src/lib.rs</span>
@@ -1178,3 +1185,10 @@ rather than outside it, the `MutexGuard` returned from the `lock` method is
 dropped as soon as the `let job` statement ends. This ensures that the lock is
 held during the call to `recv`, but it is released before the call to
 `job.call_box()`, allowing multiple requests to be serviced concurrently.
+
+[creating-type-synonyms-with-type-aliases]:
+ch19-04-advanced-types.html#creating-type-synonyms-with-type-aliases
+[integer-types]:
+ch03-02-data-types.html#integer-types
+[storing-closures-using-generic-parameters-and-the-fn-traits]:
+ch13-01-closures.html#storing-closures-using-generic-parameters-and-the-fn-traits


### PR DESCRIPTION
This is an attempt to automate consistency and automatic referencing in the rust-lang book:
I've created a [command line utility](https://github.com/mkatychev/md_ref_generator) that tries to add links to verified internal references present in any included chapter.

Running my validation with the `--flag-dead-refs` argument has also identified dangling literary references in the book:

Minor grammaticals:
* ch19-04-advanced-types dead links:
`“The Newtype Pattern to Implement External Traits on External Types.”`
Suggested:  `“Using the Newtype Pattern to Implement External Traits on External Types”`

* ch17-02:
Uppercase needed for “that” in referenced title

* ch17-03-oo-design-patterns dead links:
`“Cases When You Have More Information Than the Compiler”` 
Suggested: `“Cases in Which You Have More Information Than the Compiler”`

* ch14-02-publishing-to-crates-io dead links:
``“Treating Smart Pointers like Regular References with the `Deref` Trait”``
Uppercase needed for  “like”

* ch11-01-writing-tests dead links:
`“Derivable Traits,”`
Suggested: `“Derivable Traits”`

* ch17-02-trait-objects dead links:
`“Dynamically Sized Types & Sized”`
Suggested: `“Dynamically Sized Types and the Sized Trait”`

Also ones that I'm not sure about/unresolved:

* ch04-01-what-is-ownership dead links:
`“Module Definitions”`

* ch15-04-rc dead links:
`“Preventing Reference Cycles”`

* ch17-02-trait-objects dead links:
`“Dynamically Sized Types & Sized”`

* ch11-03-test-organization dead links:
`“Moving Modules to Other Files”`
`“Rules of Module Filesystems”`

* ch19-03-advanced-traits dead links:
`“Using Tuple Structs without Named Fields to Create Different Types”`
