### PR TITLE
Closes rust-lang/book#1682

### DIFF
--- a/src/ch04-02-references-and-borrowing.md
+++ b/src/ch04-02-references-and-borrowing.md
@@ -256,7 +256,7 @@ created. These scopes don’t overlap, so this code is allowed.
 
 It is important to note that while data races are specific to
 multi-threaded programs, rules we have just discussed apply to
-single-threaded (sequeltial) programms too. Consider following example,
+single-threaded (sequential) programms too. Consider following example,
 where we iterate over a vector whilst also mutating it inside the loop:
 
 ```rust,ignore,does_not_compile

--- a/src/ch04-02-references-and-borrowing.md
+++ b/src/ch04-02-references-and-borrowing.md
@@ -259,7 +259,7 @@ multi-threaded programs, rules we have just discussed apply to
 single-threaded (sequeltial) programms too. Consider following example,
 where we iterate over a vector whilst also mutating it inside the loop:
 
-```rust,does_not_compile
+```rust,ignore,does_not_compile
 let mut buffer = vec![1, 2, 3, 4];
 
 for i in &buffer {

--- a/src/ch04-02-references-and-borrowing.md
+++ b/src/ch04-02-references-and-borrowing.md
@@ -256,7 +256,7 @@ created. These scopes don’t overlap, so this code is allowed.
 
 It is important to note that while data races are specific to
 multithreaded programs, rules we have just discussed apply to
-singlethreaded (sequential) programs too. Consider following example,
+single threaded (sequential) programs too. Consider following example,
 where we iterate over a vector whilst also mutating it inside the loop:
 
 ```rust,ignore,does_not_compile

--- a/src/ch04-02-references-and-borrowing.md
+++ b/src/ch04-02-references-and-borrowing.md
@@ -255,8 +255,8 @@ where they are last used, which is before the mutable reference `r3` is
 created. These scopes don’t overlap, so this code is allowed.
 
 It is important to note that while data races are specific to
-multi-threaded programs, rules we have just discussed apply to
-single-threaded (sequential) programms too. Consider following example,
+multithreaded programs, rules we have just discussed apply to
+singlethreaded (sequential) programs too. Consider following example,
 where we iterate over a vector whilst also mutating it inside the loop:
 
 ```rust,ignore,does_not_compile


### PR DESCRIPTION
This will answer a question newcomers often ask about why single-threaded programs need limitation on number of mutable references.

Example from: https://manishearth.github.io/blog/2015/05/17/the-problem-with-shared-mutability/