### PR TITLE
Mention effect of `Self` in method parameters on object safety

### DIFF
--- a/src/ch17-02-trait-objects.md
+++ b/src/ch17-02-trait-objects.md
@@ -362,15 +362,15 @@ govern all the properties that make a trait object safe, but in practice, only
 two rules are relevant. A trait is object safe if all the methods defined in
 the trait have the following properties:
 
-* The return type isn’t `Self`.
+* `Self` is not used as additional method parameter type or return type.
 * There are no generic type parameters.
 
 The `Self` keyword is an alias for the type we’re implementing the traits or
 methods on. Trait objects must be object safe because once you’ve used a trait
 object, Rust no longer knows the concrete type that’s implementing that trait.
-If a trait method returns the concrete `Self` type, but a trait object forgets
-the exact type that `Self` is, there is no way the method can use the original
-concrete type. The same is true of generic type parameters that are filled in
+If a trait method uses the concrete `Self` in its additional parameters or return type, but
+a trait object forgets the exact type that `Self` is, there is no way the method can use the
+original concrete type. The same is true of generic type parameters that are filled in
 with concrete type parameters when the trait is used: the concrete types become
 part of the type that implements the trait. When the type is forgotten through
 the use of a trait object, there is no way to know what types to fill in the


### PR DESCRIPTION
Maybe content's in ```rustc --explain E0038```
should be mentioned or merged here to make it more clear