### PR TITLE
include example of public tuple struct and field

### DIFF
--- a/src/ch07-03-paths-for-referring-to-an-item-in-the-module-tree.md
+++ b/src/ch07-03-paths-for-referring-to-an-item-in-the-module-tree.md
@@ -293,12 +293,18 @@ mod back_of_house {
         seasonal_fruit: String,
     }
 
+    pub struct TotalCost(pub f32);
+
     impl Breakfast {
         pub fn summer(toast: &str) -> Breakfast {
             Breakfast {
                 toast: String::from(toast),
                 seasonal_fruit: String::from("peaches"),
             }
+        }
+
+        pub fn checkout() -> TotalCost {
+            TotalCost(7.99)
         }
     }
 }


### PR DESCRIPTION
I love the book, thank you for all the effort to create and maintain it! I just encountered a puzzling compiler error in a project of mine, and realized maybe other newcomers like myself could avoid some confusion if an example such as this was included.

Reference of the issue I faced: https://github.com/rust-lang/rust/issues/39703

If you think there is a better place for this kind of example (e.g. _not_ as part of the book), no worries at all. Otherwise, please feel free to change/improve the example as you see fit.