### PR TITLE
Fix typo in ch07 module system intro text

### DIFF
--- a/src/ch07-00-managing-growing-projects-with-packages-crates-and-modules.md
+++ b/src/ch07-00-managing-growing-projects-with-packages-crates-and-modules.md
@@ -33,7 +33,7 @@ same name in the same scope; tools are available to resolve name conflicts.
 
 Rust has a number of features that allow you to manage your code’s
 organization, including which details are exposed, which details are private,
-and what names are in each scope in your programs. These features, sometimes
+and what names are in each scope in your programs. These features are sometimes
 collectively referred to as the *module system*, and include:
 
 * **Packages:** A Cargo feature that lets you build, test, and share crates


### PR DESCRIPTION
I ran across a sentence that's grammatically incorrect -- it's missing a verb in the first clause (before the "and").

The before-fix sentence is "These features, sometimes collectively referred to as the *module system*, and include: [...]"

Trivial fix; just adding the word "are" in place of the first comma ("These features are sometimes...")