### PR TITLE
Update range so matches rust-fmt .

### DIFF
--- a/src/ch18-03-pattern-syntax.md
+++ b/src/ch18-03-pattern-syntax.md
@@ -115,16 +115,16 @@ arm will execute:
 let x = 5;
 
 match x {
-    1 ... 5 => println!("one through five"),
+    1...5 => println!("one through five"),
     _ => println!("something else"),
 }
 ```
 
 If `x` is 1, 2, 3, 4, or 5, the first arm will match. This syntax is more
-convenient than using the `|` operator to express the same idea; instead of `1
-... 5`, we would have to specify `1 | 2 | 3 | 4 | 5` if we used `|`. Specifying
-a range is much shorter, especially if we want to match, say, any number
-between 1 and 1,000!
+convenient than using the `|` operator to express the same idea; instead of
+`1...5`, we would have to specify `1 | 2 | 3 | 4 | 5` if we used `|`.
+Specifyinga range is much shorter, especially if we want to match, say, any
+number between 1 and 1,000!
 
 Ranges are only allowed with numeric values or `char` values, because the
 compiler checks that the range isn’t empty at compile time. The only types for
@@ -136,8 +136,8 @@ Here is an example using ranges of `char` values:
 let x = 'c';
 
 match x {
-    'a' ... 'j' => println!("early ASCII letter"),
-    'k' ... 'z' => println!("late ASCII letter"),
+    'a'...'j' => println!("early ASCII letter"),
+    'k'...'z' => println!("late ASCII letter"),
     _ => println!("something else"),
 }
 ```

--- a/src/ch18-03-pattern-syntax.md
+++ b/src/ch18-03-pattern-syntax.md
@@ -123,7 +123,7 @@ match x {
 If `x` is 1, 2, 3, 4, or 5, the first arm will match. This syntax is more
 convenient than using the `|` operator to express the same idea; instead of
 `1...5`, we would have to specify `1 | 2 | 3 | 4 | 5` if we used `|`.
-Specifyinga range is much shorter, especially if we want to match, say, any
+Specifying a range is much shorter, especially if we want to match, say, any
 number between 1 and 1,000!
 
 Ranges are only allowed with numeric values or `char` values, because the


### PR DESCRIPTION
When saved rust-fmt removed the spaces in `1 ... 5`. This change will make the book consistent with rust-fmt.