### PR TITLE
Error handling - link proper section of 2nd edition from 1st edition

### DIFF
--- a/first-edition/src/error-handling.md
+++ b/first-edition/src/error-handling.md
@@ -3,7 +3,7 @@
 The first edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch09-00-error-handling.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust


### PR DESCRIPTION
Pointing directly to the relevant section in the new book is more efficient for the reader interested in that part of the Rust book.