### PR TITLE
Lowercase 'into' in title

### DIFF
--- a/src/ch07-02-modules-and-use-to-control-scope-and-privacy.md
+++ b/src/ch07-02-modules-and-use-to-control-scope-and-privacy.md
@@ -686,7 +686,7 @@ If instead we specified `use std::fmt::Result` and `use std::io::Result`, we’d
 have two `Result` types in the same scope and Rust wouldn’t know which one we
 meant when we used `Result`. Try it and see what compiler error you get!
 
-### Renaming Types Brought Into Scope with the `as` Keyword
+### Renaming Types Brought into Scope with the `as` Keyword
 
 There’s another solution to the problem of bringing two types of the same name
 into the same scope: we can specify a new local name for the type by adding


### PR DESCRIPTION
Noticed this while reading. All other titles use into with a lowercase `i`. For example: https://github.com/rust-lang/book/blame/master/src/ch12-03-improving-error-handling-and-modularity.md#L590

This just brings this title in line with the rest.