### PR TITLE
Mention more about `Cargo.lock` early on

### DIFF
--- a/2018-edition/src/ch01-03-hello-cargo.md
+++ b/2018-edition/src/ch01-03-hello-cargo.md
@@ -139,9 +139,12 @@ If all goes well, `Hello, world!` should print to the terminal. Running `cargo
 build` for the first time also causes Cargo to create a new file at the top
 level: *Cargo.lock*. This file is a "locked" version of *Cargo.toml*, which
 keeps track of the *exact* versions of dependencies, rather than the more loose
-requirements in *Cargo.toml*. We'll go over this file in more detail later, but
-for now, know that it helps make sure we get the same results from `cargo build`
-until we run `cargo update` to update this file.
+requirements in *Cargo.toml*. This ensures that we "lock in" the same results
+from `cargo build` until we run `cargo update` to update this file. For more
+information see what the [cargo book][toml vs lock] has to say about the
+difference between these two files.
+
+[toml vs lock]: https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html
 
 We just built a project with `cargo build` and ran it with
 `./target/debug/hello_cargo`, but we can also use `cargo run` to compile the

--- a/2018-edition/src/ch01-03-hello-cargo.md
+++ b/2018-edition/src/ch01-03-hello-cargo.md
@@ -137,10 +137,11 @@ Hello, world!
 
 If all goes well, `Hello, world!` should print to the terminal. Running `cargo
 build` for the first time also causes Cargo to create a new file at the top
-level: *Cargo.lock*. This file keeps track of the exact versions of
-dependencies in your project. This project doesn’t have dependencies, so the
-file is a bit sparse. You won’t ever need to change this file manually; Cargo
-manages its contents for you.
+level: *Cargo.lock*. This file is a "locked" version of *Cargo.toml*, which
+keeps track of the *exact* versions of dependencies, rather than the more loose
+requirements in *Cargo.toml*. We'll go over this file in more detail later, but
+for now, know that it helps make sure we get the same results from `cargo build`
+until we run `cargo update` to update this file.
 
 We just built a project with `cargo build` and ran it with
 `./target/debug/hello_cargo`, but we can also use `cargo run` to compile the


### PR DESCRIPTION
I'm not 100% satisfied with this, but I think that it's important to mention what `Cargo.lock` is exactly when it's mentioned, rather than what's given. Because people will start committing code to VCS as soon as they start learning, it makes sense for them to understand why they might (or might not) commit `Cargo.lock` to their repos-- arguably, I'd say that it makes sense to start out by saying "if you're not sure what to do, commit `Cargo.lock`" just under the premise that most intro users will be building binaries, not libraries.

At least for now, clarifying `cargo update` seems reasonable.