### PR TITLE
Make the code not compile to match the text

### DIFF
--- a/src/ch16-02-message-passing.md
+++ b/src/ch16-02-message-passing.md
@@ -35,12 +35,11 @@ want to send over the channel.
 
 <span class="filename">Filename: src/main.rs</span>
 
-```rust
+```rust,ignore,does_not_compile
 use std::sync::mpsc;
 
 fn main() {
     let (tx, rx) = mpsc::channel();
-#     tx.send(()).unwrap();
 }
 ```
 


### PR DESCRIPTION
> First, in Listing 16-6, we’ll create a channel but not do anything with it.
Note that this won’t compile yet because Rust can’t tell what type of values we
want to send over the channel.

That was not true, however, since the code compiled due to hidden line.
This change makes the code not compile by removing it.

I did not add "ignore" alongside "does_not_compile" to allow readers to see the error message if they try to run the code (that's what the flag does, right? Couldn't find a documentation for it).