### PR TITLE
fix heading level

### DIFF
--- a/src/appendix-04-useful-development-tools.md
+++ b/src/appendix-04-useful-development-tools.md
@@ -1,10 +1,10 @@
-# Appendix D - Useful Development Tools
+## Appendix D - Useful Development Tools
 
 In this appendix, we talk about some useful development tools that the Rust
 project provides. We’ll look at automatic formatting, quick ways to apply
 warning fixes, a linter, and integrating with IDEs.
 
-## Automatic Formatting with `rustfmt`
+### Automatic Formatting with `rustfmt`
 
 The `rustfmt` tool reformats your code according to the community code style.
 Many collaborative projects use `rustfmt` to prevent arguments about which
@@ -29,7 +29,7 @@ on `rustfmt`, see [its documentation][rustfmt].
 
 [rustfmt]: https://github.com/rust-lang/rustfmt
 
-## Fix Your Code with `rustfix`
+### Fix Your Code with `rustfix`
 
 The rustfix tool is included with Rust installations and can automatically fix
 some compiler warnings. If you’ve written code in Rust, you’ve probably seen
@@ -96,7 +96,7 @@ The `for` loop variable is now named `_i`, and the warning no longer appears.
 You can also use the `cargo fix` command to transition your code between
 different Rust editions. Editions are covered in Appendix E.
 
-## More Lints with Clippy
+### More Lints with Clippy
 
 The Clippy tool is a collection of lints to analyze your code so you can catch
 common mistakes and improve your Rust code.
@@ -158,7 +158,7 @@ For more information on Clippy, see [its documentation][clippy].
 
 [clippy]: https://github.com/rust-lang/rust-clippy
 
-## IDE Integration Using the Rust Language Server
+### IDE Integration Using the Rust Language Server
 
 To help IDE integration, the Rust project distributes the *Rust Language
 Server* (`rls`). This tool speaks the [Language Server

--- a/src/appendix-05-editions.md
+++ b/src/appendix-05-editions.md
@@ -1,4 +1,4 @@
-# Appendix E - Editions
+## Appendix E - Editions
 
 In Chapter 1, you saw that `cargo new` adds a bit of metadata to your
 *Cargo.toml* file about an edition. This appendix talks about what that means!

--- a/src/appendix-07-nightly-rust.md
+++ b/src/appendix-07-nightly-rust.md
@@ -1,4 +1,4 @@
-# Appendix G - How Rust is Made and “Nightly Rust”
+## Appendix G - How Rust is Made and “Nightly Rust”
 
 This appendix is about how Rust is made and how that affects you as a Rust
 developer.


### PR DESCRIPTION
With `mdBook`, heading levels is controlled by <https://github.com/rust-lang/book/blob/master/src/SUMMARY.md>. And the table of contents in <https://github.com/rust-lang/book/blob/master/src/SUMMARY.md> is right,  so the result heading levels looks correct on <https://doc.rust-lang.org/book/title-page.html>. However, when generating the `epub` and `pdf` version by `pandoc`, which will ignore <https://github.com/rust-lang/book/blob/master/src/SUMMARY.md>, the result heading levels is differrent from <https://doc.rust-lang.org/book/title-page.html>. So I fix heading levels in some appendix files.