### PR TITLE
Pin Rust to 1.31.1 in CI for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 language: rust
 cache: cargo
 rust:
-  - stable
+  - 1.31.1
 branches:
   only:
   - master


### PR DESCRIPTION
One because that's the version we're targeting for the round of edits
we're making with nostarch, two because of #1776.

Fixes #1776.