### PR TITLE
Fix misinformation in ch03-04

### DIFF
--- a/src/ch03-04-comments.md
+++ b/src/ch03-04-comments.md
@@ -1,7 +1,8 @@
 ## Comments
 
-All programmers strive to make their code easy to understand, but sometimes
-extra explanation is warranted. In these cases, programmers leave notes, or
+All sane programmers strive to make their code easy to understand, but
+sometimes extra explanation is warranted.
+In these cases, programmers leave notes, or
 *comments*, in their source code that the compiler will ignore but people
 reading the source code may find useful.
 


### PR DESCRIPTION
The first sentence of this section contained misinformation. Therefore changed "All programmers" to "All sane programmers".

(Also moved the next sentence to a new line. Ideally every sentence in the whole project would start on its own line. This would make editing more convenient while keeping the `diff`s small.)