### PR TITLE
Move `async` and `await` keywords to 'Currently in Use'

### DIFF
--- a/src/appendix-01-keywords.md
+++ b/src/appendix-01-keywords.md
@@ -15,6 +15,8 @@ The following keywords currently have the functionality described.
 
 * `as` - perform primitive casting, disambiguate the specific trait containing
   an item, or rename items in `use` and `extern crate` statements
+* `async` -  return a `Future` instead of blocking the current thread
+* `await` - suspend execution until the result of a `Future` is ready
 * `break` - exit a loop immediately
 * `const` - define constant items or constant raw pointers
 * `continue` - continue to the next loop iteration
@@ -59,8 +61,6 @@ The following keywords do not have any functionality but are reserved by Rust
 for potential future use.
 
 * `abstract`
-* `async`
-* `await`
 * `become`
 * `box`
 * `do`


### PR DESCRIPTION
In Appendix A, these keywords were previously in the list of those reserved for future use. As of Rust 1.39, [async/.await is now stabilized][release].

The descriptions are directly taken from the keyword documentation ([async], [await]) at
the time of writing, but they might be reworded to be more specific.

[release]: https://github.com/rust-lang/rust/blob/stable/RELEASES.md#language
[async]: https://doc.rust-lang.org/std/keyword.async.html
[await]: https://doc.rust-lang.org/std/keyword.await.html