### PR TITLE
Add edition = "2018" to all Cargo.toml listings

### DIFF
--- a/src/ch02-00-guessing-game-tutorial.md
+++ b/src/ch02-00-guessing-game-tutorial.md
@@ -35,6 +35,7 @@ Look at the generated *Cargo.toml* file:
 name = "guessing_game"
 version = "0.1.0"
 authors = ["Your Name <you@example.com>"]
+edition = "2018"
 
 [dependencies]
 ```

--- a/src/ch14-02-publishing-to-crates-io.md
+++ b/src/ch14-02-publishing-to-crates-io.md
@@ -429,6 +429,7 @@ when you created the crate, your description, and a license added, the
 name = "guessing_game"
 version = "0.1.0"
 authors = ["Your Name <you@example.com>"]
+edition = "2018"
 description = "A fun game where you guess what number the computer has chosen."
 license = "MIT OR Apache-2.0"
 


### PR DESCRIPTION
Fixes #1663.

This might cause confusion because we're then relying on `edition="2018"` later.