### PR TITLE
Add destructuring tuple struct example

### DIFF
--- a/src/ch05-01-defining-structs.md
+++ b/src/ch05-01-defining-structs.md
@@ -248,6 +248,22 @@ tuple struct instances behave like tuples: you can destructure them into their
 individual pieces, you can use a `.` followed by the index to access an
 individual value, and so on.
 
+```rust
+# struct Point(i32, i32, i32);
+#
+let origin = Point(0, 0, 0);
+
+let Point(x, y, z) = origin;
+
+println!("The origin co-ordinates are x:{} y:{} z:{}", x, y, z);
+```
+
+<span class="caption">Listing 5-8: Accessing values in a tuple struct by
+destructuring syntax</span>
+
+The code in Listing 5-8 accesses values from a tuple struct using the
+destructuring syntax.
+
 ### Unit-Like Structs Without Any Fields
 
 You can also define structs that don’t have any fields! These are called


### PR DESCRIPTION
Theres a difference in the way tuple structs are destructured compared to normal tuples. Unless I've somehow completely missed a bit that shows this, it doesn't seem to have been pointed out.

This PR adds an example of how it is done.

