### PR TITLE
Fixed non idiomatic use of `use` in chapter 19

### DIFF
--- a/src/ch19-03-advanced-traits.md
+++ b/src/ch19-03-advanced-traits.md
@@ -542,9 +542,9 @@ the trait. Listing 19-30 shows an implementation of the `OutlinePrint` trait.
 <span class="filename">Filename: src/main.rs</span>
 
 ```rust
-use std::fmt;
+use std::fmt::Display;
 
-trait OutlinePrint: fmt::Display {
+trait OutlinePrint: Display {
     fn outline_print(&self) {
         let output = self.to_string();
         let len = output.len();
@@ -606,10 +606,10 @@ To fix this, we implement `Display` on `Point` and satisfy the constraint that
 #     y: i32,
 # }
 #
-use std::fmt;
+use std::fmt::{Display, Formatter, Result};
 
-impl fmt::Display for Point {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl Display for Point {
+    fn fmt(&self, f: &mut Formatter) -> Result {
         write!(f, "({}, {})", self.x, self.y)
     }
 }
@@ -644,12 +644,12 @@ that holds an instance of `Vec<T>`; then we can implement `Display` on
 <span class="filename">Filename: src/main.rs</span>
 
 ```rust
-use std::fmt;
+use std::fmt::{Display, Formatter, Result};
 
 struct Wrapper(Vec<String>);
 
-impl fmt::Display for Wrapper {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl Display for Wrapper {
+    fn fmt(&self, f: &mut Formatter) -> Result {
         write!(f, "[{}]", self.0.join(", "))
     }
 }

--- a/src/ch19-04-advanced-types.md
+++ b/src/ch19-04-advanced-types.md
@@ -128,14 +128,14 @@ the `Write` trait:
 
 ```rust
 use std::io::Error;
-use std::fmt;
+use std::fmt::Arguments;
 
 pub trait Write {
     fn write(&mut self, buf: &[u8]) -> Result<usize, Error>;
     fn flush(&mut self) -> Result<(), Error>;
 
     fn write_all(&mut self, buf: &[u8]) -> Result<(), Error>;
-    fn write_fmt(&mut self, fmt: fmt::Arguments) -> Result<(), Error>;
+    fn write_fmt(&mut self, fmt: Arguments) -> Result<(), Error>;
 }
 ```
 


### PR DESCRIPTION
In chapter 19.03 and 19.04, `use` is used in a non idiomatic way, as described in chapter 07.02