### PR TITLE
Remove "&" on "query".

### DIFF
--- a/src/ch12-05-working-with-environment-variables.md
+++ b/src/ch12-05-working-with-environment-variables.md
@@ -89,7 +89,7 @@ pub fn search_case_insensitive<'a>(query: &str, contents: &'a str) -> Vec<&'a st
     let mut results = Vec::new();
 
     for line in contents.lines() {
-        if line.to_lowercase().contains(&query) {
+        if line.to_lowercase().contains(query) {
             results.push(line);
         }
     }


### PR DESCRIPTION
Remove "&" on "query" for two reasons:
  1. query is already a reference.
  2. To be consistent with Ch. 12.4.