### PR TITLE
Removed # symbol from match chapter example code

### DIFF
--- a/src/ch06-02-match.md
+++ b/src/ch06-02-match.md
@@ -69,13 +69,13 @@ following code would print “Lucky penny!” every time the method was called w
 a `Coin::Penny` but would still return the last value of the block, `1`:
 
 ```rust
-# enum Coin {
-#    Penny,
-#    Nickel,
-#    Dime,
-#    Quarter,
-# }
-#
+enum Coin {
+   Penny,
+   Nickel,
+   Dime,
+   Quarter,
+}
+
 fn value_in_cents(coin: Coin) -> u8 {
     match coin {
         Coin::Penny => {
@@ -132,19 +132,19 @@ pattern that matches values of the variant `Coin::Quarter`. When a
 quarter’s state. Then we can use `state` in the code for that arm, like so:
 
 ```rust
-# #[derive(Debug)]
-# enum UsState {
-#    Alabama,
-#    Alaska,
-# }
-#
-# enum Coin {
-#    Penny,
-#    Nickel,
-#    Dime,
-#    Quarter(UsState),
-# }
-#
+#[derive(Debug)]
+enum UsState {
+   Alabama,
+   Alaska,
+}
+
+enum Coin {
+   Penny,
+   Nickel,
+   Dime,
+   Quarter(UsState),
+}
+
 fn value_in_cents(coin: Coin) -> u8 {
     match coin {
         Coin::Penny => 1,


### PR DESCRIPTION
I'm honestly not sure if these # symbols are supposed to be here or not, so I removed them.  They didn't look to be part of the code in any way.