### PR TITLE
Fixes a typo in Chapter 10.3 and a bug in chapter 12.3

### DIFF
--- a/2018-edition/src/ch10-03-lifetime-syntax.md
+++ b/2018-edition/src/ch10-03-lifetime-syntax.md
@@ -333,7 +333,7 @@ In this example, `string1` is valid until the end of the outer scope, `string2`
 is valid until the end of the inner scope, and `result` references something
 that is valid until the end of the inner scope. Run this code, and you’ll see
 that the borrow checker approves of this code; it will compile and print `The
-longest string is long string is long`.
+longest string is long`.
 
 Next, let’s try an example that shows that the lifetime of the reference in
 `result` must be the smaller lifetime of the two arguments. We’ll move the

--- a/2018-edition/src/ch12-03-improving-error-handling-and-modularity.md
+++ b/2018-edition/src/ch12-03-improving-error-handling-and-modularity.md
@@ -401,7 +401,7 @@ fn main() {
 
     let config = Config::new(&args).unwrap_or_else(|err| {
         println!("Problem parsing arguments: {}", err);
-        process::exit(1);
+        process::exit(1)
     });
 
     // --snip--


### PR DESCRIPTION
## What to expect when you open a pull request here

### 2018 Edition

The 2018 is a "living" edition; it's not scheduled for in-print publication at
this time, and so is able to be updated at any time. We'd love pull requests to
fix issues with this edition, but we're not interested in extremely large
changes without discussing them first. If you'd like to make a big change,
please open an issue first! We'd hate for you to do some hard work that we
ultimately wouldn't accept.

### Second edition

No Starch Press has brought the second edition to print. Pull requests fixing
factual errors will be accepted and documented as errata; pull requests changing
wording or other small corrections should be made against the 2018 edition instead.

### First edition

The first edition is frozen, and no longer accepting changes. Pull requests
made against it will be closed.


Thank you for reading, you may now delete this text!
