### PR TITLE
Fix typos in Chapter 9.3

### DIFF
--- a/src/ch09-03-to-panic-or-not-to-panic.md
+++ b/src/ch09-03-to-panic-or-not-to-panic.md
@@ -193,7 +193,7 @@ impl Guess {
 values between 1 and 100</span>
 
 First, we define a struct named `Guess` that has a field named `value` that
-holds a `i32`. This is where the number will be stored.
+holds an `i32`. This is where the number will be stored.
 
 Then we implement an associated function named `new` on `Guess` that creates
 instances of `Guess` values. The `new` function is defined to have one
@@ -210,7 +210,7 @@ of a `panic!` in the API documentation that you create in Chapter 14. If
 to the `value` parameter and return the `Guess`.
 
 Next, we implement a method named `value` that borrows `self`, doesn’t have any
-other parameters, and returns a `i32`. This kind of method is sometimes called
+other parameters, and returns an `i32`. This kind of method is sometimes called
 a *getter*, because its purpose is to get some data from its fields and return
 it. This public method is necessary because the `value` field of the `Guess`
 struct is private. It’s important that the `value` field be private so code
@@ -220,7 +220,7 @@ the module *must* use the `Guess::new` function to create an instance of
 hasn’t been checked by the conditions in the `Guess::new` function.
 
 A function that has a parameter or returns only numbers between 1 and 100 could
-then declare in its signature that it takes or returns a `Guess` rather than a
+then declare in its signature that it takes or returns a `Guess` rather than an
 `i32` and wouldn’t need to do any additional checks in its body.
 
 ## Summary


### PR DESCRIPTION
Replaces "a `i32`" with "an `i32`". This is how it's written in other chapters too.