### PR TITLE
Purge the first edition stubs from search engines

### DIFF
--- a/2018-edition/src/theme/index.hbs
+++ b/2018-edition/src/theme/index.hbs
@@ -1,0 +1,37 @@
+<!DOCTYPE HTML>
+<html lang="{{ language }}" class="no-js">
+    <head>
+        <!-- Book generated using mdBook -->
+        <meta charset="UTF-8">
+        <title>Outdated link: {{ title }}</title>
+        <meta name="robots" content="noindex,follow">
+        <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
+
+        <base href="{{ path_to_root }}">
+
+        <link rel="stylesheet" href="book.css">
+        <link href="https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800" rel="stylesheet" type="text/css">
+        <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500" rel="stylesheet" type="text/css">
+
+        <link rel="stylesheet" href="highlight.css">
+        <link rel="stylesheet" href="tomorrow-night.css">
+        <link rel="stylesheet" href="ayu-highlight.css">
+
+        <!-- Custom theme stylesheets -->
+        {{#each additional_css}}
+        <link rel="stylesheet" href="{{this}}">
+        {{/each}}
+    </head>
+    <body class="light">
+        <div id="page-wrapper" class="page-wrapper">
+            <div class="page">
+                {{> header}}
+                <div id="content" class="content">
+                    <main>
+                        {{{ content }}}
+                    </main>
+                </div>
+            </div>
+        </div>
+    </body>
+</html>

--- a/first-edition/src/theme/index.hbs
+++ b/first-edition/src/theme/index.hbs
@@ -1,0 +1,37 @@
+<!DOCTYPE HTML>
+<html lang="{{ language }}" class="no-js">
+    <head>
+        <!-- Book generated using mdBook -->
+        <meta charset="UTF-8">
+        <title>Outdated link: {{ title }}</title>
+        <meta name="robots" content="noindex,follow">
+        <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
+
+        <base href="{{ path_to_root }}">
+
+        <link rel="stylesheet" href="book.css">
+        <link href="https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800" rel="stylesheet" type="text/css">
+        <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500" rel="stylesheet" type="text/css">
+
+        <link rel="stylesheet" href="highlight.css">
+        <link rel="stylesheet" href="tomorrow-night.css">
+        <link rel="stylesheet" href="ayu-highlight.css">
+
+        <!-- Custom theme stylesheets -->
+        {{#each additional_css}}
+        <link rel="stylesheet" href="{{this}}">
+        {{/each}}
+    </head>
+    <body class="light">
+        <div id="page-wrapper" class="page-wrapper">
+            <div class="page">
+                {{> header}}
+                <div id="content" class="content">
+                    <main>
+                        {{{ content }}}
+                    </main>
+                </div>
+            </div>
+        </div>
+    </body>
+</html>

--- a/second-edition/src/theme/index.hbs
+++ b/second-edition/src/theme/index.hbs
@@ -1,0 +1,37 @@
+<!DOCTYPE HTML>
+<html lang="{{ language }}" class="no-js">
+    <head>
+        <!-- Book generated using mdBook -->
+        <meta charset="UTF-8">
+        <title>Outdated link: {{ title }}</title>
+        <meta name="robots" content="noindex,follow">
+        <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
+
+        <base href="{{ path_to_root }}">
+
+        <link rel="stylesheet" href="book.css">
+        <link href="https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800" rel="stylesheet" type="text/css">
+        <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500" rel="stylesheet" type="text/css">
+
+        <link rel="stylesheet" href="highlight.css">
+        <link rel="stylesheet" href="tomorrow-night.css">
+        <link rel="stylesheet" href="ayu-highlight.css">
+
+        <!-- Custom theme stylesheets -->
+        {{#each additional_css}}
+        <link rel="stylesheet" href="{{this}}">
+        {{/each}}
+    </head>
+    <body class="light">
+        <div id="page-wrapper" class="page-wrapper">
+            <div class="page">
+                {{> header}}
+                <div id="content" class="content">
+                    <main>
+                        {{{ content }}}
+                    </main>
+                </div>
+            </div>
+        </div>
+    </body>
+</html>


### PR DESCRIPTION
Apparently this is still an annoying problem for users: https://users.rust-lang.org/t/why-are-links-to-the-old-book-still-floating-around/24656

This adds `<meta name="robots" content="noindex,follow">` to first edition's pages in order to remove them from search engines.

To do that I had to copy the whole index.hbs ~~and update move the theme directory to location required by the current mdBook version.~~