### PR TITLE
add a tip section of crate naming convention

### DIFF
--- a/src/ch14-03-cargo-workspaces.md
+++ b/src/ch14-03-cargo-workspaces.md
@@ -156,6 +156,12 @@ fn main() {
 <span class="caption">Listing 14-7: Using the `add-one` library crate from the
 `adder` crate</span>
 
+> #### Rust Crate Naming Tip
+>
+> Use hyphens not underscores to name your Crate. Hyphens are idiomatic and
+> Cargo does the conversion to underscore in your Rust code automatically since
+> a name like `add-one` is not a valid identifier in Rust.
+
 Let’s build the workspace by running `cargo build` in the top-level *add*
 directory!
 


### PR DESCRIPTION
The examples in this chapter create a crate named `add-one` but use `use add_one` in Rust code.
This would really make beginners confused.