### PR TITLE
Add symbol for compile error in snippet and remove dead code

### DIFF
--- a/src/ch12-04-testing-the-librarys-functionality.md
+++ b/src/ch12-04-testing-the-librarys-functionality.md
@@ -41,10 +41,6 @@ yet.
 <span class="filename">Filename: src/lib.rs</span>
 
 ```rust,ignore,does_not_compile
-// pub fn search<'a>(query: &str, contents: &'a str) -> Vec<&'a str> {
-//      vec![]
-// }
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/ch12-04-testing-the-librarys-functionality.md
+++ b/src/ch12-04-testing-the-librarys-functionality.md
@@ -40,11 +40,11 @@ yet.
 
 <span class="filename">Filename: src/lib.rs</span>
 
-```rust
-# pub fn search<'a>(query: &str, contents: &'a str) -> Vec<&'a str> {
-#      vec![]
-# }
-#
+```rust,ignore,does_not_compile
+// pub fn search<'a>(query: &str, contents: &'a str) -> Vec<&'a str> {
+//      vec![]
+// }
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
I did the fixes in two steps; first just replaces the `#` with `//`, as I think was intended. The second fix removes the code snippet as it was confusing me when I read the code.

I also added `ignore,does_not_compile`, but it's hard for me to verify if that is the correct way to get the question mark crab.