### PR TITLE
Replace Cargo docs link with a more specific link

### DIFF
--- a/src/ch14-01-release-profiles.md
+++ b/src/ch14-01-release-profiles.md
@@ -66,4 +66,4 @@ Cargo will use the defaults for the `dev` profile plus our customization to
 optimizations than the default, but not as many as in a release build.
 
 For the full list of configuration options and defaults for each profile, see
-[Cargo’s documentation](https://doc.rust-lang.org/cargo/).
+[Cargo’s documentation](https://doc.rust-lang.org/cargo/reference/manifest.html#the-profile-sections).


### PR DESCRIPTION
In the "Release profiles" section, there is a link to read more about it in the Cargo book.  This replaces that link to the general Cargo book with a link to the "Profiles" section of the Cargo book.