### PR TITLE
ch15-02-deref: Improve explanation on immut-to-mut

### DIFF
--- a/src/ch15-02-deref.md
+++ b/src/ch15-02-deref.md
@@ -375,7 +375,8 @@ never coerce to mutable references. Because of the borrowing rules, if you have
 a mutable reference, that mutable reference must be the only reference to that
 data (otherwise, the program wouldn’t compile). Converting one mutable
 reference to one immutable reference will never break the borrowing rules.
-Converting an immutable reference to a mutable reference would require that
-there is only one immutable reference to that data, and the borrowing rules
-don’t guarantee that. Therefore, Rust can’t make the assumption that converting
-an immutable reference to a mutable reference is possible.
+Converting an immutable reference to a mutable reference would require that the
+initial immutable reference is the only immutable reference to that data, but
+the borrowing rules don’t guarantee that. Therefore, Rust can’t make the
+assumption that converting an immutable reference to a mutable reference is
+possible.


### PR DESCRIPTION
On a hypothetical immut-to-mut deref, the resulting mut ref should be
unique. The aliasing rules say a mutable reference should be the only
reference, so the initial immutable reference would have to be the only
one, which is not enforced. Change the phrasing so it expresses this
fact more clearly.

Signed-off-by: Eddy Petrișor <eddy.petrisor@gmail.com>