### PR TITLE
Fix Supertrait example and mark as non-compiling

### DIFF
--- a/src/ch19-03-advanced-traits.md
+++ b/src/ch19-03-advanced-traits.md
@@ -572,8 +572,9 @@ doesn’t implement `Display`, such as the `Point` struct:
 
 <span class="filename">Filename: src/main.rs</span>
 
-```rust
-# trait OutlinePrint {}
+```rust,ignore,does_not_compile
+# use std::fmt;
+# trait OutlinePrint: fmt::Display {}
 struct Point {
     x: i32,
     y: i32,
@@ -585,14 +586,14 @@ impl OutlinePrint for Point {}
 We get an error saying that `Display` is required but not implemented:
 
 ```text
-error[E0277]: the trait bound `Point: std::fmt::Display` is not satisfied
-  --> src/main.rs:20:6
+error[E0277]: `main::Point` doesn't implement `std::fmt::Display`
+  --> src/main.rs:11:10
    |
-20 | impl OutlinePrint for Point {}
-   |      ^^^^^^^^^^^^ `Point` cannot be formatted with the default formatter;
-try using `:?` instead if you are using a format string
+11 |     impl OutlinePrint for Point {}
+   |          ^^^^^^^^^^^^ `main::Point` cannot be formatted with the default formatter
    |
-   = help: the trait `std::fmt::Display` is not implemented for `Point`
+   = help: the trait `std::fmt::Display` is not implemented for `main::Point`
+   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
 ```
 
 To fix this, we implement `Display` on `Point` and satisfy the constraint that


### PR DESCRIPTION
I was initially confused because the example compiled without an error message. This adds the missing code to break the example and also marks the example as non-compiling.

The only remaining question I have is that the error messages don't match. The error message I get when I run the PR's code is:

```text
   Compiling playground v0.0.1 (/playground)
error[E0277]: `main::Point` doesn't implement `std::fmt::Display`
  --> src/main.rs:11:6
   |
11 | impl OutlinePrint for Point {}
   |      ^^^^^^^^^^^^ `main::Point` cannot be formatted with the default formatter
   |
   = help: the trait `std::fmt::Display` is not implemented for `main::Point`
   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead

error: aborting due to previous error

For more information about this error, try `rustc --explain E0277`.
error: Could not compile `playground`.

To learn more, run the command again with --verbose.
```

As opposed to the text in the book:

```text
error[E0277]: the trait bound `Point: std::fmt::Display` is not satisfied
  --> src/main.rs:20:6
   |
20 | impl OutlinePrint for Point {}
   |      ^^^^^^^^^^^^ `Point` cannot be formatted with the default formatter;
try using `:?` instead if you are using a format string
   |
   = help: the trait `std::fmt::Display` is not implemented for `Point`
```
