### PR TITLE
Change "different than" to "different from"

### DIFF
--- a/src/appendix-03-derivable-traits.md
+++ b/src/appendix-03-derivable-traits.md
@@ -14,7 +14,7 @@ library that you can use with `derive`. Each section covers:
 * The conditions in which you’re allowed or not allowed to implement the trait
 * Examples of operations that require the trait
 
-If you want different behavior than that provided by the `derive` attribute,
+If you want different behavior from that provided by the `derive` attribute,
 consult the [standard library documentation](../std/index.html)<!-- ignore -->
 for each trait for details of how to manually implement them.
 

--- a/src/ch03-01-variables-and-mutability.md
+++ b/src/ch03-01-variables-and-mutability.md
@@ -185,7 +185,7 @@ $ cargo run
 The value of x is: 12
 ```
 
-Shadowing is different than marking a variable as `mut`, because we’ll get a
+Shadowing is different from marking a variable as `mut`, because we’ll get a
 compile-time error if we accidentally try to reassign to this variable without
 using the `let` keyword. By using `let`, we can perform a few transformations
 on a value but have the variable be immutable after those transformations have

--- a/src/ch05-01-defining-structs.md
+++ b/src/ch05-01-defining-structs.md
@@ -224,7 +224,7 @@ You can also define structs that look similar to tuples, called *tuple
 structs*. Tuple structs have the added meaning the struct name provides but
 don’t have names associated with their fields; rather, they just have the types
 of the fields. Tuple structs are useful when you want to give the whole tuple a
-name and make the tuple be a different type than other tuples, and naming each
+name and make the tuple be a different type from other tuples, and naming each
 field as in a regular struct would be verbose or redundant.
 
 To define a tuple struct, start with the `struct` keyword and the struct name

--- a/src/ch10-01-syntax.md
+++ b/src/ch10-01-syntax.md
@@ -353,7 +353,7 @@ operations that are available only for floating point types.
 Generic type parameters in a struct definition aren’t always the same as those
 you use in that struct’s method signatures. For example, Listing 10-11 defines
 the method `mixup` on the `Point<T, U>` struct from Listing 10-8. The method
-takes another `Point` as a parameter, which might have different types than the
+takes another `Point` as a parameter, which might have different types from the
 `self` `Point` we’re calling `mixup` on. The method creates a new `Point`
 instance with the `x` value from the `self` `Point` (of type `T`) and the `y`
 value from the passed-in `Point` (of type `W`).
@@ -386,7 +386,7 @@ fn main() {
 ```
 
 <span class="caption">Listing 10-11: A method that uses different generic types
-than its struct’s definition</span>
+from its struct’s definition</span>
 
 In `main`, we’ve defined a `Point` that has an `i32` for `x` (with value `5`)
 and an `f64` for `y` (with value `10.4`). The `p2` variable is a `Point` struct

--- a/src/ch11-01-writing-tests.md
+++ b/src/ch11-01-writing-tests.md
@@ -709,7 +709,7 @@ means that the code in the test function did not cause a panic.
 
 Tests that use `should_panic` can be imprecise because they only indicate that
 the code has caused some panic. A `should_panic` test would pass even if the
-test panics for a different reason than the one we were expecting to happen. To
+test panics for a different reason from the one we were expecting to happen. To
 make `should_panic` tests more precise, we can add an optional `expected`
 parameter to the `should_panic` attribute. The test harness will make sure that
 the failure message contains the provided text. For example, consider the

--- a/src/ch12-05-working-with-environment-variables.md
+++ b/src/ch12-05-working-with-environment-variables.md
@@ -68,7 +68,7 @@ and should continue to pass as we work on the case-insensitive search.
 The new test for the case-*insensitive* search uses `"rUsT"` as its query. In
 the `search_case_insensitive` function we’re about to add, the query `"rUsT"`
 should match the line containing `"Rust:"` with a capital R and match the line
-`"Trust me."` even though both have different casing than the query. This is
+`"Trust me."` even though both have different casing from the query. This is
 our failing test, and it will fail to compile because we haven’t yet defined
 the `search_case_insensitive` function. Feel free to add a skeleton
 implementation that always returns an empty vector, similar to the way we did

