### PR TITLE
More precisely specify cross ref for doc comments

### DIFF
--- a/src/ch03-04-comments.md
+++ b/src/ch03-04-comments.md
@@ -44,4 +44,4 @@ fn main() {
 ```
 
 Rust also has another kind of comment, documentation comments, which we’ll
-discuss in Chapter 14.
+discuss in the “Publishing a Crate to Crates.io” section of Chapter 14.


### PR DESCRIPTION
Previously it was (even after reading the cross reference) a bit cumbersome to find the exact location of the book where documentation comments are addressed.

This is because it can't be infered from the section's name that it addresses documentation or comments.

(I myself didn't find it even after clicking through the sections of chapter 14 and then had to use the search feature.)