### PR TITLE
Async/Await keywords now in use.

### DIFF
--- a/src/appendix-01-keywords.md
+++ b/src/appendix-01-keywords.md
@@ -15,6 +15,8 @@ The following keywords currently have the functionality described.
 
 * `as` - perform primitive casting, disambiguate the specific trait containing
   an item, or rename items in `use` and `extern crate` statements
+* `async` - return a `Future` instead of blocking current thread (2018 edition)
+* `await` - suspend execution until the result of a `Future` is ready (2018 edition)
 * `break` - exit a loop immediately
 * `const` - define constant items or constant raw pointers
 * `continue` - continue to the next loop iteration
@@ -59,8 +61,6 @@ The following keywords do not have any functionality but are reserved by Rust
 for potential future use.
 
 * `abstract`
-* `async`
-* `await`
 * `become`
 * `box`
 * `do`


### PR DESCRIPTION
I'm not sure how you'd like to demarcate that these keywords are only keywords from 2018 edition onwards? I've postfixed the edition for now.