### PR TITLE
Updated appendix 07 to reflect deprecation of rustup install

### DIFF
--- a/src/appendix-07-nightly-rust.md
+++ b/src/appendix-07-nightly-rust.md
@@ -142,7 +142,7 @@ global or per-project basis. By default, you’ll have stable Rust installed. To
 install nightly, for example:
 
 ```text
-$ rustup install nightly
+$ rustup toolchain install nightly
 ```
 
 You can see all of the *toolchains* (releases of Rust and associated


### PR DESCRIPTION
This PR from the rustup repository brought me here: rust-lang/rustup#2148

TL;DR With rustup 1.21.0 rustup install and rustup uninstall are being deprecated in favor of rustup toolchain install and rustup toolchain uninstall. There's plenty of code/documentation out there that needs to be updated to reflect this.

Thought It would be cool to help, however small the change may be. :)

Keep up the great work! ⌨️ 