### PR TITLE
fix: match 15-24 with 15-18

### DIFF
--- a/listings/ch15-smart-pointers/listing-15-24/output.txt
+++ b/listings/ch15-smart-pointers/listing-15-24/output.txt
@@ -3,5 +3,5 @@ $ cargo run
     Finished dev [unoptimized + debuginfo] target(s) in 0.63s
      Running `target/debug/cons-list`
 a after = Cons(RefCell { value: 15 }, Nil)
-b after = Cons(RefCell { value: 6 }, Cons(RefCell { value: 15 }, Nil))
-c after = Cons(RefCell { value: 10 }, Cons(RefCell { value: 15 }, Nil))
+b after = Cons(RefCell { value: 3 }, Cons(RefCell { value: 15 }, Nil))
+c after = Cons(RefCell { value: 4 }, Cons(RefCell { value: 15 }, Nil))

--- a/listings/ch15-smart-pointers/listing-15-24/src/main.rs
+++ b/listings/ch15-smart-pointers/listing-15-24/src/main.rs
@@ -13,8 +13,8 @@ fn main() {
 
     let a = Rc::new(Cons(Rc::clone(&value), Rc::new(Nil)));
 
-    let b = Cons(Rc::new(RefCell::new(6)), Rc::clone(&a));
-    let c = Cons(Rc::new(RefCell::new(10)), Rc::clone(&a));
+    let b = Cons(Rc::new(RefCell::new(3)), Rc::clone(&a));
+    let c = Cons(Rc::new(RefCell::new(4)), Rc::clone(&a));
 
     *value.borrow_mut() += 10;
 


### PR DESCRIPTION
Making the example matches between to two would make it easier to follow.

Didn't do `Rc::new(Cons(10, Rc::new(Nil)))` thou.
It think making the matter part matches should be sufficient. 🌷 