### PR TITLE
Unused variable in Listing 14-1

### DIFF
--- a/src/ch14-02-publishing-to-crates-io.md
+++ b/src/ch14-02-publishing-to-crates-io.md
@@ -34,8 +34,6 @@ for an `add_one` function in a crate named `my_crate`:
 /// # Examples
 ///
 /// ```
-/// let five = 5;
-///
 /// assert_eq!(6, my_crate::add_one(5));
 /// ```
 pub fn add_one(x: i32) -> i32 {


### PR DESCRIPTION
Removes the unused variable `five` from the example code in the documentation comment of Listing 14-1 (Chapter 14.2). I'm happy to change this to use the variable instead, and maybe even create a variable `six` as mentioned in #1732.