### PR TITLE
point 2018 book redirects to existing pages instead of index

### DIFF
--- a/2018-edition/src/appendix-00.md
+++ b/2018-edition/src/appendix-00.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../appendix-00.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/appendix-01-keywords.md
+++ b/2018-edition/src/appendix-01-keywords.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../appendix-01-keywords.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/appendix-02-operators.md
+++ b/2018-edition/src/appendix-02-operators.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../appendix-02-operators.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/appendix-03-derivable-traits.md
+++ b/2018-edition/src/appendix-03-derivable-traits.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../appendix-03-derivable-traits.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/appendix-04-useful-development-tools.md
+++ b/2018-edition/src/appendix-04-useful-development-tools.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../appendix-04-useful-development-tools.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/appendix-05-editions.md
+++ b/2018-edition/src/appendix-05-editions.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../appendix-05-editions.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/appendix-06-translation.md
+++ b/2018-edition/src/appendix-06-translation.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../appendix-06-translation.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/appendix-07-nightly-rust.md
+++ b/2018-edition/src/appendix-07-nightly-rust.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../appendix-07-nightly-rust.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch00-00-introduction.md
+++ b/2018-edition/src/ch00-00-introduction.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch00-00-introduction.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch01-00-getting-started.md
+++ b/2018-edition/src/ch01-00-getting-started.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch01-00-getting-started.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch01-01-installation.md
+++ b/2018-edition/src/ch01-01-installation.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch01-01-installation.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch01-02-hello-world.md
+++ b/2018-edition/src/ch01-02-hello-world.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch01-02-hello-world.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch01-03-hello-cargo.md
+++ b/2018-edition/src/ch01-03-hello-cargo.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch01-03-hello-cargo.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch02-00-guessing-game-tutorial.md
+++ b/2018-edition/src/ch02-00-guessing-game-tutorial.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch02-00-guessing-game-tutorial.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch03-00-common-programming-concepts.md
+++ b/2018-edition/src/ch03-00-common-programming-concepts.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch03-00-common-programming-concepts.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch03-01-variables-and-mutability.md
+++ b/2018-edition/src/ch03-01-variables-and-mutability.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch03-01-variables-and-mutability.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch03-02-data-types.md
+++ b/2018-edition/src/ch03-02-data-types.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch03-02-data-types.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch03-03-how-functions-work.md
+++ b/2018-edition/src/ch03-03-how-functions-work.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch03-03-how-functions-work.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch03-04-comments.md
+++ b/2018-edition/src/ch03-04-comments.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch03-04-comments.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch03-05-control-flow.md
+++ b/2018-edition/src/ch03-05-control-flow.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch03-05-control-flow.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch04-00-understanding-ownership.md
+++ b/2018-edition/src/ch04-00-understanding-ownership.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch04-00-understanding-ownership.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch04-01-what-is-ownership.md
+++ b/2018-edition/src/ch04-01-what-is-ownership.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch04-01-what-is-ownership.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch04-02-references-and-borrowing.md
+++ b/2018-edition/src/ch04-02-references-and-borrowing.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch04-02-references-and-borrowing.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch04-03-slices.md
+++ b/2018-edition/src/ch04-03-slices.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch04-03-slices.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch05-00-structs.md
+++ b/2018-edition/src/ch05-00-structs.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch05-00-structs.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch05-01-defining-structs.md
+++ b/2018-edition/src/ch05-01-defining-structs.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch05-01-defining-structs.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch05-02-example-structs.md
+++ b/2018-edition/src/ch05-02-example-structs.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch05-02-example-structs.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch05-03-method-syntax.md
+++ b/2018-edition/src/ch05-03-method-syntax.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch05-03-method-syntax.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch06-00-enums.md
+++ b/2018-edition/src/ch06-00-enums.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch06-00-enums.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch06-01-defining-an-enum.md
+++ b/2018-edition/src/ch06-01-defining-an-enum.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch06-01-defining-an-enum.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch06-02-match.md
+++ b/2018-edition/src/ch06-02-match.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch06-02-match.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch06-03-if-let.md
+++ b/2018-edition/src/ch06-03-if-let.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch06-03-if-let.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch08-00-common-collections.md
+++ b/2018-edition/src/ch08-00-common-collections.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch08-00-common-collections.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch08-01-vectors.md
+++ b/2018-edition/src/ch08-01-vectors.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch08-01-vectors.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch08-02-strings.md
+++ b/2018-edition/src/ch08-02-strings.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch08-02-strings.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch08-03-hash-maps.md
+++ b/2018-edition/src/ch08-03-hash-maps.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch08-03-hash-maps.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch09-00-error-handling.md
+++ b/2018-edition/src/ch09-00-error-handling.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch09-00-error-handling.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch09-01-unrecoverable-errors-with-panic.md
+++ b/2018-edition/src/ch09-01-unrecoverable-errors-with-panic.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch09-01-unrecoverable-errors-with-panic.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch09-02-recoverable-errors-with-result.md
+++ b/2018-edition/src/ch09-02-recoverable-errors-with-result.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch09-02-recoverable-errors-with-result.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch09-03-to-panic-or-not-to-panic.md
+++ b/2018-edition/src/ch09-03-to-panic-or-not-to-panic.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch09-03-to-panic-or-not-to-panic.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch10-00-generics.md
+++ b/2018-edition/src/ch10-00-generics.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch10-00-generics.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch10-01-syntax.md
+++ b/2018-edition/src/ch10-01-syntax.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch10-01-syntax.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch10-02-traits.md
+++ b/2018-edition/src/ch10-02-traits.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch10-02-traits.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch10-03-lifetime-syntax.md
+++ b/2018-edition/src/ch10-03-lifetime-syntax.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch10-03-lifetime-syntax.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch11-00-testing.md
+++ b/2018-edition/src/ch11-00-testing.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch11-00-testing.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch11-01-writing-tests.md
+++ b/2018-edition/src/ch11-01-writing-tests.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch11-01-writing-tests.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch11-02-running-tests.md
+++ b/2018-edition/src/ch11-02-running-tests.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch11-02-running-tests.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch11-03-test-organization.md
+++ b/2018-edition/src/ch11-03-test-organization.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch11-03-test-organization.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch12-00-an-io-project.md
+++ b/2018-edition/src/ch12-00-an-io-project.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch12-00-an-io-project.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch12-01-accepting-command-line-arguments.md
+++ b/2018-edition/src/ch12-01-accepting-command-line-arguments.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch12-01-accepting-command-line-arguments.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch12-02-reading-a-file.md
+++ b/2018-edition/src/ch12-02-reading-a-file.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch12-02-reading-a-file.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch12-03-improving-error-handling-and-modularity.md
+++ b/2018-edition/src/ch12-03-improving-error-handling-and-modularity.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch12-03-improving-error-handling-and-modularity.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch12-04-testing-the-librarys-functionality.md
+++ b/2018-edition/src/ch12-04-testing-the-librarys-functionality.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch12-04-testing-the-librarys-functionality.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch12-05-working-with-environment-variables.md
+++ b/2018-edition/src/ch12-05-working-with-environment-variables.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch12-05-working-with-environment-variables.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch12-06-writing-to-stderr-instead-of-stdout.md
+++ b/2018-edition/src/ch12-06-writing-to-stderr-instead-of-stdout.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch12-06-writing-to-stderr-instead-of-stdout.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch13-00-functional-features.md
+++ b/2018-edition/src/ch13-00-functional-features.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch13-00-functional-features.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch13-01-closures.md
+++ b/2018-edition/src/ch13-01-closures.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch13-01-closures.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch13-02-iterators.md
+++ b/2018-edition/src/ch13-02-iterators.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch13-02-iterators.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch13-03-improving-our-io-project.md
+++ b/2018-edition/src/ch13-03-improving-our-io-project.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch13-03-improving-our-io-project.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch13-04-performance.md
+++ b/2018-edition/src/ch13-04-performance.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch13-04-performance.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch14-00-more-about-cargo.md
+++ b/2018-edition/src/ch14-00-more-about-cargo.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch14-00-more-about-cargo.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch14-01-release-profiles.md
+++ b/2018-edition/src/ch14-01-release-profiles.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch14-01-release-profiles.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch14-02-publishing-to-crates-io.md
+++ b/2018-edition/src/ch14-02-publishing-to-crates-io.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch14-02-publishing-to-crates-io.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch14-03-cargo-workspaces.md
+++ b/2018-edition/src/ch14-03-cargo-workspaces.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch14-03-cargo-workspaces.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch14-04-installing-binaries.md
+++ b/2018-edition/src/ch14-04-installing-binaries.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch14-04-installing-binaries.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch14-05-extending-cargo.md
+++ b/2018-edition/src/ch14-05-extending-cargo.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch14-05-extending-cargo.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch15-00-smart-pointers.md
+++ b/2018-edition/src/ch15-00-smart-pointers.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch15-00-smart-pointers.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch15-01-box.md
+++ b/2018-edition/src/ch15-01-box.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch15-01-box.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch15-02-deref.md
+++ b/2018-edition/src/ch15-02-deref.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch15-02-deref.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch15-03-drop.md
+++ b/2018-edition/src/ch15-03-drop.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch15-03-drop.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch15-04-rc.md
+++ b/2018-edition/src/ch15-04-rc.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch15-04-rc.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch15-05-interior-mutability.md
+++ b/2018-edition/src/ch15-05-interior-mutability.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch15-05-interior-mutability.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch15-06-reference-cycles.md
+++ b/2018-edition/src/ch15-06-reference-cycles.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch15-06-reference-cycles.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch16-00-concurrency.md
+++ b/2018-edition/src/ch16-00-concurrency.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch16-00-concurrency.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch16-01-threads.md
+++ b/2018-edition/src/ch16-01-threads.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch16-01-threads.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch16-02-message-passing.md
+++ b/2018-edition/src/ch16-02-message-passing.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch16-02-message-passing.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch16-03-shared-state.md
+++ b/2018-edition/src/ch16-03-shared-state.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch16-03-shared-state.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch16-04-extensible-concurrency-sync-and-send.md
+++ b/2018-edition/src/ch16-04-extensible-concurrency-sync-and-send.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch16-04-extensible-concurrency-sync-and-send.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch17-00-oop.md
+++ b/2018-edition/src/ch17-00-oop.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch17-00-oop.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch17-01-what-is-oo.md
+++ b/2018-edition/src/ch17-01-what-is-oo.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch17-01-what-is-oo.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch17-02-trait-objects.md
+++ b/2018-edition/src/ch17-02-trait-objects.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch17-02-trait-objects.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch17-03-oo-design-patterns.md
+++ b/2018-edition/src/ch17-03-oo-design-patterns.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch17-03-oo-design-patterns.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch18-00-patterns.md
+++ b/2018-edition/src/ch18-00-patterns.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch18-00-patterns.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch18-01-all-the-places-for-patterns.md
+++ b/2018-edition/src/ch18-01-all-the-places-for-patterns.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch18-01-all-the-places-for-patterns.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch18-02-refutability.md
+++ b/2018-edition/src/ch18-02-refutability.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch18-02-refutability.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch18-03-pattern-syntax.md
+++ b/2018-edition/src/ch18-03-pattern-syntax.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch18-03-pattern-syntax.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch19-00-advanced-features.md
+++ b/2018-edition/src/ch19-00-advanced-features.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch19-00-advanced-features.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch19-01-unsafe-rust.md
+++ b/2018-edition/src/ch19-01-unsafe-rust.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch19-01-unsafe-rust.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch19-03-advanced-traits.md
+++ b/2018-edition/src/ch19-03-advanced-traits.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch19-03-advanced-traits.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch19-04-advanced-types.md
+++ b/2018-edition/src/ch19-04-advanced-types.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch19-04-advanced-types.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch19-05-advanced-functions-and-closures.md
+++ b/2018-edition/src/ch19-05-advanced-functions-and-closures.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch19-05-advanced-functions-and-closures.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch19-06-macros.md
+++ b/2018-edition/src/ch19-06-macros.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch19-06-macros.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch20-00-final-project-a-web-server.md
+++ b/2018-edition/src/ch20-00-final-project-a-web-server.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch20-00-final-project-a-web-server.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch20-01-single-threaded.md
+++ b/2018-edition/src/ch20-01-single-threaded.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch20-01-single-threaded.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch20-02-multithreaded.md
+++ b/2018-edition/src/ch20-02-multithreaded.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch20-02-multithreaded.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/ch20-03-graceful-shutdown-and-cleanup.md
+++ b/2018-edition/src/ch20-03-graceful-shutdown-and-cleanup.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../ch20-03-graceful-shutdown-and-cleanup.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/2018-edition/src/foreword.md
+++ b/2018-edition/src/foreword.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](../foreword.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust


### PR DESCRIPTION
Fix "current version of the book" links on pages like
https://doc.rust-lang.org/book/second-edition/ch13-02-iterators.html