### PR TITLE
ch09-02: ? may be used with Result or Option

### DIFF
--- a/src/ch09-02-recoverable-errors-with-result.md
+++ b/src/ch09-02-recoverable-errors-with-result.md
@@ -470,13 +470,13 @@ and returns it. Of course, using `fs::read_to_string` doesn’t give us the
 opportunity to explain all the error handling, so we did it the longer way
 first.
 
-#### The `?` Operator Can Only Be Used in Functions That Return `Result`
+#### The `?` Operator Can Only Be Used in Functions That Return `Result` or `Option`
 
 The `?` operator can only be used in functions that have a return type of
-`Result`, because it is defined to work in the same way as the `match`
-expression we defined in Listing 9-6. The part of the `match` that requires a
-return type of `Result` is `return Err(e)`, so the return type of the function
-must be a `Result` to be compatible with this `return`.
+`Result` or `Option`, because it is defined to work in the same way as the
+`match` expression we defined in Listing 9-6. The part of the `match` that
+requires a return type of `Result` is `return Err(e)`, so the return type of
+the function must be a `Result` to be compatible with this `return`.
 
 Let’s look at what happens if we use the `?` operator in the `main` function,
 which you’ll recall has a return type of `()`:


### PR DESCRIPTION
ch09-02 makes (what seems to me, I'm still learning!) to be a false claim that `?` may only be used with Result.

Yet when I tried this it compiled just fine:

```
fn hello() -> Option<String> {
    Some(String::from("hello"))?;
    Some(String::from("bye"))
}
```

I'm a little uncomfortable with the change I'm suggesting here since it seems strange to claim that `?` works with `Option` without demonstrating it as such - however this section of the book doesn't seem like the right place for that. Any advice?