### PR TITLE
Update go docs link

### DIFF
--- a/src/ch16-02-message-passing.md
+++ b/src/ch16-02-message-passing.md
@@ -3,8 +3,8 @@
 One increasingly popular approach to ensuring safe concurrency is *message
 passing*, where threads or actors communicate by sending each other messages
 containing data. Here’s the idea in a slogan from [the Go language
-documentation](http://golang.org/doc/effective_go.html): “Do not communicate by
-sharing memory; instead, share memory by communicating.”
+documentation](https://golang.org/doc/effective_go.html#concurrency): 
+“Do not communicate by sharing memory; instead, share memory by communicating.”
 
 One major tool Rust has for accomplishing message-sending concurrency is the
 *channel*, a programming concept that Rust’s standard library provides an


### PR DESCRIPTION
- Use https instead of http
- Link directly to the concurency section