### PR TITLE
Remove "pub" specification for function eat_at_restaurant.

### DIFF
--- a/src/ch07-01-packages-and-crates.md
+++ b/src/ch07-01-packages-and-crates.md
@@ -17,12 +17,12 @@ Let’s walk through what happens when we create a package. First, we enter the
 command `cargo new`:
 
 ```text
-$ cargo new my-project
-     Created binary (application) `my-project` package
-$ ls my-project
+$ cargo new my_project
+     Created binary (application) `my_project` package
+$ ls my_project
 Cargo.toml
 src
-$ ls my-project/src
+$ ls my_project/src
 main.rs
 ```
 
@@ -36,7 +36,7 @@ crate root. Cargo passes the crate root files to `rustc` to build the library
 or binary.
 
 Here, we have a package that only contains *src/main.rs*, meaning it only
-contains a binary crate named `my-project`. If a package contains *src/main.rs*
+contains a binary crate named `my_project`. If a package contains *src/main.rs*
 and *src/lib.rs*, it has two crates: a library and a binary, both with the same
 name as the package. A package can have multiple binary crates by placing files
 in the *src/bin* directory: each file will be a separate binary crate.

--- a/src/ch07-03-paths-for-referring-to-an-item-in-the-module-tree.md
+++ b/src/ch07-03-paths-for-referring-to-an-item-in-the-module-tree.md
@@ -31,7 +31,7 @@ mod front_of_house {
     }
 }
 
-pub fn eat_at_restaurant() {
+fn eat_at_restaurant() {
     // Absolute path
     crate::front_of_house::hosting::add_to_waitlist();
 
@@ -137,7 +137,7 @@ mod front_of_house {
     }
 }
 
-pub fn eat_at_restaurant() {
+fn eat_at_restaurant() {
     // Absolute path
     crate::front_of_house::hosting::add_to_waitlist();
 
@@ -193,7 +193,7 @@ mod front_of_house {
     }
 }
 
-pub fn eat_at_restaurant() {
+fn eat_at_restaurant() {
     // Absolute path
     crate::front_of_house::hosting::add_to_waitlist();
 
@@ -300,7 +300,7 @@ mod back_of_house {
     }
 }
 
-pub fn eat_at_restaurant() {
+fn eat_at_restaurant() {
     // Order a breakfast in the summer with Rye toast
     let mut meal = back_of_house::Breakfast::summer("Rye");
     // Change our mind about what bread we'd like
@@ -342,7 +342,7 @@ mod back_of_house {
     }
 }
 
-pub fn eat_at_restaurant() {
+fn eat_at_restaurant() {
     let order1 = back_of_house::Appetizer::Soup;
     let order2 = back_of_house::Appetizer::Salad;
 }

--- a/src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md
+++ b/src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md
@@ -24,7 +24,7 @@ mod front_of_house {
 
 use crate::front_of_house::hosting;
 
-pub fn eat_at_restaurant() {
+fn eat_at_restaurant() {
     hosting::add_to_waitlist();
     hosting::add_to_waitlist();
     hosting::add_to_waitlist();
@@ -57,7 +57,7 @@ mod front_of_house {
 
 use self::front_of_house::hosting;
 
-pub fn eat_at_restaurant() {
+fn eat_at_restaurant() {
     hosting::add_to_waitlist();
     hosting::add_to_waitlist();
     hosting::add_to_waitlist();
@@ -89,7 +89,7 @@ mod front_of_house {
 
 use crate::front_of_house::hosting::add_to_waitlist;
 
-pub fn eat_at_restaurant() {
+fn eat_at_restaurant() {
     add_to_waitlist();
     add_to_waitlist();
     add_to_waitlist();
@@ -210,7 +210,7 @@ mod front_of_house {
 
 pub use crate::front_of_house::hosting;
 
-pub fn eat_at_restaurant() {
+fn eat_at_restaurant() {
     hosting::add_to_waitlist();
     hosting::add_to_waitlist();
     hosting::add_to_waitlist();

--- a/src/ch07-05-separating-modules-into-different-files.md
+++ b/src/ch07-05-separating-modules-into-different-files.md
@@ -17,7 +17,7 @@ mod front_of_house;
 
 pub use crate::front_of_house::hosting;
 
-pub fn eat_at_restaurant() {
+fn eat_at_restaurant() {
     hosting::add_to_waitlist();
     hosting::add_to_waitlist();
     hosting::add_to_waitlist();


### PR DESCRIPTION
I'm removing the "pub" for eat_at_restaurant since:
1. The first time this function appears in Chapter 7.3, we haven't introduced the keyword "pub" yet. It creates confusions to use it in the code without any previous mentionings.
2. The "pub" keyword looks useless for eat_at_restaurant throughout Chapter 7. Better to just remove it everywhere.