### PR TITLE
Update cargo profiles link.

### DIFF
--- a/src/ch14-01-release-profiles.md
+++ b/src/ch14-01-release-profiles.md
@@ -73,4 +73,4 @@ Cargo will use the defaults for the `dev` profile plus our customization to
 optimizations than the default, but not as many as in a release build.
 
 For the full list of configuration options and defaults for each profile, see
-[Cargo’s documentation](https://doc.rust-lang.org/cargo/reference/manifest.html#the-profile-sections).
+[Cargo’s documentation](https://doc.rust-lang.org/cargo/reference/profiles.html).


### PR DESCRIPTION
Cargo has a new chapter for profiles that replaces the old section.