### PR TITLE
Set default dark theme

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -5,3 +5,4 @@ author = "Steve Klabnik and Carol Nichols, with Contributions from the Rust Comm
 [output.html]
 additional-css = ["ferris.css", "theme/2018-edition.css"]
 additional-js = ["ferris.js"]
+preferred-dark-theme = "coal"


### PR DESCRIPTION
mdBook has a setting to set the default dark theme for when the 'prefers-color-scheme' CSS media query changes: https://github.com/rust-lang/mdBook/blob/d63ef8330dfea202116bfef525e1ccac20f1fab7/book-example/src/format/config.md#html-renderer-options. It defaults to the default theme.

This PR should make the switch to the `coal` theme when the user switches system settings, but in my testing, it does nothing. So, uh...