### PR TITLE
Add more words to the quote from the actual Go documentation

### DIFF
--- a/src/ch16-03-shared-state.md
+++ b/src/ch16-03-shared-state.md
@@ -2,7 +2,7 @@
 
 Message passing is a fine way of handling concurrency, but it’s not the only
 one. Consider this part of the slogan from the Go language documentation again:
-“communicate by sharing memory.”
+“do not communicate by sharing memory.”
 
 What would communicating by sharing memory look like? In addition, why would
 message-passing enthusiasts not use it and do the opposite instead?


### PR DESCRIPTION
Full quote [from Go docs](https://blog.golang.org/share-memory-by-communicating) is: "Do not communicate by sharing memory; instead, share memory by communicating.".

The part of the quote in the current book, while quoted correctly, does indicate the opposite meaning of what Go philiosophy wanted to convey.

So the simplest fix is to extend the quotation to return back the original meaning.