### PR TITLE
Wording: in 17.1 one method reads only

### DIFF
--- a/2018-edition/src/ch17-01-what-is-oo.md
+++ b/2018-edition/src/ch17-01-what-is-oo.md
@@ -101,11 +101,11 @@ impl AveragedCollection {
 <span class="caption">Listing 17-2: Implementations of the public methods
 `add`, `remove`, and `average` on `AveragedCollection`</span>
 
-The public methods `add`, `remove`, and `average` are the only ways to modify
-an instance of `AveragedCollection`. When an item is added to `list` using the
-`add` method or removed using the `remove` method, the implementations of each
-call the private `update_average` method that handles updating the `average`
-field as well.
+The public methods `add`, `remove`, and `average` are the only ways to access 
+or modify data in an instance of `AveragedCollection`. When an item is added 
+to `list` using the `add` method or removed using the `remove` method, the 
+implementations of each call the private `update_average` method that handles 
+updating the `average` field as well.
 
 We leave the `list` and `average` fields private so there is no way for
 external code to add or remove items to the `list` field directly; otherwise,


### PR DESCRIPTION
average(&self) doesn't mutate self, in other words it never modifies the object being operated on.

## What to expect when you open a pull request here

### 2018 Edition

The 2018 is a "living" edition; it's not scheduled for in-print publication at
this time, and so is able to be updated at any time. We'd love pull requests to
fix issues with this edition, but we're not interested in extremely large
changes without discussing them first. If you'd like to make a big change,
please open an issue first! We'd hate for you to do some hard work that we
ultimately wouldn't accept.

### Second edition

No Starch Press has brought the second edition to print. Pull requests fixing
factual errors will be accepted and documented as errata; pull requests changing
wording or other small corrections should be made against the 2018 edition instead.

### First edition

The first edition is frozen, and no longer accepting changes. Pull requests
made against it will be closed.


Thank you for reading, you may now delete this text!
