### PR TITLE
Added a hyperlink to "Appendix A" where it is referenced in "Programming Concepts"

### DIFF
--- a/src/ch03-00-common-programming-concepts.md
+++ b/src/ch03-00-common-programming-concepts.md
@@ -18,4 +18,7 @@ them early will give you a strong core to start from.
 > special meanings, and you’ll be using them to do various tasks in your Rust
 > programs; a few have no current functionality associated with them but have
 > been reserved for functionality that might be added to Rust in the future. You
-> can find a list of the keywords in Appendix A.
+> can find a list of the keywords in [“Appendix A”][appendix_a].
+
+
+[appendix_A]: appendix-01-keywords.md


### PR DESCRIPTION
The "Programming Concepts" section had a reference to "Appendix A" containing a list of keywords, but the words "Appendix A" were not hyperlinked in the way that references are in other sections.