### PR TITLE
Macros: Small updates

### DIFF
--- a/src/ch19-06-macros.md
+++ b/src/ch19-06-macros.md
@@ -325,17 +325,10 @@ won’t compile until we add a definition for the `impl_hello_macro` function.
 
 <span class="filename">Filename: hello_macro_derive/src/lib.rs</span>
 
-<!--
-This usage of `extern crate` is required for the moment with 1.31.0, see:
-https://github.com/rust-lang/rust/issues/54418
-https://github.com/rust-lang/rust/pull/54658
-https://github.com/rust-lang/rust/issues/55599
--->
-
 ```rust,ignore
 extern crate proc_macro;
 
-use crate::proc_macro::TokenStream;
+use proc_macro::TokenStream;
 use quote::quote;
 use syn;
 

--- a/src/ch19-06-macros.md
+++ b/src/ch19-06-macros.md
@@ -315,8 +315,8 @@ in a moment, so we need to add them as dependencies. Add the following to the
 proc-macro = true
 
 [dependencies]
-syn = "0.14.4"
-quote = "0.6.3"
+syn = "1.0"
+quote = "1.0"
 ```
 
 To start defining the procedural macro, place the code in Listing 19-31 into
@@ -417,7 +417,7 @@ with the `ident` (identifier, meaning the name) of `Pancakes`. There are more
 fields on this struct for describing all sorts of Rust code; check the [`syn`
 documentation for `DeriveInput`][syn-docs] for more information.
 
-[syn-docs]: https://docs.rs/syn/0.14.4/syn/struct.DeriveInput.html
+[syn-docs]: https://docs.rs/syn/1.0/syn/struct.DeriveInput.html
 
 Soon we’ll define the `impl_hello_macro` function, which is where we’ll build
 the new Rust code we want to include. But before we do, note that the output

--- a/src/ch19-06-macros.md
+++ b/src/ch19-06-macros.md
@@ -446,7 +446,7 @@ fn impl_hello_macro(ast: &syn::DeriveInput) -> TokenStream {
     let gen = quote! {
         impl HelloMacro for #name {
             fn hello_macro() {
-                println!("Hello, Macro! My name is {}", stringify!(#name));
+                println!("Hello, Macro! My name is {}!", stringify!(#name));
             }
         }
     };


### PR DESCRIPTION
I noticed three things when reading the Macros Chapter:
1. An exclamation mark is missing. It is present in other places. I changed it to be consistent.
2. The `syn` and `quote` crates are out of date. I updated them to `1.0`.
3. I stumbled over the multiline comment in line 328 ff.. I think the comment can be resolved by using `proc_macro` over `crate::proc_macro` as I did.

What do you think?