### PR TITLE
traits: add word to clarify paragraph intent

### DIFF
--- a/src/ch10-02-traits.md
+++ b/src/ch10-02-traits.md
@@ -151,7 +151,7 @@ local to our `aggregator` crate. This restriction is part of a property of
 programs called *coherence*, and more specifically the *orphan rule*, so named
 because the parent type is not present. This rule ensures that other people’s
 code can’t break your code and vice versa. Without the rule, two crates could
-implement the same trait for the same type, and Rust wouldn’t know which
+implement the same trait differently for the same type, and Rust wouldn’t know which
 implementation to use.
 
 ### Default Implementations


### PR DESCRIPTION
This change adds a word to the paragraph to help the reader understand the complex reasoning behind not allowing trait implementations on external types. Previously, the paragraph could not exactly convey the context where trait implementation on external type would lead of failure. But now, the specific situation has be clearly pointed out and the hope is that it will help the reader instantly identify the situation.