--- a/src/ch15-02-deref.md
+++ b/src/ch15-02-deref.md
@@ -96,7 +96,7 @@ that enables us to use the dereference operator by defining our own box type.
 ### Defining Our Own Smart Pointer
 
 Let’s build a smart pointer similar to the `Box<T>` type provided by the
-standard library to experience how smart pointers behave differently than
+standard library to experience how smart pointers behave differently from
 references by default. Then we’ll look at how to add the ability to use the
 dereference operator.
 

--- a/src/ch15-03-drop.md
+++ b/src/ch15-03-drop.md
@@ -132,7 +132,7 @@ We can’t disable the automatic insertion of `drop` when a value goes out of
 scope, and we can’t call the `drop` method explicitly. So, if we need to force
 a value to be cleaned up early, we can use the `std::mem::drop` function.
 
-The `std::mem::drop` function is different than the `drop` method in the `Drop`
+The `std::mem::drop` function is different from the `drop` method in the `Drop`
 trait. We call it by passing the value we want to force to be dropped early as
 an argument. The function is in the prelude, so we can modify `main` in Listing
 15-15 to call the `drop` function, as shown in Listing 15-16:

--- a/src/ch15-06-reference-cycles.md
+++ b/src/ch15-06-reference-cycles.md
@@ -476,7 +476,7 @@ and memory leaks.
 ## Summary
 
 This chapter covered how to use smart pointers to make different guarantees and
-trade-offs than those Rust makes by default with regular references. The
+trade-offs from those Rust makes by default with regular references. The
 `Box<T>` type has a known size and points to data allocated on the heap. The
 `Rc<T>` type keeps track of the number of references to data on the heap so
 that data can have multiple owners. The `RefCell<T>` type with its interior

--- a/src/ch17-02-trait-objects.md
+++ b/src/ch17-02-trait-objects.md
@@ -124,7 +124,7 @@ impl Screen {
 <span class="caption">Listing 17-5: A `run` method on `Screen` that calls the
 `draw` method on each component</span>
 
-This works differently than defining a struct that uses a generic type
+This works differently from defining a struct that uses a generic type
 parameter with trait bounds. A generic type parameter can only be substituted
 with one concrete type at a time, whereas trait objects allow for multiple
 concrete types to fill in for the trait object at runtime. For example, we

--- a/src/ch19-06-macros.md
+++ b/src/ch19-06-macros.md
@@ -113,7 +113,7 @@ pattern matches, the associated block of code will be emitted. Given that this
 is the only pattern in this macro, there is only one valid way to match; any
 other will be an error. More complex macros will have more than one arm.
 
-Valid pattern syntax in macro definitions is different than the pattern syntax
+Valid pattern syntax in macro definitions is different from the pattern syntax
 covered in Chapter 18 because macro patterns are matched against Rust code
 structure rather than values. Let’s walk through what the pieces of the pattern
 in Listing D-1 mean; for the full macro pattern syntax, see [the reference].
@@ -483,7 +483,7 @@ the name of the annotated type.
 
 The `stringify!` macro used here is built into Rust. It takes a Rust
 expression, such as `1 + 2`, and at compile time turns the expression into a
-string literal, such as `"1 + 2"`. This is different than `format!` or
+string literal, such as `"1 + 2"`. This is different from `format!` or
 `println!`, which evaluate the expression and then turn the result into a
 `String`. There is a possibility that the `#name` input might be an expression
 to print literally, so we use `stringify!`. Using `stringify!` also saves an

--- a/src/ch20-01-single-threaded.md
+++ b/src/ch20-01-single-threaded.md
@@ -441,7 +441,7 @@ fn handle_connection(mut stream: TcpStream) {
 ```
 
 <span class="caption">Listing 20-6: Matching the request and handling requests
-to */* differently than other requests</span>
+to */* differently from other requests</span>
 
 First, we hardcode the data corresponding to the */* request into the `get`
 variable. Because we’re reading raw bytes into the buffer, we transform `get`


### PR DESCRIPTION
I've changed "different than" and similar phrases to use "from" instead.
After looking the issue up, it seems to me that compared to "different than", "different from" is much more common out of the US, somewhat less common in the US, and widely (though not universally) considered to be more grammatical. I think that’s an improvement overall.