### PR TITLE
Add the missing word to the sentence (ch06-2)

### DIFF
--- a/src/ch06-02-match.md
+++ b/src/ch06-02-match.md
@@ -181,7 +181,7 @@ pattern we forgot! Matches in Rust are *exhaustive*: we must exhaust every last
 possibility in order for the code to be valid. Especially in the case of
 `Option<T>`, when Rust prevents us from forgetting to explicitly handle the
 `None` case, it protects us from assuming that we have a value when we might
-have null, thus making the billion-dollar mistake discussed earlier.
+have null, thus making the billion-dollar mistake discussed earlier impossible.
 
 ### The `_` Placeholder
 


### PR DESCRIPTION
Chapter 6.2, discussing matches seems to have an unfinished sentence.

Add the missing `impossible` word into the `thus making the billion-dollar mistake discussed earlier.` sentence.