### PR TITLE
[2018 Edition] Fix the guessing game code examples

### DIFF
--- a/src/ch02-00-guessing-game-tutorial.md
+++ b/src/ch02-00-guessing-game-tutorial.md
@@ -516,6 +516,8 @@ Now that you’ve added the `rand` crate to *Cargo.toml*, let’s start using
 <span class="filename">Filename: src/main.rs</span>
 
 ```rust,ignore
+extern crate rand;
+
 use std::io;
 use rand::Rng;
 
@@ -604,6 +606,8 @@ will explain.
 <span class="filename">Filename: src/main.rs</span>
 
 ```rust,ignore,does_not_compile
+extern crate rand;
+
 use std::io;
 use std::cmp::Ordering;
 use rand::Rng;
@@ -968,6 +972,8 @@ secret number. Listing 2-6 shows the final code.
 <span class="filename">Filename: src/main.rs</span>
 
 ```rust,ignore
+extern crate rand;
+
 use std::io;
 use std::cmp::Ordering;
 use rand::Rng;


### PR DESCRIPTION
This fixes some code examples that must be compiled successfully, by adding `extern crate rand;`

```
$ rustc --version && cargo --version
rustc 1.30.1 (1433507eb 2018-11-07)
cargo 1.30.0 (a1a4ad372 2018-11-02)
```