### PR TITLE
Increase HTTP buffer size and add 'Content-Length' header

### DIFF
--- a/listings/ch20-web-server/listing-20-02/src/main.rs
+++ b/listings/ch20-web-server/listing-20-02/src/main.rs
@@ -13,7 +13,7 @@ fn main() {
 }
 
 fn handle_connection(mut stream: TcpStream) {
-    let mut buffer = [0; 512];
+    let mut buffer = [0; 1024];
 
     stream.read(&mut buffer).unwrap();
 

--- a/listings/ch20-web-server/listing-20-03/src/main.rs
+++ b/listings/ch20-web-server/listing-20-03/src/main.rs
@@ -14,7 +14,7 @@ fn main() {
 
 // ANCHOR: here
 fn handle_connection(mut stream: TcpStream) {
-    let mut buffer = [0; 512];
+    let mut buffer = [0; 1024];
 
     stream.read(&mut buffer).unwrap();
 

--- a/listings/ch20-web-server/listing-20-04/src/main.rs
+++ b/listings/ch20-web-server/listing-20-04/src/main.rs
@@ -13,7 +13,7 @@ fn main() {
 }
 
 fn handle_connection(mut stream: TcpStream) {
-    let mut buffer = [0; 512];
+    let mut buffer = [0; 1024];
 
     stream.read(&mut buffer).unwrap();
 

--- a/listings/ch20-web-server/listing-20-05/src/main.rs
+++ b/listings/ch20-web-server/listing-20-05/src/main.rs
@@ -19,12 +19,16 @@ fn main() {
 
 // ANCHOR: here
 fn handle_connection(mut stream: TcpStream) {
-    let mut buffer = [0; 512];
+    let mut buffer = [0; 1024];
     stream.read(&mut buffer).unwrap();
 
     let contents = fs::read_to_string("hello.html").unwrap();
 
-    let response = format!("HTTP/1.1 200 OK\r\n\r\n{}", contents);
+    let response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}",
+        contents.len(),
+        contents
+    );
 
     stream.write(response.as_bytes()).unwrap();
     stream.flush().unwrap();

--- a/listings/ch20-web-server/listing-20-06/src/main.rs
+++ b/listings/ch20-web-server/listing-20-06/src/main.rs
@@ -17,7 +17,7 @@ fn main() {
 // --snip--
 
 fn handle_connection(mut stream: TcpStream) {
-    let mut buffer = [0; 512];
+    let mut buffer = [0; 1024];
     stream.read(&mut buffer).unwrap();
 
     let get = b"GET / HTTP/1.1\r\n";
@@ -25,7 +25,11 @@ fn handle_connection(mut stream: TcpStream) {
     if buffer.starts_with(get) {
         let contents = fs::read_to_string("hello.html").unwrap();
 
-        let response = format!("HTTP/1.1 200 OK\r\n\r\n{}", contents);
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}",
+            contents.len(),
+            contents
+        );
 
         stream.write(response.as_bytes()).unwrap();
         stream.flush().unwrap();

--- a/listings/ch20-web-server/listing-20-07/src/main.rs
+++ b/listings/ch20-web-server/listing-20-07/src/main.rs
@@ -14,7 +14,7 @@ fn main() {
 }
 
 fn handle_connection(mut stream: TcpStream) {
-    let mut buffer = [0; 512];
+    let mut buffer = [0; 1024];
     stream.read(&mut buffer).unwrap();
 
     let get = b"GET / HTTP/1.1\r\n";
@@ -22,7 +22,11 @@ fn handle_connection(mut stream: TcpStream) {
     if buffer.starts_with(get) {
         let contents = fs::read_to_string("hello.html").unwrap();
 
-        let response = format!("HTTP/1.1 200 OK\r\n\r\n{}", contents);
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}",
+            contents.len(),
+            contents
+        );
 
         stream.write(response.as_bytes()).unwrap();
         stream.flush().unwrap();

--- a/listings/ch20-web-server/listing-20-08/src/main.rs
+++ b/listings/ch20-web-server/listing-20-08/src/main.rs
@@ -14,7 +14,7 @@ fn main() {
 }
 
 fn handle_connection(mut stream: TcpStream) {
-    let mut buffer = [0; 512];
+    let mut buffer = [0; 1024];
     stream.read(&mut buffer).unwrap();
 
     let get = b"GET / HTTP/1.1\r\n";
@@ -22,7 +22,11 @@ fn handle_connection(mut stream: TcpStream) {
     if buffer.starts_with(get) {
         let contents = fs::read_to_string("hello.html").unwrap();
 
-        let response = format!("HTTP/1.1 200 OK\r\n\r\n{}", contents);
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}",
+            contents.len(),
+            contents
+        );
 
         stream.write(response.as_bytes()).unwrap();
         stream.flush().unwrap();

--- a/listings/ch20-web-server/listing-20-09/src/main.rs
+++ b/listings/ch20-web-server/listing-20-09/src/main.rs
@@ -20,7 +20,7 @@ fn handle_connection(mut stream: TcpStream) {
     // --snip--
 
     // ANCHOR_END: here
-    let mut buffer = [0; 512];
+    let mut buffer = [0; 1024];
     stream.read(&mut buffer).unwrap();
 
     let get = b"GET / HTTP/1.1\r\n";

--- a/listings/ch20-web-server/listing-20-10/src/main.rs
+++ b/listings/ch20-web-server/listing-20-10/src/main.rs
@@ -23,7 +23,7 @@ fn handle_connection(mut stream: TcpStream) {
     // --snip--
 
     // ANCHOR_END: here
-    let mut buffer = [0; 512];
+    let mut buffer = [0; 1024];
     stream.read(&mut buffer).unwrap();
 
     // ANCHOR: here

--- a/listings/ch20-web-server/listing-20-11/src/main.rs
+++ b/listings/ch20-web-server/listing-20-11/src/main.rs
@@ -20,7 +20,7 @@ fn main() {
 // ANCHOR_END: here
 
 fn handle_connection(mut stream: TcpStream) {
-    let mut buffer = [0; 512];
+    let mut buffer = [0; 1024];
     stream.read(&mut buffer).unwrap();
 
     let get = b"GET / HTTP/1.1\r\n";

--- a/listings/ch20-web-server/listing-20-12/src/main.rs
+++ b/listings/ch20-web-server/listing-20-12/src/main.rs
@@ -21,7 +21,7 @@ fn main() {
 // ANCHOR_END: here
 
 fn handle_connection(mut stream: TcpStream) {
-    let mut buffer = [0; 512];
+    let mut buffer = [0; 1024];
     stream.read(&mut buffer).unwrap();
 
     let get = b"GET / HTTP/1.1\r\n";

--- a/listings/ch20-web-server/listing-20-13/src/bin/main.rs
+++ b/listings/ch20-web-server/listing-20-13/src/bin/main.rs
@@ -20,7 +20,7 @@ fn main() {
 }
 
 fn handle_connection(mut stream: TcpStream) {
-    let mut buffer = [0; 512];
+    let mut buffer = [0; 1024];
     stream.read(&mut buffer).unwrap();
 
     let get = b"GET / HTTP/1.1\r\n";

--- a/listings/ch20-web-server/listing-20-14/src/bin/main.rs
+++ b/listings/ch20-web-server/listing-20-14/src/bin/main.rs
@@ -20,7 +20,7 @@ fn main() {
 }
 
 fn handle_connection(mut stream: TcpStream) {
-    let mut buffer = [0; 512];
+    let mut buffer = [0; 1024];
     stream.read(&mut buffer).unwrap();
 
     let get = b"GET / HTTP/1.1\r\n";

--- a/listings/ch20-web-server/listing-20-15/src/bin/main.rs
+++ b/listings/ch20-web-server/listing-20-15/src/bin/main.rs
@@ -20,7 +20,7 @@ fn main() {
 }
 
 fn handle_connection(mut stream: TcpStream) {
-    let mut buffer = [0; 512];
+    let mut buffer = [0; 1024];
     stream.read(&mut buffer).unwrap();
 
     let get = b"GET / HTTP/1.1\r\n";

--- a/listings/ch20-web-server/listing-20-16/src/bin/main.rs
+++ b/listings/ch20-web-server/listing-20-16/src/bin/main.rs
@@ -20,7 +20,7 @@ fn main() {
 }
 
 fn handle_connection(mut stream: TcpStream) {
-    let mut buffer = [0; 512];
+    let mut buffer = [0; 1024];
     stream.read(&mut buffer).unwrap();
 
     let get = b"GET / HTTP/1.1\r\n";

--- a/listings/ch20-web-server/listing-20-17/src/bin/main.rs
+++ b/listings/ch20-web-server/listing-20-17/src/bin/main.rs
@@ -20,7 +20,7 @@ fn main() {
 }
 
 fn handle_connection(mut stream: TcpStream) {
-    let mut buffer = [0; 512];
+    let mut buffer = [0; 1024];
     stream.read(&mut buffer).unwrap();
 
     let get = b"GET / HTTP/1.1\r\n";

--- a/listings/ch20-web-server/listing-20-18/src/bin/main.rs
+++ b/listings/ch20-web-server/listing-20-18/src/bin/main.rs
@@ -20,7 +20,7 @@ fn main() {
 }
 
 fn handle_connection(mut stream: TcpStream) {
-    let mut buffer = [0; 512];
+    let mut buffer = [0; 1024];
     stream.read(&mut buffer).unwrap();
 
     let get = b"GET / HTTP/1.1\r\n";

--- a/listings/ch20-web-server/listing-20-19/src/bin/main.rs
+++ b/listings/ch20-web-server/listing-20-19/src/bin/main.rs
@@ -20,7 +20,7 @@ fn main() {
 }
 
 fn handle_connection(mut stream: TcpStream) {
-    let mut buffer = [0; 512];
+    let mut buffer = [0; 1024];
     stream.read(&mut buffer).unwrap();
 
     let get = b"GET / HTTP/1.1\r\n";

--- a/listings/ch20-web-server/listing-20-20/src/bin/main.rs
+++ b/listings/ch20-web-server/listing-20-20/src/bin/main.rs
@@ -20,7 +20,7 @@ fn main() {
 }
 
 fn handle_connection(mut stream: TcpStream) {
-    let mut buffer = [0; 512];
+    let mut buffer = [0; 1024];
     stream.read(&mut buffer).unwrap();
 
     let get = b"GET / HTTP/1.1\r\n";

--- a/listings/ch20-web-server/listing-20-21/src/bin/main.rs
+++ b/listings/ch20-web-server/listing-20-21/src/bin/main.rs
@@ -20,7 +20,7 @@ fn main() {
 }
 
 fn handle_connection(mut stream: TcpStream) {
-    let mut buffer = [0; 512];
+    let mut buffer = [0; 1024];
     stream.read(&mut buffer).unwrap();
 
     let get = b"GET / HTTP/1.1\r\n";

--- a/listings/ch20-web-server/listing-20-22/src/bin/main.rs
+++ b/listings/ch20-web-server/listing-20-22/src/bin/main.rs
@@ -20,7 +20,7 @@ fn main() {
 }
 
 fn handle_connection(mut stream: TcpStream) {
-    let mut buffer = [0; 512];
+    let mut buffer = [0; 1024];
     stream.read(&mut buffer).unwrap();
 
     let get = b"GET / HTTP/1.1\r\n";

--- a/listings/ch20-web-server/listing-20-23/src/bin/main.rs
+++ b/listings/ch20-web-server/listing-20-23/src/bin/main.rs
@@ -20,7 +20,7 @@ fn main() {
 }
 
 fn handle_connection(mut stream: TcpStream) {
-    let mut buffer = [0; 512];
+    let mut buffer = [0; 1024];
     stream.read(&mut buffer).unwrap();
 
     let get = b"GET / HTTP/1.1\r\n";

--- a/listings/ch20-web-server/listing-20-24/src/bin/main.rs
+++ b/listings/ch20-web-server/listing-20-24/src/bin/main.rs
@@ -20,7 +20,7 @@ fn main() {
 }
 
 fn handle_connection(mut stream: TcpStream) {
-    let mut buffer = [0; 512];
+    let mut buffer = [0; 1024];
     stream.read(&mut buffer).unwrap();
 
     let get = b"GET / HTTP/1.1\r\n";

--- a/listings/ch20-web-server/listing-20-25/src/bin/main.rs
+++ b/listings/ch20-web-server/listing-20-25/src/bin/main.rs
@@ -25,7 +25,7 @@ fn main() {
 // ANCHOR_END: here
 
 fn handle_connection(mut stream: TcpStream) {
-    let mut buffer = [0; 512];
+    let mut buffer = [0; 1024];
     stream.read(&mut buffer).unwrap();
 
     let get = b"GET / HTTP/1.1\r\n";

--- a/listings/ch20-web-server/no-listing-01-define-threadpool-struct/src/bin/main.rs
+++ b/listings/ch20-web-server/no-listing-01-define-threadpool-struct/src/bin/main.rs
@@ -22,7 +22,7 @@ fn main() {
 }
 
 fn handle_connection(mut stream: TcpStream) {
-    let mut buffer = [0; 512];
+    let mut buffer = [0; 1024];
     stream.read(&mut buffer).unwrap();
 
     let get = b"GET / HTTP/1.1\r\n";

--- a/listings/ch20-web-server/no-listing-02-impl-threadpool-new/src/bin/main.rs
+++ b/listings/ch20-web-server/no-listing-02-impl-threadpool-new/src/bin/main.rs
@@ -20,7 +20,7 @@ fn main() {
 }
 
 fn handle_connection(mut stream: TcpStream) {
-    let mut buffer = [0; 512];
+    let mut buffer = [0; 1024];
     stream.read(&mut buffer).unwrap();
 
     let get = b"GET / HTTP/1.1\r\n";

--- a/listings/ch20-web-server/no-listing-03-define-execute/src/bin/main.rs
+++ b/listings/ch20-web-server/no-listing-03-define-execute/src/bin/main.rs
@@ -20,7 +20,7 @@ fn main() {
 }
 
 fn handle_connection(mut stream: TcpStream) {
-    let mut buffer = [0; 512];
+    let mut buffer = [0; 1024];
     stream.read(&mut buffer).unwrap();
 
     let get = b"GET / HTTP/1.1\r\n";

--- a/listings/ch20-web-server/no-listing-04-update-worker-definition/src/bin/main.rs
+++ b/listings/ch20-web-server/no-listing-04-update-worker-definition/src/bin/main.rs
@@ -20,7 +20,7 @@ fn main() {
 }
 
 fn handle_connection(mut stream: TcpStream) {
-    let mut buffer = [0; 512];
+    let mut buffer = [0; 1024];
     stream.read(&mut buffer).unwrap();
 
     let get = b"GET / HTTP/1.1\r\n";

--- a/listings/ch20-web-server/no-listing-05-fix-worker-new/src/bin/main.rs
+++ b/listings/ch20-web-server/no-listing-05-fix-worker-new/src/bin/main.rs
@@ -20,7 +20,7 @@ fn main() {
 }
 
 fn handle_connection(mut stream: TcpStream) {
-    let mut buffer = [0; 512];
+    let mut buffer = [0; 1024];
     stream.read(&mut buffer).unwrap();
 
     let get = b"GET / HTTP/1.1\r\n";

--- a/listings/ch20-web-server/no-listing-06-fix-threadpool-drop/src/bin/main.rs
+++ b/listings/ch20-web-server/no-listing-06-fix-threadpool-drop/src/bin/main.rs
@@ -20,7 +20,7 @@ fn main() {
 }
 
 fn handle_connection(mut stream: TcpStream) {
-    let mut buffer = [0; 512];
+    let mut buffer = [0; 1024];
     stream.read(&mut buffer).unwrap();
 
     let get = b"GET / HTTP/1.1\r\n";

--- a/listings/ch20-web-server/no-listing-07-define-message-enum/src/bin/main.rs
+++ b/listings/ch20-web-server/no-listing-07-define-message-enum/src/bin/main.rs
@@ -20,7 +20,7 @@ fn main() {
 }
 
 fn handle_connection(mut stream: TcpStream) {
-    let mut buffer = [0; 512];
+    let mut buffer = [0; 1024];
     stream.read(&mut buffer).unwrap();
 
     let get = b"GET / HTTP/1.1\r\n";

--- a/src/ch20-01-single-threaded.md
+++ b/src/ch20-01-single-threaded.md
@@ -325,7 +325,8 @@ familiar; we used it in Chapter 12 when we read the contents of a file for our
 I/O project in Listing 12-4.
 
 Next, we use `format!` to add the file’s contents as the body of the success
-response.
+response. To ensure a valid HTTP response, we add the `Content-Length` header
+which is set to the size of our response body, in this case the size of `hello.html`.
 
 Run this code with `cargo run` and load *127.0.0.1:7878* in your browser; you
 should see your HTML rendered!


### PR DESCRIPTION
Fixes #1324 where missing `Content-Length` header or a buffer too small to hold the request resulted in Connection Reset errors in Chrome and Firefox under specific user setups. There may be further edge-cases with user-setups but this should fix all issues mentioned in #1324 