### PR TITLE
Make a portion of text less ambiguous 

### DIFF
--- a/src/ch07-05-separating-modules-into-different-files.md
+++ b/src/ch07-05-separating-modules-into-different-files.md
@@ -76,7 +76,7 @@ that module.
 
 ## Summary
 
-Rust lets you organize your packages into crates and your crates into modules
+Rust lets you divide a package into multiple crates and a crates into modules
 so you can refer to items defined in one module from another module. You can do
 this by specifying absolute or relative paths. These paths can be brought into
 scope with a `use` statement so you can use a shorter path for multiple uses of

--- a/src/ch07-05-separating-modules-into-different-files.md
+++ b/src/ch07-05-separating-modules-into-different-files.md
@@ -76,7 +76,7 @@ that module.
 
 ## Summary
 
-Rust lets you divide a package into multiple crates and a crates into modules
+Rust lets you divide a package into multiple crates and a crate into modules
 so you can refer to items defined in one module from another module. You can do
 this by specifying absolute or relative paths. These paths can be brought into
 scope with a `use` statement so you can use a shorter path for multiple uses of

--- a/src/ch07-05-separating-modules-into-different-files.md
+++ b/src/ch07-05-separating-modules-into-different-files.md
@@ -76,7 +76,7 @@ that module.
 
 ## Summary
 
-Rust lets you divide a package into multiple crates and a crate into modules
+Rust lets you partition a package into multiple crates and a crate into modules
 so you can refer to items defined in one module from another module. You can do
 this by specifying absolute or relative paths. These paths can be brought into
 scope with a `use` statement so you can use a shorter path for multiple uses of

--- a/src/ch07-05-separating-modules-into-different-files.md
+++ b/src/ch07-05-separating-modules-into-different-files.md
@@ -76,7 +76,7 @@ that module.
 
 ## Summary
 
-Rust lets you partition a package into multiple crates and a crate into modules
+Rust lets you split a package into multiple crates and a crate into modules
 so you can refer to items defined in one module from another module. You can do
 this by specifying absolute or relative paths. These paths can be brought into
 scope with a `use` statement so you can use a shorter path for multiple uses of


### PR DESCRIPTION
My apologies if this seems a little nitpicky, but the way I first read "Rust lets you organize your packages into crates and your crates into modules" I incorrectly interpreted this to suggest packages are put into crates and crates are put into modules, which would lead a reader to think that modules are the largest container.

I think using the stronger language  and explicitly saying "partition a package into multiple crates ..." (adding the word  multiple/partition and using the singular of the larger containers) can prevent some readers from interpreting the text incorrectly. 

