### PR TITLE
Always remember to release a mutex

### DIFF
--- a/listings/ch20-web-server/listing-20-20/src/lib.rs
+++ b/listings/ch20-web-server/listing-20-20/src/lib.rs
@@ -55,7 +55,9 @@ struct Worker {
 impl Worker {
     fn new(id: usize, receiver: Arc<Mutex<mpsc::Receiver<Job>>>) -> Worker {
         let thread = thread::spawn(move || loop {
-            let job = receiver.lock().unwrap().recv().unwrap();
+            let receiver = receiver.lock().unwrap();
+            let job = receiver.recv().unwrap();
+            drop(receiver); // release mutex
 
             println!("Worker {} got a job; executing.", id);
 

--- a/listings/ch20-web-server/listing-20-21/src/lib.rs
+++ b/listings/ch20-web-server/listing-20-21/src/lib.rs
@@ -54,7 +54,9 @@ struct Worker {
 impl Worker {
     fn new(id: usize, receiver: Arc<Mutex<mpsc::Receiver<Job>>>) -> Worker {
         let thread = thread::spawn(move || {
-            while let Ok(job) = receiver.lock().unwrap().recv() {
+            while let Ok(receiver) = receiver.lock() {
+                let job = receiver.recv().unwrap();
+                drop(receiver); // release mutex
                 println!("Worker {} got a job; executing.", id);
 
                 job();

--- a/listings/ch20-web-server/listing-20-22/src/lib.rs
+++ b/listings/ch20-web-server/listing-20-22/src/lib.rs
@@ -64,7 +64,9 @@ struct Worker {
 impl Worker {
     fn new(id: usize, receiver: Arc<Mutex<mpsc::Receiver<Job>>>) -> Worker {
         let thread = thread::spawn(move || loop {
-            let job = receiver.lock().unwrap().recv().unwrap();
+            let receiver = receiver.lock().unwrap();
+            let job = receiver.recv().unwrap();
+            drop(receiver); // release mutex
 
             println!("Worker {} got a job; executing.", id);
 

--- a/listings/ch20-web-server/listing-20-23/src/lib.rs
+++ b/listings/ch20-web-server/listing-20-23/src/lib.rs
@@ -82,7 +82,9 @@ struct Worker {
 impl Worker {
     fn new(id: usize, receiver: Arc<Mutex<mpsc::Receiver<Message>>>) -> Worker {
         let thread = thread::spawn(move || loop {
-            let message = receiver.lock().unwrap().recv().unwrap();
+            let receiver = receiver.lock().unwrap();
+            let message = receiver.recv().unwrap();
+            drop(receiver); // release mutex
 
             match message {
                 Message::NewJob(job) => {

--- a/listings/ch20-web-server/listing-20-24/src/lib.rs
+++ b/listings/ch20-web-server/listing-20-24/src/lib.rs
@@ -79,7 +79,9 @@ struct Worker {
 impl Worker {
     fn new(id: usize, receiver: Arc<Mutex<mpsc::Receiver<Message>>>) -> Worker {
         let thread = thread::spawn(move || loop {
-            let message = receiver.lock().unwrap().recv().unwrap();
+            let receiver = receiver.lock().unwrap();
+            let message = receiver.recv().unwrap();
+            drop(receiver); // release mutex
 
             match message {
                 Message::NewJob(job) => {

--- a/listings/ch20-web-server/listing-20-25/src/lib.rs
+++ b/listings/ch20-web-server/listing-20-25/src/lib.rs
@@ -78,7 +78,9 @@ struct Worker {
 impl Worker {
     fn new(id: usize, receiver: Arc<Mutex<mpsc::Receiver<Message>>>) -> Worker {
         let thread = thread::spawn(move || loop {
-            let message = receiver.lock().unwrap().recv().unwrap();
+            let receiver = receiver.lock().unwrap();
+            let message = receiver.recv().unwrap();
+            drop(receiver); // release mutex
 
             match message {
                 Message::NewJob(job) => {


### PR DESCRIPTION
Mutex was never released before handling connection, rendering the program sequential, no matter how many threads were created. On the other hand it is a nice exercise for Rust beginners to fix this bug themselves. 