### PR TITLE
Update ch06-01-defining-an-enum.md

### DIFF
--- a/src/ch06-01-defining-an-enum.md
+++ b/src/ch06-01-defining-an-enum.md
@@ -256,7 +256,7 @@ useful: `Option`.
 
 ### The `Option` Enum and Its Advantages Over Null Values
 
-In the previous section, we looked at how the `IpAddr` enum let us use Rust’s
+In the previous section, we looked at how the `IpAddr` enum lets us use Rust’s
 type system to encode more information than just the data into our program.
 This section explores a case study of `Option`, which is another enum defined
 by the standard library. The `Option` type is used in many places because it


### PR DESCRIPTION
Minor typo (`let us` --> `lets us`).