### PR TITLE
Change if to of for receiver_if_method

### DIFF
--- a/src/ch19-03-advanced-traits.md
+++ b/src/ch19-03-advanced-traits.md
@@ -501,7 +501,7 @@ A baby dog is called a puppy
 In general, fully qualified syntax is defined as follows:
 
 ```rust,ignore
-<Type as Trait>::function(receiver_if_method, next_arg, ...);
+<Type as Trait>::function(receiver_of_method, next_arg, ...);
 ```
 
 For associated functions, there would not be a `receiver`: there would only be


### PR DESCRIPTION
Fixes typo `_if_` to `_of_` in the fully qualified syntax definition. 