### PR TITLE
Typo?

### DIFF
--- a/src/ch06-02-match.md
+++ b/src/ch06-02-match.md
@@ -11,7 +11,7 @@ possible cases are handled.
 Think of a `match` expression as being like a coin-sorting machine: coins slide
 down a track with variously sized holes along it, and each coin falls through
 the first hole it encounters that it fits into. In the same way, values go
-through each pattern in a `match`, and at the first pattern the value “fits,”
+through each pattern in a `match`, and at the first pattern the value “fits”,
 the value falls into the associated code block to be used during execution.
 
 Because we just mentioned coins, let’s use them as an example using `match`! We


### PR DESCRIPTION
'"fits", ' fits this sentence better.
If the original sentence is what you intended, just ignore this PR, please.