### PR TITLE
Add Rust version of the book in title for clarity

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -1,5 +1,5 @@
 [book]
-title = "The Rust Programming Language"
+title = "The Rust Programming Language - Rust >= 1.31.0"
 author = "Steve Klabnik and Carol Nichols, with Contributions from the Rust Community"
 
 [output.html]


### PR DESCRIPTION
This pull request is related to this thread https://github.com/rust-lang/book/issues/1663#issuecomment-493738068 about the guessing game exemple.

I had a hard time to figure out why, even when adding `edition="2018"` in the cargo.toml, cargo did not compile.

I understood when a friend of me point out that `This version of the text assumes you are using Rust 1.31.0 or later` which is written on the first page of the book and anywhere else.