### PR TITLE
fix accidental <ol>'s

### DIFF
--- a/src/ch03-02-data-types.md
+++ b/src/ch03-02-data-types.md
@@ -100,8 +100,8 @@ which you’d use `isize` or `usize` is when indexing some sort of collection.
 
 > ##### Integer Overflow
 >
-> Let’s say you have a variable of type `u8` that can hold values between 0 and
-> 255. If you try to change the variable to a value outside of that range, such
+> Let’s say you have a variable of type `u8` that can hold values between 0 and 255.
+> If you try to change the variable to a value outside of that range, such
 > as 256, *integer overflow* will occur. Rust has some interesting rules
 > involving this behavior. When you’re compiling in debug mode, Rust includes
 > checks for integer overflow that causes your program to *panic* at runtime if

--- a/src/ch12-01-accepting-command-line-arguments.md
+++ b/src/ch12-01-accepting-command-line-arguments.md
@@ -29,8 +29,8 @@ just learning this concept, let’s implement this capability ourselves.
 To enable `minigrep` to read the values of command line arguments we pass to
 it, we’ll need a function provided in Rust’s standard library, which is
 `std::env::args`. This function returns an iterator of the command line
-arguments that were given to `minigrep`. We’ll cover iterators fully in Chapter
-13. For now, you only need to know two details about iterators: iterators
+arguments that were given to `minigrep`. We’ll cover iterators fully in Chapter 13.
+For now, you only need to know two details about iterators: iterators
 produce a series of values, and we can call the `collect` method on an iterator
 to turn it into a collection, such as a vector, containing all the elements the
 iterator produces.


### PR DESCRIPTION
mkBook was rendering ordered lists instead of plain text.