### PR TITLE
Add the missing word to the sentence in the ch08-2

### DIFF
--- a/src/ch08-02-strings.md
+++ b/src/ch08-02-strings.md
@@ -39,7 +39,8 @@ or `Str`? They refer to owned and borrowed variants, just like the `String` and
 `str` types you’ve seen previously. These string types can store text in
 different encodings or be represented in memory in a different way, for
 example. We won’t discuss these other string types in this chapter; see their
-API documentation for more about how to use them and when each is appropriate.
+API documentation for more information about how to use them and when each is
+appropriate.
 
 ### Creating a New String
 


### PR DESCRIPTION
Chapter 8.2 about strings has the missing `information` word in one of the sentences:

> These string types can store text in different encodings or be represented in memory in a different way, for example. We won’t discuss these other string types in this chapter; see their API documentation for more `information` about how to use them and when each is appropriate.