### PR TITLE
Improve wording around drop

### DIFF
--- a/src/ch15-03-drop.md
+++ b/src/ch15-03-drop.md
@@ -6,7 +6,7 @@ provide an implementation for the `Drop` trait on any type, and the code you
 specify can be used to release resources like files or network connections.
 We’re introducing `Drop` in the context of smart pointers because the
 functionality of the `Drop` trait is almost always used when implementing a
-smart pointer. For example, `Box<T>` customizes `Drop` to deallocate the space
+smart pointer. For example, when a `Box<T>` is dropped it will deallocate the space
 on the heap that the box points to.
 
 In some languages, the programmer must call code to free memory or resources


### PR DESCRIPTION
Technically box is still special so this is in the compiler, not in a Drop impl.

Fixes #2260