### PR TITLE
Update ch03-02-data-types.md

### DIFF
--- a/src/ch03-02-data-types.md
+++ b/src/ch03-02-data-types.md
@@ -277,11 +277,11 @@ want to access. For example:
 fn main() {
     let x: (i32, f64, u8) = (500, 6.4, 1);
 
-    let five_hundred = x.0;
+    let five_hundred = tup.0;
 
-    let six_point_four = x.1;
+    let six_point_four = tup.1;
 
-    let one = x.2;
+    let one = tup.2;
 }
 ```
 


### PR DESCRIPTION
Lines 280, 282 and 284 used variable x instead of the tuple tup.