### PR TITLE
Use tx.clone() instead of mpsc::Sender::clone(&tx)

### DIFF
--- a/src/ch16-02-message-passing.md
+++ b/src/ch16-02-message-passing.md
@@ -298,7 +298,7 @@ so by cloning the transmitting half of the channel, as shown in Listing 16-11:
 
 let (tx, rx) = mpsc::channel();
 
-let tx1 = mpsc::Sender::clone(&tx);
+let tx1 = tx.clone();
 thread::spawn(move || {
     let vals = vec![
         String::from("hi"),


### PR DESCRIPTION
Both forms are same, but `tx.clone()` is more concise.