### PR TITLE
fixed type in ch07-05 (ignoring main fn)

### DIFF
--- a/src/ch07-05-separating-modules-into-different-files.md
+++ b/src/ch07-05-separating-modules-into-different-files.md
@@ -32,7 +32,7 @@ And *src/front_of_house.rs* gets the definitions from the body of the
 
 <span class="filename">Filename: src/front_of_house.rs</span>
 
-```rust
+```rust, ignore
 pub mod hosting {
     pub fn add_to_waitlist() {}
 }


### PR DESCRIPTION
```
pub mod hosting{
    pub fn add_to_waitlist(){}
}
```

Should not contain `fn main(){}` wrapping it, fixed with `ignore` tag besides language specification in code block.