### PR TITLE
Update Rust code in "tools" to 2018 edition Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "rust-book"
 version = "0.0.1"
 authors = ["Steve Klabnik <steve@steveklabnik.com>"]
 description = "The Rust Book"
+edition = "2018"
 
 [[bin]]
 name = "concat_chapters"

--- a/tools/src/bin/concat_chapters.rs
+++ b/tools/src/bin/concat_chapters.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 #[macro_use] extern crate lazy_static;
-extern crate regex;
+
 
 use std::env;
 use std::io;

--- a/tools/src/bin/concat_chapters.rs
+++ b/tools/src/bin/concat_chapters.rs
@@ -89,18 +89,18 @@ fn group_by_target(matched_files: Vec<(PathBuf, PathBuf)>) -> BTreeMap<PathBuf, 
 
 fn concat_files(source_paths: Vec<PathBuf>, target_path: PathBuf) -> io::Result<()> {
     println!("Concatenating into {}:", target_path.to_string_lossy());
-    let mut target = try!(File::create(target_path));
-    try!(target.write_all(b"\n[TOC]\n"));
+    let mut target = File::create(target_path)?;
+    target.write_all(b"\n[TOC]\n")?;
 
     for path in source_paths {
         println!("  {}", path.to_string_lossy());
-        let mut source = try!(File::open(path));
+        let mut source = File::open(path)?;
         let mut contents: Vec<u8> = Vec::new();
-        try!(source.read_to_end(&mut contents));
+        source.read_to_end(&mut contents)?;
 
-        try!(target.write_all(b"\n"));
-        try!(target.write_all(&contents));
-        try!(target.write_all(b"\n"));
+        target.write_all(b"\n")?;
+        target.write_all(&contents)?;
+        target.write_all(b"\n")?;
     }
     Ok(())
 }
@@ -108,7 +108,7 @@ fn concat_files(source_paths: Vec<PathBuf>, target_path: PathBuf) -> io::Result<
 fn ensure_dir_exists(dir_string: &str) -> io::Result<&Path> {
     let path = Path::new(dir_string);
     if !path.exists() {
-        try!(create_dir(path));
+        create_dir(path)?;
     }
     Ok(&path)
 }

--- a/tools/src/bin/convert_quotes.rs
+++ b/tools/src/bin/convert_quotes.rs
@@ -34,7 +34,7 @@ fn main() {
             is_in_html_tag = false;
             write!(io::stdout(), "{}\n", line).unwrap();
         } else {
-            let mut modified_line = &mut String::new();
+            let modified_line = &mut String::new();
             let mut previous_char = std::char::REPLACEMENT_CHARACTER;
             let mut chars_in_line = line.chars();
 

--- a/tools/src/bin/lfp.rs
+++ b/tools/src/bin/lfp.rs
@@ -11,10 +11,10 @@
 // We have some long regex literals, so:
 // ignore-tidy-linelength
 
-extern crate rustc_serialize;
-extern crate docopt;
+
+
 use docopt::Docopt;
-extern crate walkdir;
+use walkdir;
 use std::{path, fs, io};
 use std::io::{BufRead, Write};
 

--- a/tools/src/bin/link2print.rs
+++ b/tools/src/bin/link2print.rs
@@ -12,7 +12,7 @@
 // FIXME: We have some long lines that could be refactored, but it's not a big deal.
 // ignore-tidy-linelength
 
-extern crate regex;
+
 
 use std::collections::HashMap;
 use std::io;
@@ -40,7 +40,7 @@ fn parse_references(buffer: String) -> (String, HashMap<String, String>) {
     let mut ref_map = HashMap::new();
     // FIXME: Currently doesn't handle "title" in following line
     let re = Regex::new(r###"(?m)\n?^ {0,3}\[([^]]+)\]:[[:blank:]]*(.*)$"###).unwrap();
-    let output = re.replace_all(&buffer, |caps: &Captures| {
+    let output = re.replace_all(&buffer, |caps: &Captures<'_>| {
         let key = caps.at(1).unwrap().to_owned().to_uppercase();
         let val = caps.at(2).unwrap().to_owned();
         if ref_map.insert(key, val).is_some() {
@@ -55,7 +55,7 @@ fn parse_links((buffer, ref_map): (String, HashMap<String, String>)) -> String {
     // FIXME: check which punctuation is allowed by spec
     let re = Regex::new(r###"(?:(?P<pre>(?:```(?:[^`]|`[^`])*`?\n```\n)|(?:[^[]`[^`\n]+[\n]?[^`\n]*`))|(?:\[(?P<name>[^]]+)\](?:(?:\([[:blank:]]*(?P<val>[^")]*[^ ])(?:[[:blank:]]*"[^"]*")?\))|(?:\[(?P<key>[^]]*)\]))?))"###).expect("could not create regex");
     let error_code = Regex::new(r###"^E\d{4}$"###).expect("could not create regex");
-    let output = re.replace_all(&buffer, |caps: &Captures| {
+    let output = re.replace_all(&buffer, |caps: &Captures<'_>| {
         match caps.name("pre") {
             Some(pre_section) => format!("{}", pre_section.to_owned()),
             None => {

--- a/tools/src/bin/remove_links.rs
+++ b/tools/src/bin/remove_links.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate regex;
+
 
 use std::io;
 use std::io::{Read, Write};
@@ -26,7 +26,7 @@ fn main () {
     // capture all links and link references
     let regex = r"\[([^\]]+)\](?:(?:\[([^\]]+)\])|(?:\([^\)]+\)))(?i)<!-- ignore -->";
     let link_regex = Regex::new(regex).unwrap();
-    let first_pass = link_regex.replace_all(&buffer, |caps: &Captures| {
+    let first_pass = link_regex.replace_all(&buffer, |caps: &Captures<'_>| {
 
         // save the link reference we want to delete
         if let Some(reference) = caps.at(2) {
@@ -39,7 +39,7 @@ fn main () {
 
     // search for the references we need to delete
     let ref_regex = Regex::new(r"\n\[([^\]]+)\]:\s.*\n").unwrap();
-    let out = ref_regex.replace_all(&first_pass, |caps: &Captures| {
+    let out = ref_regex.replace_all(&first_pass, |caps: &Captures<'_>| {
         let capture = caps.at(1).unwrap().to_owned();
 
         // check if we've marked this reference for deletion...

--- a/tools/src/bin/remove_markup.rs
+++ b/tools/src/bin/remove_markup.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate regex;
+
 use std::io;
 use std::io::{Read, Write};
 use regex::{Regex, Captures};
@@ -50,7 +50,7 @@ fn remove_markup(input: String) -> String {
         // Remove the span around filenames and captions
         } else {
             let result = regexen.iter().fold(line.to_string(), |result, regex| {
-                regex.replace_all(&result, |caps: &Captures| {
+                regex.replace_all(&result, |caps: &Captures<'_>| {
                     caps.at(1).unwrap().to_owned()
                 })
             });


### PR DESCRIPTION
Ran:

* cargo fix --edition
* cargo fix --edition-idioms

And manually updated ```concat_chapters.rs``` to use the ```?``` operator instead of the ```try!``` macro.

Tested:

* That the tools compile (cargo build)
* That none of the doctests fail (cargo test)
