### PR TITLE
Fix nomicon links.

### DIFF
--- a/src/ch15-06-reference-cycles.md
+++ b/src/ch15-06-reference-cycles.md
@@ -315,4 +315,4 @@ information.
 Next, we’ll talk about concurrency in Rust. You’ll even learn about a few new
 smart pointers.
 
-[nomicon]: ../nomicon/
+[nomicon]: ../nomicon/index.html

--- a/src/ch16-04-extensible-concurrency-sync-and-send.md
+++ b/src/ch16-04-extensible-concurrency-sync-and-send.md
@@ -86,4 +86,4 @@ relate to those you might be familiar with from object-oriented programming.
 
 [sharing-a-mutext-between-multiple-threads]:
 ch16-03-shared-state.html#sharing-a-mutext-between-multiple-threads
-[nomicon]: ../nomicon/
+[nomicon]: ../nomicon/index.html


### PR DESCRIPTION
The rust-lang linkchecker does not allow bare directory paths.  This is required for updating rust-lang/rust.