### PR TITLE
Fix code snippet

### DIFF
--- a/src/ch19-04-advanced-types.md
+++ b/src/ch19-04-advanced-types.md
@@ -143,7 +143,7 @@ The `Result<..., Error>` is repeated a lot. As such, `std::io` has this type of
 alias declaration:
 
 ```rust,ignore
-type Result<T> = Result<T, std::io::Error>;
+type Result<T> = std::result::Result<T, std::io::Error>;
 ```
 
 Because this declaration is in the `std::io` module, we can use the fully


### PR DESCRIPTION
```rust
type Result<T> = Result<T, std::io::Error>;
```
This example [doesn't compile](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=7b13da576c5fd89ca3e2a89720c3fc8c):
```
error[E0107]: wrong number of type arguments: expected 1, found 2
 --> src/main.rs:1:28
  |
1 | type Result<T> = Result<T, std::io::Error>;
  |                            ^^^^^^^^^^^^^^ unexpected type argument

error[E0391]: cycle detected when processing `Result`
 --> src/main.rs:1:18
  |
1 | type Result<T> = Result<T, std::io::Error>;
  |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: ...which again requires processing `Result`, completing the cycle
```