### PR TITLE
Fix wording that introduces the module system

### DIFF
--- a/src/ch07-00-managing-growing-projects-with-packages-crates-and-modules.md
+++ b/src/ch07-00-managing-growing-projects-with-packages-crates-and-modules.md
@@ -33,8 +33,8 @@ same name in the same scope; tools are available to resolve name conflicts.
 
 Rust has a number of features that allow you to manage your code’s
 organization, including which details are exposed, which details are private,
-and what names are in each scope in your programs. These features, sometimes
-collectively referred to as the *module system*, and include:
+and what names are in each scope in your programs. These features are sometimes
+collectively referred to as the *module system* and include:
 
 * **Packages:** A Cargo feature that lets you build, test, and share crates
 * **Crates:** A tree of modules that produces a library or executable


### PR DESCRIPTION
Just fixing a sentence that's structured incorrectly. Another option would be:

> These features, sometimes collectively referred to as the *module system*, include:

(This would just remove the problematic `and`.)

