### PR TITLE
Fix broken front_of_house.rs test on nightly.

### DIFF
--- a/src/ch07-05-separating-modules-into-different-files.md
+++ b/src/ch07-05-separating-modules-into-different-files.md
@@ -39,7 +39,7 @@ declaration of the `hosting` module:
 
 <span class="filename">Filename: src/front_of_house.rs</span>
 
-```
+```rust,ignore
 {{#rustdoc_include ../listings/ch07-managing-growing-projects/no-listing-02-extracting-hosting/src/front_of_house.rs}}
 ```
 
@@ -49,7 +49,7 @@ Then we create a *src/front_of_house* directory and a file
 
 <span class="filename">Filename: src/front_of_house/hosting.rs</span>
 
-```
+```rust
 {{#rustdoc_include ../listings/ch07-managing-growing-projects/no-listing-02-extracting-hosting/src/front_of_house/hosting.rs}}
 ```
 


### PR DESCRIPTION
Through some strange interaction, `rustdoc --test` was allowing code blocks like this:

```rust
pub mod foo;
```

until recent nightlies (changed by https://github.com/rust-lang/rust/pull/69838).  This now (correctly) fails.  Added `ignore` to skip this code block.  Also added a `rust` annotation to correctly highlight another listing on the same page.

This should fix the broken toolstate status.