### PR TITLE
ch14-02, listing 14-3: Wrong color model of enum SecondaryColor

### DIFF
--- a/src/ch14-02-publishing-to-crates-io.md
+++ b/src/ch14-02-publishing-to-crates-io.md
@@ -200,7 +200,7 @@ pub mod kinds {
         Blue,
     }
 
-    /// The secondary colors according to the RYB color model.
+    /// The secondary colors according to the OGP color model.
     pub enum SecondaryColor {
         Orange,
         Green,


### PR DESCRIPTION
Currently, the book displays this, which is incorrect.
```rust
pub mod kinds {
    /// The primary colors according to the RYB color model.
    pub enum PrimaryColor {
        Red,
        Yellow,
        Blue,
    }

    /// The secondary colors according to the RYB color model.
    pub enum SecondaryColor {
        Orange,
        Green,
        Purple,
    }
}
```