### PR TITLE
Fix tests on nightly.

### DIFF
--- a/src/ch15-05-interior-mutability.md
+++ b/src/ch15-05-interior-mutability.md
@@ -195,7 +195,7 @@ implement a mock object to do just that, but the borrow checker won’t allow it
 
 <span class="filename">Filename: src/lib.rs</span>
 
-```rust,does_not_compile
+```rust,ignore,does_not_compile
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -274,7 +274,7 @@ shows what that looks like:
 
 <span class="filename">Filename: src/lib.rs</span>
 
-```rust
+```rust,ignore
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Since rust-lang/rust#59940, test blocks are now included.  These code blocks are incomplete, and now cause test failures.