### PR TITLE
Update ch01-01-installation.md to require TLS 1.2

### DIFF
--- a/ci/dictionary.txt
+++ b/ci/dictionary.txt
@@ -198,6 +198,7 @@ Hoare
 Hola
 homogenous
 html
+https
 hyperoptimize
 hypotheticals
 Iceburgh
@@ -357,6 +358,7 @@ PrimaryColor
 println
 priv
 proc
+proto
 pthreads
 pushups
 QuitMessage
@@ -476,6 +478,7 @@ timestamp
 Tiếng
 timeline
 tlborm
+tlsv
 TODO
 TokenStream
 toml

--- a/src/ch01-01-installation.md
+++ b/src/ch01-01-installation.md
@@ -28,7 +28,7 @@ using these steps should work as expected with the content of this book.
 If you’re using Linux or macOS, open a terminal and enter the following command:
 
 ```text
-$ curl https://sh.rustup.rs -sSf | sh
+$ curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | sh
 ```
 
 The command downloads a script and starts the installation of the `rustup`


### PR DESCRIPTION
Require tlsv1.2 when downloading rustup init script like this:

```
$ curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | sh
```

The new code snippet still fits on one line (tested with Source Code Pro font in Firefox).

Closes #2300