### PR TITLE
Remove most usages of 'extern crate' for 2018 edition

### DIFF
--- a/2018-edition/src/ch02-00-guessing-game-tutorial.md
+++ b/2018-edition/src/ch02-00-guessing-game-tutorial.md
@@ -515,8 +515,6 @@ Now that you’ve added the `rand` crate to *Cargo.toml*, let’s start using
 <span class="filename">Filename: src/main.rs</span>
 
 ```rust,ignore
-extern crate rand;
-
 use std::io;
 use rand::Rng;
 
@@ -605,8 +603,6 @@ will explain.
 <span class="filename">Filename: src/main.rs</span>
 
 ```rust,ignore,does_not_compile
-extern crate rand;
-
 use std::io;
 use std::cmp::Ordering;
 use rand::Rng;
@@ -957,8 +953,6 @@ secret number. Listing 2-5 shows the final code:
 <span class="filename">Filename: src/main.rs</span>
 
 ```rust,ignore
-extern crate rand;
-
 use std::io;
 use std::cmp::Ordering;
 use rand::Rng;

--- a/2018-edition/src/ch11-03-test-organization.md
+++ b/2018-edition/src/ch11-03-test-organization.md
@@ -120,7 +120,7 @@ Let’s create an integration test. With the code in Listing 11-12 still in the
 <span class="filename">Filename: tests/integration_test.rs</span>
 
 ```rust,ignore
