### PR TITLE
make value_in_cents borrow its Coin

### DIFF
--- a/src/ch06-02-match.md
+++ b/src/ch06-02-match.md
@@ -27,7 +27,7 @@ enum Coin {
     Quarter,
 }
 
-fn value_in_cents(coin: Coin) -> u8 {
+fn value_in_cents(coin: &Coin) -> u8 {
     match coin {
         Coin::Penny => 1,
         Coin::Nickel => 5,
@@ -76,7 +76,7 @@ a `Coin::Penny` but would still return the last value of the block, `1`:
 #    Quarter,
 # }
 #
-fn value_in_cents(coin: Coin) -> u8 {
+fn value_in_cents(coin: &Coin) -> u8 {
     match coin {
         Coin::Penny => {
             println!("Lucky penny!");
@@ -145,7 +145,7 @@ quarter’s state. Then we can use `state` in the code for that arm, like so:
 #    Quarter(UsState),
 # }
 #
-fn value_in_cents(coin: Coin) -> u8 {
+fn value_in_cents(coin: &Coin) -> u8 {
     match coin {
         Coin::Penny => 1,
         Coin::Nickel => 5,


### PR DESCRIPTION
Though it doesn't cause an error in any of the examples, the `value_in_cents` function as written will take ownership of and destroy the coin passed to it.  This is likely not what you'd want such a function to do if you were using it for real.

PR changes the parameter to a borrow so that the function means and behaves how someone new to the language (e.g. me!) would think.  It doesn't touch the text yet - I don't know how an experienced Rustacean would feel about saying "the type of `coin` in this example is the `Coin` enum" if the function is specifically borrowing/getting a reference.