### PR TITLE
Make Twos Complement a link.

### DIFF
--- a/src/ch03-02-data-types.md
+++ b/src/ch03-02-data-types.md
@@ -66,9 +66,7 @@ with it (signed) or whether it will only ever be positive and can therefore be
 represented without a sign (unsigned). It’s like writing numbers on paper: when
 the sign matters, a number is shown with a plus sign or a minus sign; however,
 when it’s safe to assume the number is positive, it’s shown with no sign.
-Signed numbers are stored using two’s complement representation (if you’re
-unsure what this is, you can search for it online; an explanation is outside
-the scope of this book).
+Signed numbers are stored using [two’s complement](https://en.wikipedia.org/wiki/Two%27s_complement) representation.
 
 Each signed variant can store numbers from -(2<sup>n - 1</sup>) to 2<sup>n -
 1</sup> - 1 inclusive, where *n* is the number of bits that variant uses. So an


### PR DESCRIPTION
Sorry if I'm out of line submitting a PR like this - it's my first time. I felt having Twos complement as text was advertising what the book didn't cover, rather than what it did, and a simple link to Wikipedia would serve better. I completely understand if the community doesn't agree.

Hope you all have a lovely day.