### PR TITLE
typo fix in the beginning of chapter 7

### DIFF
--- a/2018-edition/nostarch/chapter07.md
+++ b/2018-edition/nostarch/chapter07.md
@@ -8,7 +8,7 @@ know about at this location in the code? What functions am I allowed to call?
 What does this variable refer to?
 
 Rust has a number of features related to scopes. This is sometimes called
-“the module system,” but it encompases more than just modules:
+“the module system,” but it encompasses more than just modules:
 
 * *Packages* are a Cargo feature that let you build, test, and share crates.
 * *Crates* are a tree of modules that produce a library or executable.


### PR DESCRIPTION
Hi! I hope I'm doing this right. I believe that the word "encompases" is actually spelled "encompasses". Hope this helps!