### PR TITLE
Chapter 15-06: fix return type of Weak#upgrade

### DIFF
--- a/src/ch15-06-reference-cycles.md
+++ b/src/ch15-06-reference-cycles.md
@@ -198,7 +198,7 @@ anything with the value that a `Weak<T>` is pointing to, you must make sure the
 value still exists. Do this by calling the `upgrade` method on a `Weak<T>`
 instance, which will return an `Option<Rc<T>>`. You’ll get a result of `Some`
 if the `Rc<T>` value has not been dropped yet and a result of `None` if the
-`Rc<T>` value has been dropped. Because `upgrade` returns an `Option<T>`, Rust
+`Rc<T>` value has been dropped. Because `upgrade` returns an `Option<Rc<T>>`, Rust
 will ensure that the `Some` case and the `None` case are handled, and there
 won’t be an invalid pointer.
 


### PR DESCRIPTION
According to rust [doc][1] Weak#upgrade returns a type of `Option<Rc<T>>` and not just `Option<T>`.
This is more likely a typo since the correct type is mentioned a few sentences before.
This commit fixes just that.

[1]: https://doc.rust-lang.org/std/rc/struct.Weak.html#method.upgrade