### PR TITLE
Fix typo in hello_macro_derive example

### DIFF
--- a/2018-edition/src/appendix-04-macros.md
+++ b/2018-edition/src/appendix-04-macros.md
@@ -321,7 +321,7 @@ use proc_macro::TokenStream;
 
 #[proc_macro_derive(HelloMacro)]
 pub fn hello_macro_derive(input: TokenStream) -> TokenStream {
-    // Construct a represntation of Rust code as a syntax tree
+    // Construct a representation of Rust code as a syntax tree
     // that we can manipulate
     let ast = syn::parse(input).unwrap();
 

--- a/2018-edition/src/ch19-06-macros.md
+++ b/2018-edition/src/ch19-06-macros.md
@@ -328,7 +328,7 @@ use syn;
 
 #[proc_macro_derive(HelloMacro)]
 pub fn hello_macro_derive(input: TokenStream) -> TokenStream {
-    // Construct a represntation of Rust code as a syntax tree
+    // Construct a representation of Rust code as a syntax tree
     // that we can manipulate
     let ast = syn::parse(input).unwrap();
 


### PR DESCRIPTION
In the macro comment: represntation -> representation