### PR TITLE
Fix tidy error.

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -14,7 +14,6 @@ echo 'Linting for local file paths...'
 cargo run --bin lfp src
 echo 'Validating references'
 for file in src/*.md ; do
-	echo Checking references in $file
-	cargo run --quiet --bin link2print < $file > /dev/null
+    echo Checking references in $file
+    cargo run --quiet --bin link2print < $file > /dev/null
 done
-


### PR DESCRIPTION
Upstream tidy doesn't like the whitespace in `ci/build.sh` (no tabs,
too many newlines).