### PR TITLE
Change use cons list enum to crate to refer to the current crate.

### DIFF
--- a/src/ch15-01-box.md
+++ b/src/ch15-01-box.md
@@ -129,7 +129,7 @@ Listing 15-3:
 <span class="filename">Filename: src/main.rs</span>
 
 ```rust,ignore
-use List::{Cons, Nil};
+use crate::List::{Cons, Nil};
 
 fn main() {
     let list = Cons(1, Cons(2, Cons(3, Nil)));
@@ -240,7 +240,7 @@ enum List {
     Nil,
 }
 
-use List::{Cons, Nil};
+use crate::List::{Cons, Nil};
 
 fn main() {
     let list = Cons(1,

--- a/src/ch15-04-rc.md
+++ b/src/ch15-04-rc.md
@@ -56,7 +56,7 @@ enum List {
     Nil,
 }
 
-use List::{Cons, Nil};
+use crate::List::{Cons, Nil};
 
 fn main() {
     let a = Cons(5,
@@ -115,7 +115,7 @@ enum List {
     Nil,
 }
 
-use List::{Cons, Nil};
+use crate::List::{Cons, Nil};
 use std::rc::Rc;
 
 fn main() {
@@ -161,7 +161,7 @@ then we can see how the reference count changes when `c` goes out of scope.
 #     Nil,
 # }
 #
-# use List::{Cons, Nil};
+# use crate::List::{Cons, Nil};
 # use std::rc::Rc;
 #
 fn main() {

--- a/src/ch15-05-interior-mutability.md
+++ b/src/ch15-05-interior-mutability.md
@@ -419,7 +419,7 @@ enum List {
     Nil,
 }
 
-use List::{Cons, Nil};
+use crate::List::{Cons, Nil};
 use std::rc::Rc;
 use std::cell::RefCell;
 

--- a/src/ch15-06-reference-cycles.md
+++ b/src/ch15-06-reference-cycles.md
@@ -24,7 +24,7 @@ doc tests do; the `use List` fails if this listing is put within a main -->
 # fn main() {}
 use std::rc::Rc;
 use std::cell::RefCell;
-use List::{Cons, Nil};
+use crate::List::{Cons, Nil};
 
 #[derive(Debug)]
 enum List {
@@ -61,7 +61,7 @@ reference counts are at various points in this process.
 <span class="filename">Filename: src/main.rs</span>
 
 ```rust
-# use List::{Cons, Nil};
+# use crate::List::{Cons, Nil};
 # use std::rc::Rc;
 # use std::cell::RefCell;
 # #[derive(Debug)]


### PR DESCRIPTION
Use crate for cons list to refer to current crate. This change allows code to run for both 2015 and 2018 edition.

The crate keyword is mentioned in chapter 7 section 2.