### PR TITLE
Remove "pub" specifier from function eat_at_restaurant

### DIFF
--- a/src/ch07-03-paths-for-referring-to-an-item-in-the-module-tree.md
+++ b/src/ch07-03-paths-for-referring-to-an-item-in-the-module-tree.md
@@ -31,7 +31,7 @@ mod front_of_house {
     }
 }
 
-pub fn eat_at_restaurant() {
+fn eat_at_restaurant() {
     // Absolute path
     crate::front_of_house::hosting::add_to_waitlist();
 
@@ -137,7 +137,7 @@ mod front_of_house {
     }
 }
 
-pub fn eat_at_restaurant() {
+fn eat_at_restaurant() {
     // Absolute path
     crate::front_of_house::hosting::add_to_waitlist();
 
@@ -193,7 +193,7 @@ mod front_of_house {
     }
 }
 
-pub fn eat_at_restaurant() {
+fn eat_at_restaurant() {
     // Absolute path
     crate::front_of_house::hosting::add_to_waitlist();
 
@@ -300,7 +300,7 @@ mod back_of_house {
     }
 }
 
-pub fn eat_at_restaurant() {
+fn eat_at_restaurant() {
     // Order a breakfast in the summer with Rye toast
     let mut meal = back_of_house::Breakfast::summer("Rye");
     // Change our mind about what bread we'd like
@@ -342,7 +342,7 @@ mod back_of_house {
     }
 }
 
-pub fn eat_at_restaurant() {
+fn eat_at_restaurant() {
     let order1 = back_of_house::Appetizer::Soup;
     let order2 = back_of_house::Appetizer::Salad;
 }

--- a/src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md
+++ b/src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md
@@ -24,7 +24,7 @@ mod front_of_house {
 
 use crate::front_of_house::hosting;
 
-pub fn eat_at_restaurant() {
+fn eat_at_restaurant() {
     hosting::add_to_waitlist();
     hosting::add_to_waitlist();
     hosting::add_to_waitlist();
@@ -57,7 +57,7 @@ mod front_of_house {
 
 use self::front_of_house::hosting;
 
-pub fn eat_at_restaurant() {
+fn eat_at_restaurant() {
     hosting::add_to_waitlist();
     hosting::add_to_waitlist();
     hosting::add_to_waitlist();
@@ -89,7 +89,7 @@ mod front_of_house {
 
 use crate::front_of_house::hosting::add_to_waitlist;
 
-pub fn eat_at_restaurant() {
+fn eat_at_restaurant() {
     add_to_waitlist();
     add_to_waitlist();
     add_to_waitlist();
@@ -210,7 +210,7 @@ mod front_of_house {
 
 pub use crate::front_of_house::hosting;
 
-pub fn eat_at_restaurant() {
+fn eat_at_restaurant() {
     hosting::add_to_waitlist();
     hosting::add_to_waitlist();
     hosting::add_to_waitlist();

--- a/src/ch07-05-separating-modules-into-different-files.md
+++ b/src/ch07-05-separating-modules-into-different-files.md
@@ -17,7 +17,7 @@ mod front_of_house;
 
 pub use crate::front_of_house::hosting;
 
-pub fn eat_at_restaurant() {
+fn eat_at_restaurant() {
     hosting::add_to_waitlist();
     hosting::add_to_waitlist();
     hosting::add_to_waitlist();


### PR DESCRIPTION
I'm removing "pub" specifier from function eat_at_restaurant for two reasons:
1. The first time this "pub" appears (Ch 7.3, or source code ch07-03-paths-for-referring-to-an-item-in-the-module-tree.md, line 34), we haven't introduced the keyword "pub" yet. It creates confusions.
2. The "pub" specifier for eat_at_restaurant is not useful or relevant to the whole chapter.