### PR TITLE
break semicolon removal

### DIFF
--- a/listings/ch03-common-programming-concepts/no-listing-33-return-value-from-loop/src/main.rs
+++ b/listings/ch03-common-programming-concepts/no-listing-33-return-value-from-loop/src/main.rs
@@ -5,7 +5,7 @@ fn main() {
         counter += 1;
 
         if counter == 10 {
-            break counter * 2;
+            break counter * 2
         }
     };
 


### PR DESCRIPTION
In this code example from section 3.5 Returning Values From Loops, we use `break` to return the result of the expression `counter * 2`. The Rust compiler is fine with or without ending this line with a semicolon. But it seems more consistent to Not use the semicolon since the absence of the   ;   declares/implies this block will be returning a value.