### PR TITLE
Replace `T: 'a + Messenger` with `T: Messenger`

### DIFF
--- a/src/ch15-05-interior-mutability.md
+++ b/src/ch15-05-interior-mutability.md
@@ -140,7 +140,7 @@ pub trait Messenger {
     fn send(&self, msg: &str);
 }
 
-pub struct LimitTracker<'a, T: 'a + Messenger> {
+pub struct LimitTracker<'a, T: Messenger> {
     messenger: &'a T,
     value: usize,
     max: usize,


### PR DESCRIPTION
reasons:

1. This annotation is no longer needed since it can be inferred from the fields present in the definitions in Rust 2018.
2. `T: 'a` annotation is never mentioned in previous chapters, this would make beinners confused.

references:

https://github.com/rust-lang/rfcs/pull/2093
https://github.com/rust-lang/rust/issues/44493
https://rust-lang-nursery.github.io/edition-guide/rust-2018/ownership-and-lifetimes/inference-in-structs.html