### PR TITLE
Adding trailing comma

### DIFF
--- a/src/ch18-03-pattern-syntax.md
+++ b/src/ch18-03-pattern-syntax.md
@@ -335,7 +335,7 @@ colors in the `ChangeColor` message, as shown in Listing 18-16.
 ```rust
 enum Color {
    Rgb(i32, i32, i32),
-   Hsv(i32, i32, i32)
+   Hsv(i32, i32, i32),
 }
 
 enum Message {


### PR DESCRIPTION
The trailing comma was missing from the final variant of the Color enum.
I thought it would be nice to add it for consistency.