### PR TITLE
Add github repo link

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -5,3 +5,4 @@ author = "Steve Klabnik and Carol Nichols, with Contributions from the Rust Comm
 [output.html]
 additional-css = ["ferris.css", "theme/2018-edition.css"]
 additional-js = ["ferris.js"]
+git-repository-url = "https://github.com/rust-lang/book"


### PR DESCRIPTION
.. so we get a "Git repository" link next to the "Print this book" link in the upper right corner - to get more people involved in editing the book contents.

See also rust-lang/mdBook#1148