### PR TITLE
ch02-00-guessing-game missing call to extern crate

### DIFF
--- a/src/ch02-00-guessing-game-tutorial.md
+++ b/src/ch02-00-guessing-game-tutorial.md
@@ -517,6 +517,8 @@ Now that you’ve added the `rand` crate to *Cargo.toml*, let’s start using
 <span class="filename">Filename: src/main.rs</span>
 
 ```rust,ignore
+extern crate rand;
+
 use std::io;
 use rand::Rng;
 


### PR DESCRIPTION
The example under listing 2-3 will not compile without the line added to the file. This omitted line is also mentioned in the paragraph explaining it below the example.