### PR TITLE
Remove repetition of word "setting"

### DIFF
--- a/src/ch18-03-pattern-syntax.md
+++ b/src/ch18-03-pattern-syntax.md
@@ -497,8 +497,7 @@ example, when we want to test for only part of a value but have no use for the
 other parts in the corresponding code we want to run. Listing 18-18 shows code
 responsible for managing a setting’s value. The business requirements are that
 the user should not be allowed to overwrite an existing customization of a
-setting but can unset the setting and can give the setting a value if it is
-currently unset.
+setting but can unset the setting and give it a value if it is currently unset.
 
 ```rust
 let mut setting_value = Some(5);


### PR DESCRIPTION
It sounded to me that the word "setting" we being used too many times in this sentence. I changed it to be a little less repetitive.