### PR TITLE
ch13: closures capture from scope they're *defined* in, not *called* in

### DIFF
--- a/2018-edition/src/ch13-01-closures.md
+++ b/2018-edition/src/ch13-01-closures.md
@@ -3,7 +3,7 @@
 Rust’s closures are anonymous functions you can save in a variable or pass as
 arguments to other functions. You can create the closure in one place and then
 call the closure to evaluate it in a different context. Unlike functions,
-closures can capture values from the scope in which they’re called. We’ll
+closures can capture values from the scope in which they’re defined. We’ll
 demonstrate how these closure features allow for code reuse and behavior
 customization.
 


### PR DESCRIPTION
Closures don't capture values from the scope in which they're *called*, otherwise this code would compile and print "42":

```rust
fn main() {
    let closure = |x| a + x;

    {
        let a = 12;
        println!("{}", closure(30));
    }
}
```

In fact, [Rust can't find `a` in the scope where `closure` is defined](https://play.rust-lang.org/?version=stable&mode=debug&edition=2015&gist=4a6beb2f11f8ec02e1811d7ab1353fd6).

The same issue exists in the second edition, but I wasn't sure if I should fix it as well: CONTRIBUTING.md states the 2nd ed is frozen and doesn't accept changes, while README and PR template both state that factual errors should be corrected. What should I do?

And, since I don't know when the next opportunity will present itself: thank you for the great book! I especially love how some examples teach both Rust and some less-well-known technique (like memoization here in chapter 13). Thanks!