### PR TITLE
Remove optional commas from match arms in ch18-03

### DIFF
--- a/src/ch18-03-pattern-syntax.md
+++ b/src/ch18-03-pattern-syntax.md
@@ -281,7 +281,7 @@ fn main() {
     match msg {
         Message::Quit => {
             println!("The Quit variant has no data to destructure.")
-        },
+        }
         Message::Move { x, y } => {
             println!(
                 "Move in the x direction {} and in the y direction {}",
@@ -356,7 +356,7 @@ fn main() {
                 g,
                 b
             )
-        },
+        }
         Message::ChangeColor(Color::Hsv(h, s, v)) => {
             println!(
                 "Change the color to hue {}, saturation {}, and value {}",


### PR DESCRIPTION
Removes a couple of optional commas from the match arms, for consistency within the examples, which in other arms do not have (optional) commas. Matches `rustfmt` behaviour.