### PR TITLE
Update the version of mdbook we use in-tree to match rust-lang/rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,6 @@ addons:
       - aspell
       - aspell-en
 before_script:
-  - (cargo install mdbook --vers 0.1.7 --force || true)
+  - (cargo install mdbook --vers 0.2.3 --force || true)
 script:
   - bash ci/build.sh

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ releases are updated less frequently.
 
 ## Requirements
 
-Building the book requires [mdBook], ideally the same version that
+Building the book requires [mdBook], ideally the same 0.2.x version that
 rust-lang/rust uses in [this file][rust-mdbook]. To get it:
 
 [mdBook]: https://github.com/azerupi/mdBook


### PR DESCRIPTION
As of the merging of https://github.com/rust-lang/rust/pull/59876, TRPL
is using mdbook 2!

Just checking to make sure travis passes here and then i'll merge.