### PR TITLE
Clarify performance distinctions between stack vs heap

### DIFF
--- a/2018-edition/src/ch04-01-what-is-ownership.md
+++ b/2018-edition/src/ch04-01-what-is-ownership.md
@@ -34,30 +34,32 @@ strings.
 > to use at runtime, but they are structured in different ways. The stack stores
 > values in the order it gets them and removes the values in the opposite order.
 > This is referred to as *last in, first out*. Think of a stack of plates: when
-> you add more plates, you put them on top of the pile, and when you need a
-> plate, you take one off the top. Adding or removing plates from the middle or
-> bottom wouldn’t work as well! Adding data is called *pushing onto the stack*,
-> and removing data is called *popping off the stack*.
+> you add more plates, you put them on top of the pile, and when you need a plate,
+> you take one off the top. Adding or removing plates from the middle or bottom
+> wouldn’t work as well! Adding data is called *pushing onto the stack*, and
+> removing data is called *popping off the stack*.
 >
-> The stack is fast because of the way it accesses the data: it never has to
-> search for a place to put new data or a place to get data from because that
-> place is always the top. Another property that makes the stack fast is that
-> all data on the stack must take up a known, fixed size.
->
-> Data with a size unknown at compile time or a size that might change can be
-> stored on the heap instead. The heap is less organized: when you put data on
-> the heap, you ask for some amount of space. The operating system finds an
-> empty spot somewhere in the heap that is big enough, marks it as being in
-> use, and returns a *pointer*, which is the address of that location. This
-> process is called *allocating on the heap*, sometimes abbreviated as just
-> “allocating.” Pushing values onto the stack is not considered allocating.
-> Because the pointer is a known, fixed size, you can store the pointer on the
-> stack, but when you want the actual data, you have to follow the pointer.
+> All data stored on the stack must have a known, fixed size. Data with a size
+> that is unknown at compile time or a size that might change must be stored on
+> the heap instead. The heap is less organized: when you put data on the heap,
+> you ask for some amount of space. The operating system finds an empty spot
+> somewhere in the heap that is big enough, marks it as being in use, and returns
+> a *pointer*, which is the address of that location. This process is called
+> *allocating on the heap*, sometimes abbreviated as just “allocating.” Pushing
+> values onto the stack is not considered allocating. Because the pointer is a
+> known, fixed size, you can store the pointer on the stack, but when you want
+> the actual data, you have to follow the pointer.
 >
 > Think of being seated at a restaurant. When you enter, you state the number of
 > people in your group, and the staff finds an empty table that fits everyone
 > and leads you there. If someone in your group comes late, they can ask where
 > you’ve been seated to find you.
+>
+> Pushing to the stack is faster than allocating on the heap because it never has
+> to search for a place to put new data - that place is always at the top of the
+> stack. Comparatively, allocating space on the heap requires more work, since
+> the operating system must first find a space big enough to hold the data and
+> then perform bookkeeping to prepare for the next allocation.
 >
 > Accessing data in the heap is slower than accessing data on the stack because
 > you have to follow a pointer to get there. Contemporary processors are faster


### PR DESCRIPTION
closes #1524

Github diff doesn't work very well on this patch so to summarize here:

* Replaces lines 42 - 45 with lines 58 - 63
    * Moves the paragraphs dealing with performance together instead of being split apart
    * Avoids discussing why the stack tends to be fast (implictly: relative to the heap) before actually discussing what heap allocation is
    * Reworded to be more precise