### PR TITLE
add does_not_compile for a snippet

### DIFF
--- a/src/ch09-02-recoverable-errors-with-result.md
+++ b/src/ch09-02-recoverable-errors-with-result.md
@@ -481,7 +481,7 @@ must be a `Result` to be compatible with this `return`.
 Let’s look at what happens if we use the `?` operator in the `main` function,
 which you’ll recall has a return type of `()`:
 
-```rust,ignore
+```rust,ignore,does_not_compile
 use std::fs::File;
 
 fn main() {


### PR DESCRIPTION
The snippet in the section "The `?` Operator Can Only Be Used in Functions That Return `Result`" doesn't compile (as expected) thus I added the "does_not_compile" keyword.