### PR TITLE
ch17-03: mark code snippet with `does_not_compile`

### DIFF
--- a/src/ch17-03-oo-design-patterns.md
+++ b/src/ch17-03-oo-design-patterns.md
@@ -34,7 +34,7 @@ because we haven’t implemented the `blog` crate yet.
 
 <span class="filename">Filename: src/main.rs</span>
 
-```rust,ignore
+```rust,ignore,does_not_compile
 use blog::Post;
 
 fn main() {


### PR DESCRIPTION
Because the book says so in the line leading to the snippet:

> This won’t compile yet because we haven’t implemented the `blog` crate yet.