### PR TITLE
This example have an unused variable: x

### DIFF
--- a/src/ch03-03-how-functions-work.md
+++ b/src/ch03-03-how-functions-work.md
@@ -214,6 +214,7 @@ fn main() {
     };
 
     println!("The value of y is: {}", y);
+    println!("The value of x is: {}", x);
 }
 ```
 


### PR DESCRIPTION
only print the 'x' variable fix this issue.

`cargo build`
 --> src/main.rs:2:9
  |
2 |     let x = 5;
  |         ^ help: consider prefixing with an underscore: `_x`
  |
  = note: `#[warn(unused_variables)]` on by default