### PR TITLE
Update ch15-02-deref.md error message, 2018edition

### DIFF
--- a/2018-edition/src/ch15-02-deref.md
+++ b/2018-edition/src/ch15-02-deref.md
@@ -52,15 +52,13 @@ If we tried to write `assert_eq!(5, y);` instead, we would get this compilation
 error:
 
 ```text
-error[E0277]: the trait bound `{integer}: std::cmp::PartialEq<&{integer}>` is
-not satisfied
+error[E0277]: can't compare `{integer}` with `&{integer}`
  --> src/main.rs:6:5
   |
 6 |     assert_eq!(5, y);
-  |     ^^^^^^^^^^^^^^^^^ can't compare `{integer}` with `&{integer}`
+  |     ^^^^^^^^^^^^^^^^^ no implementation for `{integer} == &{integer}`
   |
-  = help: the trait `std::cmp::PartialEq<&{integer}>` is not implemented for
-  `{integer}`
+  = help: the trait `std::cmp::PartialEq<&{integer}>` is not implemented for `{integer}`
 ```
 
 Comparing a number and a reference to a number isn’t allowed because they’re


### PR DESCRIPTION
On the latest nightly (as well as on beta and stable) the error message from this particular example is slightly different than what is currently written in the book. This PR fixes that.

Follow up to #1569

