### PR TITLE
macros: add additional note

### DIFF
--- a/2018-edition/src/appendix-04-macros.md
+++ b/2018-edition/src/appendix-04-macros.md
@@ -79,6 +79,15 @@ source code passed to the macro, the patterns are compared with the structure
 of that source code, and the code associated with each pattern is the code that
 replaces the code passed to the macro. This all happens during compilation.
 
+> Note: Unlike macros in C, Rust macros cannot return entirely arbritary chunks
+> of code; there are restrictions that require that it be something well-formed.
+> Also, the code returned from a macro, if given as a parameter to another macro
+> call, matches against a token tree; the macro pattern matching will not
+> destructure that token tree, it sees it as an opaque object. Thus, for
+> instance, you cannot create a pair of macros where one returns a fixed array
+> of items, and pass the returned code into the second for it to add one or
+> more additional items.
+
 To define a macro, you use the `macro_rules!` construct. Let’s explore how to
 use `macro_rules!` by looking at how the `vec!` macro is defined. Chapter 8
 covered how we can use the `vec!` macro to create a new vector with particular


### PR DESCRIPTION
point out:
 - well formed bits of code must be returned, not something arbitrary like
   we did in C
 - that the return from a macro is an opaque token tree object, which is
   not destructured if passed as the param to another macro in a nested
   call.

I have wasted much time myself in frustration on the latter only to find
it was not possible. It would have been helpful if the book had mentioned
this.