### PR TITLE
ch10 - Prefer `PascalCase` over `CamelCase` + Comma fix

### DIFF
--- a/src/ch10-01-syntax.md
+++ b/src/ch10-01-syntax.md
@@ -69,7 +69,7 @@ To parameterize the types in the new function we’ll define, we need to name th
 type parameter, just as we do for the value parameters to a function. You can
 use any identifier as a type parameter name. But we’ll use `T` because, by
 convention, parameter names in Rust are short, often just a letter, and Rust’s
-type-naming convention is PascalCase. Short for “type,” `T` is the default
+type-naming convention is PascalCase. Short for “type”, `T` is the default
 choice of most Rust programmers.
 
 When we use a parameter in the body of the function, we have to declare the

--- a/src/ch10-01-syntax.md
+++ b/src/ch10-01-syntax.md
@@ -69,7 +69,7 @@ To parameterize the types in the new function we’ll define, we need to name th
 type parameter, just as we do for the value parameters to a function. You can
 use any identifier as a type parameter name. But we’ll use `T` because, by
 convention, parameter names in Rust are short, often just a letter, and Rust’s
-type-naming convention is CamelCase. Short for “type,” `T` is the default
+type-naming convention is PascalCase. Short for “type,” `T` is the default
 choice of most Rust programmers.
 
 When we use a parameter in the body of the function, we have to declare the


### PR DESCRIPTION
As [Wikipedia](https://en.wikipedia.org/wiki/Camel_case) says,

> Some people and organizations, notably Microsoft, use the term camel case only for lower camel case. **Pascal case means only upper camel case**. 

I think it would be more appropriate to call `ThisExample` PascalCase, as opposed to `camelCase`.

Anyway, both versions are completely okay.

----
It also fixes a comma that was inside quotes:
> Rust’s type-naming convention is PascalCase. Short for **“type,”** `T` is the default choice of most Rust programmers.