-extern crate adder;
+use adder;
 
 #[test]
 fn it_adds_two() {
@@ -131,9 +131,9 @@ fn it_adds_two() {
 <span class="caption">Listing 11-13: An integration test of a function in the
 `adder` crate</span>
 
-We’ve added `extern crate adder` at the top of the code, which we didn’t need
-in the unit tests. The reason is that each test in the `tests` directory is a
-separate crate, so we need to import our library into each of them.
+We’ve added `use adder` at the top of the code, which we didn’t need in the
+unit tests. The reason is that each test in the `tests` directory is a separate
+crate, so we need to import our library into each of them.
 
 We don’t need to annotate any code in *tests/integration_test.rs* with
 `#[cfg(test)]`. Cargo treats the `tests` directory specially and compiles files
@@ -280,7 +280,7 @@ function from the `it_adds_two` test in *tests/integration_test.rs*:
 <span class="filename">Filename: tests/integration_test.rs</span>
 
 ```rust,ignore
-extern crate adder;
+use adder;
 
 mod common;
 
@@ -299,14 +299,14 @@ we demonstrated in Listing 7-4. Then in the test function, we can call the
 
 If our project is a binary crate that only contains a *src/main.rs* file and
 doesn’t have a *src/lib.rs* file, we can’t create integration tests in the
-*tests* directory and use `extern crate` to import functions defined in the
+*tests* directory and use `use` to import functions defined in the
 *src/main.rs* file. Only library crates expose functions that other crates can
 call and use; binary crates are meant to be run on their own.
 
 This is one of the reasons Rust projects that provide a binary have a
 straightforward *src/main.rs* file that calls logic that lives in the
 *src/lib.rs* file. Using that structure, integration tests *can* test the
-library crate by using `extern crate` to exercise the important functionality.
+library crate by using `use` to make the important functionality available.
 If the important functionality works, the small amount of code in the
 *src/main.rs* file will work as well, and that small amount of code doesn’t
 need to be tested.

--- a/2018-edition/src/ch12-03-improving-error-handling-and-modularity.md
+++ b/2018-edition/src/ch12-03-improving-error-handling-and-modularity.md
@@ -639,11 +639,10 @@ binary crate in *src/main.rs*, as shown in Listing 12-14:
 <span class="filename">Filename: src/main.rs</span>
 
 ```rust,ignore
-extern crate minigrep;
-
 use std::env;
 use std::process;
 
+use minigrep;
 use minigrep::Config;
 
 fn main() {
@@ -657,11 +656,11 @@ fn main() {
 <span class="caption">Listing 12-14: Bringing the `minigrep` crate into the
 scope of *src/main.rs*</span>
 
-To bring the library crate into the binary crate, we use `extern crate
-minigrep`. Then we add a `use minigrep::Config` line to bring the `Config` type
-into scope, and we prefix the `run` function with our crate name. Now all the
-functionality should be connected and should work. Run the program with `cargo
-run` and make sure everything works correctly.
+To bring the library crate into the binary crate, we use `use minigrep`.
+Then we add a `use minigrep::Config` line to bring the `Config` type
+into scope as well, and we prefix the `run` function with our crate name. Now
+all the functionality should be connected and should work. Run the program with
+`cargo run` and make sure everything works correctly.
 
 Whew! That was a lot of work, but we’ve set ourselves up for success in the
 future. Now it’s much easier to handle errors, and we’ve made the code more

--- a/2018-edition/src/ch14-02-publishing-to-crates-io.md
+++ b/2018-edition/src/ch14-02-publishing-to-crates-io.md
@@ -242,8 +242,6 @@ and `mix` items from the `art` crate:
 <span class="filename">Filename: src/main.rs</span>
 
 ```rust,ignore
-extern crate art;
-
 use art::kinds::PrimaryColor;
 use art::utils::mix;
 
@@ -311,8 +309,6 @@ structure in Listing 14-5, as shown in Listing 14-6:
 <span class="filename">Filename: src/main.rs</span>
 
 ```rust,ignore
-extern crate art;
-
 use art::PrimaryColor;
 use art::mix;
 

--- a/2018-edition/src/ch14-03-cargo-workspaces.md
+++ b/2018-edition/src/ch14-03-cargo-workspaces.md
@@ -138,14 +138,14 @@ Cargo doesn’t assume that crates in a workspace will depend on each other, so
 we need to be explicit about the dependency relationships between the crates.
 
 Next, let’s use the `add_one` function from the `add-one` crate in the `adder`
-crate. Open the *adder/src/main.rs* file and add an `extern crate` line at
-the top to bring the new `add-one` library crate into scope. Then change the
-`main` function to call the `add_one` function, as in Listing 14-7:
+crate. Open the *adder/src/main.rs* file and add an `use` line at the top to
+bring the new `add-one` library crate into scope. Then change the `main`
+function to call the `add_one` function, as in Listing 14-7:
 
 <span class="filename">Filename: adder/src/main.rs</span>
 
 ```rust,ignore
-extern crate add_one;
+use add_one;
 
 fn main() {
     let num = 10;
@@ -200,9 +200,9 @@ crate:
 rand = "0.3.14"
 ```
 
-We can now add `extern crate rand;` to the *add-one/src/lib.rs* file, and
-building the whole workspace by running `cargo build` in the *add* directory
-will bring in and compile the `rand` crate:
+We can now add `use rand;` to the *add-one/src/lib.rs* file, and building the
+whole workspace by running `cargo build` in the *add* directory will bring in
+and compile the `rand` crate:
 
 ```text
 $ cargo build
@@ -229,7 +229,7 @@ error: use of unstable library feature 'rand': use `rand` from crates.io (see
 issue #27703)
  --> adder/src/main.rs:1:1
   |
-1 | extern crate rand;
+1 | use rand;
 ```
 
 To fix this, edit the *Cargo.toml* file for the `adder` crate and indicate that

--- a/2018-edition/src/ch17-02-trait-objects.md
+++ b/2018-edition/src/ch17-02-trait-objects.md
@@ -212,7 +212,6 @@ If someone using our library decides to implement a `SelectBox` struct that has
 <span class="filename">Filename: src/main.rs</span>
 
 ```rust,ignore
-extern crate gui;
 use gui::Draw;
 
 struct SelectBox {
@@ -296,7 +295,6 @@ with a `String` as a component:
 <span class="filename">Filename: src/main.rs</span>
 
 ```rust,ignore,does_not_compile
-extern crate gui;
 use gui::Screen;
 
 fn main() {

--- a/2018-edition/src/ch17-03-oo-design-patterns.md
+++ b/2018-edition/src/ch17-03-oo-design-patterns.md
@@ -35,7 +35,6 @@ because we haven’t implemented the `blog` crate yet.
 <span class="filename">Filename: src/main.rs</span>
 
 ```rust,ignore
-extern crate blog;
 use blog::Post;
 
 fn main() {
@@ -528,7 +527,6 @@ Let’s consider the first part of `main` in Listing 17-11:
 <span class="filename">Filename: src/main.rs</span>
 
 ```rust,ignore
-# extern crate blog;
 # use blog::Post;
 
 fn main() {
@@ -670,7 +668,6 @@ The updated code in `main` is shown in Listing 17-21:
 <span class="filename">Filename: src/main.rs</span>
 
 ```rust,ignore
-extern crate blog;
 use blog::Post;
 
 fn main() {

--- a/2018-edition/src/ch19-06-macros.md
+++ b/2018-edition/src/ch19-06-macros.md
@@ -167,7 +167,7 @@ The second form of macros is called *procedural macros* because they’re more
 like functions (which are a type of procedure). Procedural macros accept some
 Rust code as an input, operate on that code, and produce some Rust code as an
 output rather than matching against patterns and replacing the code with other
-code as declarative macros do. 
+code as declarative macros do.
 
 While there are three kinds of procedural macros, they all work in a similar
 fashion. First, they must reside in their own crate, with a special crate type.
@@ -175,19 +175,15 @@ This is for complex technical reasons that we hope to eliminate in the future,
 and so won't discuss here. Second, they all take a form like this:
 
 ```rust,ignore
-extern crate proc_macro;
+use proc_macro;
 
 #[some_attribute]
 pub fn some_name(input: TokenStream) -> TokenStream {
 }
 ```
 
-First, the `extern crate` line. `extern crate` is a holdover from the old
-Rust module system; for now, when defining a proc macro, you must add this
-line to your `src/lib.rs`. Someday, this will not be necessary.
-
-Second, procedural macros consist of a function, which is how they get their
-name: "procedure" is a synonym for "function." Why not call them "functional
+Procedural macros consist of a function, which is how they get their name:
+"procedure" is a synonym for "function." Why not call them "functional
 macros"? Well, one of the types is "function-like", and that would get
 confusing. Anyway, the function takes a `TokenStream` as an input, and
 produces a `TokenStream` as an output. This is the core of the macro;
@@ -196,7 +192,7 @@ and the code we produce from our macro is the output `TokenStream`.
 We'll talk more about `TokenStream` when we actually build one of these
 things. Finally, the function has an attribute on it; this attribute
 says which kind of procedural macro we're creating. We can have multiple
-kinds of procedual macros in the same crate.
+kinds of procedural macros in the same crate.
 
 Given that the kinds of macros are so similar, we'll start with a custom
 derive macro, and then in the other sections, we'll explain the small
@@ -320,8 +316,6 @@ compile until we add a definition for the `impl_hello_macro` function.
 <span class="filename">Filename: hello_macro_derive/src/lib.rs</span>
 
 ```rust,ignore
-extern crate proc_macro;
-
 use proc_macro::TokenStream;
 use quote::quote;
 use syn;

--- a/2018-edition/src/ch20-02-multithreaded.md
+++ b/2018-edition/src/ch20-02-multithreaded.md
@@ -244,7 +244,6 @@ following code to the top of *src/bin/main.rs*:
 <span class="filename">Filename: src/bin/main.rs</span>
 
 ```rust,ignore
-extern crate hello;
 use hello::ThreadPool;
 ```
 

--- a/2018-edition/src/ch20-03-graceful-shutdown-and-cleanup.md
+++ b/2018-edition/src/ch20-03-graceful-shutdown-and-cleanup.md
@@ -383,7 +383,6 @@ Here’s the full code for reference:
 <span class="filename">Filename: src/bin/main.rs</span>
 
 ```rust,ignore
-extern crate hello;
 use hello::ThreadPool;
 
 use std::io::prelude::*;


### PR DESCRIPTION
As 2018 edition rust allows the use of 'use' in most contexts instead of
first requiring 'extern crate', we can remove them from code examples
and change the surrounding text to match.