### PR TITLE
remove unnecessary derive annotation

### DIFF
--- a/src/ch05-03-method-syntax.md
+++ b/src/ch05-03-method-syntax.md
@@ -17,7 +17,6 @@ in Listing 5-13.
 <span class="filename">Filename: src/main.rs</span>
 
 ```rust
-#[derive(Debug)]
 struct Rectangle {
     width: u32,
     height: u32,


### PR DESCRIPTION
The derive annotation is not needed since println! displays an u32 integer