### PR TITLE
[ch19-06-macros] Fix example for hello_macro_derive

### DIFF
--- a/src/ch19-06-macros.md
+++ b/src/ch19-06-macros.md
@@ -334,10 +334,11 @@ https://github.com/rust-lang/rust/issues/55599
 
 ```rust,ignore
 extern crate proc_macro;
+extern crate quote;
+extern crate syn;
 
 use crate::proc_macro::TokenStream;
 use quote::quote;
-use syn;
 
 #[proc_macro_derive(HelloMacro)]
 pub fn hello_macro_derive(input: TokenStream) -> TokenStream {


### PR DESCRIPTION
Using the following rust version:
rustc 1.37.0 (eae3437df 2019-08-13)
1.37.0-x86_64-apple-darwin

it was not possible to compile provided example with errors:
```bash
error[E0432]: unresolved import `quote`
 --> src/lib.rs:4:5
  |
4 | use quote::quote;
  |     ^^^^^ maybe a missing crate `quote`?

error[E0432]: unresolved import `syn`
 --> src/lib.rs:5:5
  |
5 | use syn;
  |     ^^^ no `syn` in the root

error: cannot determine resolution for the macro `quote`
  --> src/lib.rs:19:15
   |
19 |     let gen = quote! {
   |               ^^^^^
   |
   = note: import resolution is stuck, try simplifying macro imports

error: aborting due to 3 previous errors

For more information about this error, try `rustc --explain E0432`.
error: Could not compile `hello_macro_derive`.


```

The proposed changes fixed the issue and example could be compiled again. 