### PR TITLE
Link to macros by example rather than macros

### DIFF
--- a/src/ch19-06-macros.md
+++ b/src/ch19-06-macros.md
@@ -120,7 +120,7 @@ covered in Chapter 18 because macro patterns are matched against Rust code
 structure rather than values. Let’s walk through what the pattern pieces in
 Listing 19-28 mean; for the full macro pattern syntax, see [the reference].
 
-[the reference]: ../reference/macros.html
+[the reference]: ../reference/macros-by-example.html
 
 First, a set of parentheses encompasses the whole pattern. A dollar sign (`$`)
 is next, followed by a set of parentheses that captures values that match the


### PR DESCRIPTION
That file contains the actual information about pattern matching

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rust-lang/book/2164)
<!-- Reviewable:end -->
