### PR TITLE
text -> console

### DIFF
--- a/src/appendix-04-useful-development-tools.md
+++ b/src/appendix-04-useful-development-tools.md
@@ -12,14 +12,14 @@ style to use when writing Rust: everyone formats their code using the tool.
 
 To install `rustfmt`, enter the following:
 
-```text
+```console
 $ rustup component add rustfmt
 ```
 
 This command gives you `rustfmt` and `cargo-fmt`, similar to how Rust gives you
 both `rustc` and `cargo`. To format any Cargo project, enter the following:
 
-```text
+```console
 $ cargo fmt
 ```
 
@@ -50,7 +50,7 @@ fn main() {
 Here, we’re calling the `do_something` function 100 times, but we never use the
 variable `i` in the body of the `for` loop. Rust warns us about that:
 
-```text
+```console
 $ cargo build
    Compiling myprogram v0.1.0 (file:///projects/myprogram)
 warning: unused variable: `i`
@@ -69,7 +69,7 @@ indicates that we intend for this variable to be unused. We can automatically
 apply that suggestion using the `rustfix` tool by running the command `cargo
 fix`:
 
-```text
+```console
 $ cargo fix
     Checking myprogram v0.1.0 (file:///projects/myprogram)
       Fixing src/main.rs (1 fix)
@@ -103,13 +103,13 @@ common mistakes and improve your Rust code.
 
 To install Clippy, enter the following:
 
-```text
+```console
 $ rustup component add clippy
 ```
 
 To run Clippy’s lints on any Cargo project, enter the following:
 
-```text
+```console
 $ cargo clippy
 ```
 
@@ -171,7 +171,7 @@ such as [the Rust plug-in for Visual Studio Code][vscode].
 
 To install the `rls`, enter the following:
 
-```text
+```console
 $ rustup component add rls
 ```
 

--- a/src/appendix-07-nightly-rust.md
+++ b/src/appendix-07-nightly-rust.md
@@ -141,7 +141,7 @@ Rustup makes it easy to change between different release channels of Rust, on a
 global or per-project basis. By default, you’ll have stable Rust installed. To
 install nightly, for example:
 
-```text
+```console
 $ rustup toolchain install nightly
 ```
 
@@ -162,7 +162,7 @@ nightly on a specific project, because you care about a cutting-edge feature.
 To do so, you can use `rustup override` in that project’s directory to set the
 nightly toolchain as the one `rustup` should use when you’re in that directory:
 
-```text
+```console
 $ cd ~/projects/needs-nightly
 $ rustup override set nightly
 ```

--- a/src/ch01-01-installation.md
+++ b/src/ch01-01-installation.md
@@ -27,7 +27,7 @@ using these steps should work as expected with the content of this book.
 
 If you’re using Linux or macOS, open a terminal and enter the following command:
 
-```text
+```console
 $ curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | sh
 ```
 
@@ -67,14 +67,14 @@ If there are specific differences, we’ll explain which to use.
 After you’ve installed Rust via `rustup`, updating to the latest version is
 easy. From your shell, run the following update script:
 
-```text
+```console
 $ rustup update
 ```
 
 To uninstall Rust and `rustup`, run the following uninstall script from your
 shell:
 
-```text
+```console
 $ rustup self uninstall
 ```
 
@@ -83,7 +83,7 @@ $ rustup self uninstall
 To check whether you have Rust installed correctly, open a shell and enter this
 line:
 
-```text
+```console
 $ rustc --version
 ```
 

--- a/src/ch01-02-hello-world.md
+++ b/src/ch01-02-hello-world.md
@@ -24,7 +24,7 @@ and a directory for the “Hello, world!” project within the *projects* direct
 
 For Linux, macOS, and PowerShell on Windows, enter this:
 
-```text
+```console
 $ mkdir ~/projects
 $ cd ~/projects
 $ mkdir hello_world
@@ -62,7 +62,7 @@ fn main() {
 Save the file and go back to your terminal window. On Linux or macOS, enter
 the following commands to compile and run the file:
 
-```text
+```console
 $ rustc main.rs
 $ ./main
 Hello, world!
@@ -143,7 +143,7 @@ Before running a Rust program, you must compile it using the Rust compiler by
 entering the `rustc` command and passing it the name of your source file, like
 this:
 
-```text
+```console
 $ rustc main.rs
 ```
 
@@ -174,7 +174,7 @@ This shows the source code file with the *.rs* extension, the executable file
 Windows, a file containing debugging information with the *.pdb* extension.
 From here, you run the *main* or *main.exe* file, like this:
 
-```text
+```console
 $ ./main # or .\main.exe on Windows
 ```
 

--- a/src/ch01-03-hello-cargo.md
+++ b/src/ch01-03-hello-cargo.md
@@ -18,7 +18,7 @@ used the official installers discussed in the
 through some other means, check whether Cargo is installed by entering the
 following into your terminal:
 
-```text
+```console
 $ cargo --version
 ```
 
@@ -33,7 +33,7 @@ original “Hello, world!” project. Navigate back to your *projects* directory
 wherever you decided to store your code). Then, on any operating system, run
 the following:
 
-```text
+```console
 $ cargo new hello_cargo
 $ cd hello_cargo
 ```
@@ -124,7 +124,7 @@ Now let’s look at what’s different when we build and run the “Hello, world
 program with Cargo! From your *hello_cargo* directory, build your project by
 entering the following command:
 
-```text
+```console
 $ cargo build
    Compiling hello_cargo v0.1.0 (file:///projects/hello_cargo)
     Finished dev [unoptimized + debuginfo] target(s) in 2.85 secs
@@ -134,7 +134,7 @@ This command creates an executable file in *target/debug/hello_cargo* (or
 *target\debug\hello_cargo.exe* on Windows) rather than in your current
 directory. You can run the executable with this command:
 
-```text
+```console
 $ ./target/debug/hello_cargo # or .\target\debug\hello_cargo.exe on Windows
 Hello, world!
 ```
@@ -150,7 +150,7 @@ We just built a project with `cargo build` and ran it with
 `./target/debug/hello_cargo`, but we can also use `cargo run` to compile the
 code and then run the resulting executable all in one command:
 
-```text
+```console
 $ cargo run
     Finished dev [unoptimized + debuginfo] target(s) in 0.0 secs
      Running `target/debug/hello_cargo`
@@ -162,7 +162,7 @@ Notice that this time we didn’t see output indicating that Cargo was compiling
 the binary. If you had modified your source code, Cargo would have rebuilt the
 project before running it, and you would have seen this output:
 
-```text
+```console
 $ cargo run
    Compiling hello_cargo v0.1.0 (file:///projects/hello_cargo)
     Finished dev [unoptimized + debuginfo] target(s) in 0.33 secs
@@ -173,7 +173,7 @@ Hello, world!
 Cargo also provides a command called `cargo check`. This command quickly checks
 your code to make sure it compiles but doesn’t produce an executable:
 
-```text
+```console
 $ cargo check
    Checking hello_cargo v0.1.0 (file:///projects/hello_cargo)
     Finished dev [unoptimized + debuginfo] target(s) in 0.32 secs
@@ -222,7 +222,7 @@ tooling you’ll use in the rest of your Rust career. In fact, to work on any
 existing projects, you can use the following commands to check out the code
 using Git, change to that project’s directory, and build:
 
-```text
+```console
 $ git clone someurl.com/someproject
 $ cd someproject
 $ cargo build

--- a/src/ch02-00-guessing-game-tutorial.md
+++ b/src/ch02-00-guessing-game-tutorial.md
@@ -17,7 +17,7 @@ correct, the game will print a congratulatory message and exit.
 To set up a new project, go to the *projects* directory that you created in
 Chapter 1 and make a new project using Cargo, like so:
 
-```text
+```console
 $ cargo new guessing_game
 $ cd guessing_game
 ```
@@ -49,7 +49,7 @@ you. Check out the *src/main.rs* file:
 Now let’s compile this “Hello, world!” program and run it in the same step
 using the `cargo run` command:
 
-```text
+```console
 {{#include ../listings/ch02-guessing-game-tutorial/no-listing-01-cargo-new/output.txt}}
 ```
 
@@ -260,7 +260,7 @@ entered into standard input.
 
 If you don’t call `expect`, the program will compile, but you’ll get a warning:
 
-```text
+```console
 {{#include ../listings/ch02-guessing-game-tutorial/no-listing-02-without-expect/output.txt}}
 ```
 
@@ -306,7 +306,7 @@ cargo clean
 cargo run
 input 6 -->
 
-```text
+```console
 $ cargo run
    Compiling guessing_game v0.1.0 (file:///projects/guessing_game)
     Finished dev [unoptimized + debuginfo] target(s) in 6.44s
@@ -375,7 +375,7 @@ cd listings/ch02-guessing-game-tutorial/listing-02-02/
 cargo clean
 cargo build -->
 
-```text
+```console
 $ cargo build
     Updating crates.io index
   Downloaded rand v0.5.5
@@ -426,7 +426,7 @@ cd listings/ch02-guessing-game-tutorial/listing-02-02/
 touch src/main.rs
 cargo build -->
 
-```text
+```console
 $ cargo build
    Compiling guessing_game v0.1.0 (file:///projects/guessing_game)
     Finished dev [unoptimized + debuginfo] target(s) in 2.53 secs
@@ -474,7 +474,7 @@ cargo update
 assuming there is a new 0.5.x version of rand; otherwise use another update
 as a guide to creating the hypothetical output shown here -->
 
-```text
+```console
 $ cargo update
     Updating crates.io index
     Updating rand v0.5.5 -> v0.5.6
@@ -555,7 +555,7 @@ cargo run
 5
 -->
 
-```text
+```console
 $ cargo run
    Compiling guessing_game v0.1.0 (file:///projects/guessing_game)
     Finished dev [unoptimized + debuginfo] target(s) in 2.53s
@@ -633,7 +633,7 @@ expression ends because it has no need to look at the last arm in this scenario.
 
 However, the code in Listing 2-4 won’t compile yet. Let’s try it:
 
-```text
+```console
 {{#include ../listings/ch02-guessing-game-tutorial/listing-02-04/output.txt}}
 ```
 
@@ -717,7 +717,7 @@ cargo run
   76
 -->
 
-```text
+```console
 $ cargo run
    Compiling guessing_game v0.1.0 (file:///projects/guessing_game)
     Finished dev [unoptimized + debuginfo] target(s) in 0.43s
@@ -771,7 +771,7 @@ cargo run
 quit
 -->
 
-```text
+```console
 $ cargo run
    Compiling guessing_game v0.1.0 (file:///projects/guessing_game)
     Finished dev [unoptimized + debuginfo] target(s) in 1.50s
@@ -863,7 +863,7 @@ foo
 (correct guess)
 -->
 
-```text
+```console
 $ cargo run
    Compiling guessing_game v0.1.0 (file:///projects/guessing_game)
      Running `target/debug/guessing_game`

--- a/src/ch03-01-variables-and-mutability.md
+++ b/src/ch03-01-variables-and-mutability.md
@@ -23,7 +23,7 @@ code with the following code that won’t compile just yet:
 Save and run the program using `cargo run`. You should receive an error
 message, as shown in this output:
 
-```text
+```console
 {{#include ../listings/ch03-common-programming-concepts/no-listing-01-variables-are-immutable/output.txt}}
 ```
 
@@ -65,7 +65,7 @@ For example, let’s change *src/main.rs* to the following:
 
 When we run the program now, we get this:
 
-```text
+```console
 {{#include ../listings/ch03-common-programming-concepts/no-listing-02-adding-mut/output.txt}}
 ```
 
@@ -147,7 +147,7 @@ repeating `let x =`, taking the original value and adding `1` so the value of
 previous value by `2` to give `x` a final value of `12`. When we run this
 program, it will output the following:
 
-```text
+```console
 {{#include ../listings/ch03-common-programming-concepts/no-listing-03-shadowing/output.txt}}
 ```
 
@@ -180,7 +180,7 @@ try to use `mut` for this, as shown here, we’ll get a compile-time error:
 
 The error says we’re not allowed to mutate a variable’s type:
 
-```text
+```console
 {{#include ../listings/ch03-common-programming-concepts/no-listing-05-mut-cant-change-types/output.txt}}
 ```
 

--- a/src/ch03-02-data-types.md
+++ b/src/ch03-02-data-types.md
@@ -20,7 +20,7 @@ If we don’t add the type annotation here, Rust will display the following
 error, which means the compiler needs more information from us to know which
 type we want to use:
 
-```text
+```console
 {{#include ../listings/ch03-common-programming-concepts/output-only-01-no-type-annotations/output.txt}}
 ```
 
@@ -326,7 +326,7 @@ compile but exit with an error when it runs:
 
 Running this code using `cargo run` produces the following result:
 
-```text
+```console
 {{#include ../listings/ch03-common-programming-concepts/no-listing-15-invalid-array-access/output.txt}}
 ```
 

--- a/src/ch03-03-how-functions-work.md
+++ b/src/ch03-03-how-functions-work.md
@@ -30,7 +30,7 @@ Let’s start a new binary project named *functions* to explore functions
 further. Place the `another_function` example in *src/main.rs* and run it. You
 should see the following output:
 
-```text
+```console
 {{#include ../listings/ch03-common-programming-concepts/no-listing-16-functions/output.txt}}
 ```
 
@@ -59,7 +59,7 @@ look like in Rust:
 
 Try running this program; you should get the following output:
 
-```text
+```console
 {{#include ../listings/ch03-common-programming-concepts/no-listing-17-functions-with-parameters/output.txt}}
 ```
 
@@ -91,7 +91,7 @@ Let’s try running this code. Replace the program currently in your *functions*
 project’s *src/main.rs* file with the preceding example and run it using `cargo
 run`:
 
-```text
+```console
 {{#include ../listings/ch03-common-programming-concepts/no-listing-18-functions-with-multiple-parameters/output.txt}}
 ```
 
@@ -136,7 +136,8 @@ to another variable, as the following code tries to do; you’ll get an error:
 ```
 
 When you run this program, the error you’ll get looks like this:
-```text
+
+```console
 {{#include ../listings/ch03-common-programming-concepts/no-listing-19-statements-vs-expressions/output.txt}}
 ```
 
@@ -197,7 +198,7 @@ function—just the number `5` by itself. That’s a perfectly valid function in
 Rust. Note that the function’s return type is specified too, as `-> i32`. Try
 running this code; the output should look like this:
 
-```text
+```console
 {{#include ../listings/ch03-common-programming-concepts/no-listing-21-function-return-values/output.txt}}
 ```
 
@@ -235,7 +236,7 @@ expression to a statement, we’ll get an error.
 
 Compiling this code produces an error, as follows:
 
-```text
+```console
 {{#include ../listings/ch03-common-programming-concepts/no-listing-23-statements-dont-return-values/output.txt}}
 ```
 

--- a/src/ch03-05-control-flow.md
+++ b/src/ch03-05-control-flow.md
@@ -39,7 +39,7 @@ to the next bit of code.
 
 Try running this code; you should see the following output:
 
-```text
+```console
 {{#include ../listings/ch03-common-programming-concepts/no-listing-26-if-true/output.txt}}
 ```
 
@@ -52,7 +52,7 @@ Let’s try changing the value of `number` to a value that makes the condition
 
 Run the program again, and look at the output:
 
-```text
+```console
 {{#include ../listings/ch03-common-programming-concepts/no-listing-27-if-false/output.txt}}
 ```
 
@@ -69,7 +69,7 @@ following code:
 The `if` condition evaluates to a value of `3` this time, and Rust throws an
 error:
 
-```text
+```console
 {{#include ../listings/ch03-common-programming-concepts/no-listing-28-if-condition-must-be-bool/output.txt}}
 ```
 
@@ -102,7 +102,7 @@ expression. For example:
 This program has four possible paths it can take. After running it, you should
 see the following output:
 
-```text
+```console
 {{#include ../listings/ch03-common-programming-concepts/no-listing-30-else-if/output.txt}}
 ```
 
@@ -134,7 +134,7 @@ to a variable</span>
 The `number` variable will be bound to a value based on the outcome of the `if`
 expression. Run this code to see what happens:
 
-```text
+```console
 {{#include ../listings/ch03-common-programming-concepts/listing-03-02/output.txt}}
 ```
 
@@ -156,7 +156,7 @@ When we try to compile this code, we’ll get an error. The `if` and `else` arms
 have value types that are incompatible, and Rust indicates exactly where to
 find the problem in the program:
 
-```text
+```console
 {{#include ../listings/ch03-common-programming-concepts/no-listing-31-arms-must-return-same-type/output.txt}}
 ```
 
@@ -203,7 +203,7 @@ cargo run
 CTRL-C
 -->
 
-```text
+```console
 $ cargo run
    Compiling loops v0.1.0 (file:///projects/loops)
     Finished dev [unoptimized + debuginfo] target(s) in 0.29s

--- a/src/ch04-01-what-is-ownership.md
+++ b/src/ch04-01-what-is-ownership.md
@@ -316,7 +316,7 @@ use `s1` after `s2` is created; it won’t work:
 You’ll get an error like this because Rust prevents you from using the
 invalidated reference:
 
-```text
+```console
 {{#include ../listings/ch04-understanding-ownership/no-listing-04-cant-use-after-move/output.txt}}
 ```
 

--- a/src/ch04-02-references-and-borrowing.md
+++ b/src/ch04-02-references-and-borrowing.md
@@ -73,7 +73,7 @@ Listing 4-6. Spoiler alert: it doesn’t work!
 
 Here’s the error:
 
-```text
+```console
 {{#include ../listings/ch04-understanding-ownership/listing-04-06/output.txt}}
 ```
 
@@ -106,7 +106,7 @@ fail:
 
 Here’s the error:
 
-```text
+```console
 {{#include ../listings/ch04-understanding-ownership/no-listing-10-multiple-mut-not-allowed/output.txt}}
 ```
 
@@ -142,7 +142,7 @@ results in an error:
 
 Here’s the error:
 
-```text
+```console
 {{#include ../listings/ch04-understanding-ownership/no-listing-12-immutable-and-mutable-not-allowed/output.txt}}
 ```
 
@@ -191,7 +191,7 @@ compile-time error:
 
 Here’s the error:
 
-```text
+```console
 {{#include ../listings/ch04-understanding-ownership/no-listing-14-dangling-reference/output.txt}}
 ```
 

--- a/src/ch04-03-slices.md
+++ b/src/ch04-03-slices.md
@@ -211,7 +211,7 @@ compile-time error:
 
 Here’s the compiler error:
 
-```text
+```console
 {{#include ../listings/ch04-understanding-ownership/no-listing-19-slice-error/output.txt}}
 ```
 

--- a/src/ch05-01-defining-structs.md
+++ b/src/ch05-01-defining-structs.md
@@ -193,7 +193,7 @@ itself. We’ll discuss traits in Chapter 10.
 >
 > The compiler will complain that it needs lifetime specifiers:
 >
-> ```text
+> ```console
 > $ cargo run
 >    Compiling structs v0.1.0 (file:///projects/structs)
 > error[E0106]: missing lifetime specifier

--- a/src/ch05-02-example-structs.md
+++ b/src/ch05-02-example-structs.md
@@ -20,7 +20,7 @@ specified by separate width and height variables</span>
 
 Now, run this program using `cargo run`:
 
-```text
+```console
 {{#include ../listings/ch05-using-structs-to-structure-related-data/listing-05-08/output.txt}}
 ```
 
@@ -175,7 +175,7 @@ trait and printing the `Rectangle` instance using debug formatting</span>
 Now when we run the program, we won’t get any errors, and we’ll see the
 following output:
 
-```text
+```console
 {{#include ../listings/ch05-using-structs-to-structure-related-data/listing-05-12/output.txt}}
 ```
 
@@ -185,7 +185,7 @@ larger structs, it’s useful to have output that’s a bit easier to read; in
 those cases, we can use `{:#?}` instead of `{:?}` in the `println!` string.
 When we use the `{:#?}` style in the example, the output will look like this:
 
-```text
+```console
 {{#include ../listings/ch05-using-structs-to-structure-related-data/output-only-02-pretty-debug/output.txt}}
 ```
 

--- a/src/ch06-01-defining-an-enum.md
+++ b/src/ch06-01-defining-an-enum.md
@@ -263,7 +263,7 @@ trying to add an `i8` to an `Option<i8>`:
 
 If we run this code, we get an error message like this:
 
-```text
+```console
 {{#include ../listings/ch06-enums-and-pattern-matching/no-listing-07-cant-use-option-directly/output.txt}}
 ```
 

--- a/src/ch06-02-match.md
+++ b/src/ch06-02-match.md
@@ -172,7 +172,7 @@ We didn’t handle the `None` case, so this code will cause a bug. Luckily, it�
 a bug Rust knows how to catch. If we try to compile this code, we’ll get this
 error:
 
-```text
+```console
 {{#include ../listings/ch06-enums-and-pattern-matching/no-listing-10-non-exhaustive-match/output.txt}}
 ```
 

--- a/src/ch07-01-packages-and-crates.md
+++ b/src/ch07-01-packages-and-crates.md
@@ -16,7 +16,7 @@ binary).
 Let’s walk through what happens when we create a package. First, we enter the
 command `cargo new`:
 
-```text
+```console
 $ cargo new my-project
      Created binary (application) `my-project` package
 $ ls my-project

--- a/src/ch07-03-paths-for-referring-to-an-item-in-the-module-tree.md
+++ b/src/ch07-03-paths-for-referring-to-an-item-in-the-module-tree.md
@@ -67,7 +67,7 @@ likely to move code definitions and item calls independently of each other.
 Let’s try to compile Listing 7-3 and find out why it won’t compile yet! The
 error we get is shown in Listing 7-4.
 
-```text
+```console
 {{#include ../listings/ch07-managing-growing-projects/listing-07-03/output.txt}}
 ```
 
@@ -119,7 +119,7 @@ use it from `eat_at_restaurant`</span>
 Unfortunately, the code in Listing 7-5 still results in an error, as shown in
 Listing 7-6.
 
-```text
+```console
 {{#include ../listings/ch07-managing-growing-projects/listing-07-05/output.txt}}
 ```
 

--- a/src/ch08-01-vectors.md
+++ b/src/ch08-01-vectors.md
@@ -149,7 +149,7 @@ while holding a reference to an item</span>
 
 Compiling this code will result in this error:
 
-```text
+```console
 {{#include ../listings/ch08-common-collections/listing-08-07/output.txt}}
 ```
 

--- a/src/ch08-02-strings.md
+++ b/src/ch08-02-strings.md
@@ -229,7 +229,7 @@ String</span>
 
 This code will result in the following error:
 
-```text
+```console
 {{#include ../listings/ch08-common-collections/listing-08-19/output.txt}}
 ```
 
@@ -342,7 +342,7 @@ Earlier, we mentioned that each of these characters was 2 bytes, which means
 What would happen if we used `&hello[0..1]`? The answer: Rust would panic at
 runtime in the same way as if an invalid index were accessed in a vector:
 
-```text
+```console
 {{#include ../listings/ch08-common-collections/output-only-01-not-char-boundary/output.txt}}
 ```
 

--- a/src/ch09-01-unrecoverable-errors-with-panic.md
+++ b/src/ch09-01-unrecoverable-errors-with-panic.md
@@ -34,7 +34,7 @@ Let’s try calling `panic!` in a simple program:
 
 When you run the program, you’ll see something like this:
 
-```text
+```console
 {{#include ../listings/ch09-error-handling/no-listing-01-panic/output.txt}}
 ```
 
@@ -86,7 +86,7 @@ To protect your program from this sort of vulnerability, if you try to read an
 element at an index that doesn’t exist, Rust will stop execution and refuse to
 continue. Let’s try it and see:
 
-```text
+```console
 {{#include ../listings/ch09-error-handling/listing-09-01/output.txt}}
 ```
 
@@ -114,7 +114,7 @@ copy the backtrace output below
 check the backtrace number mentioned in the text below the listing
 -->
 
-```text
+```console
 $ RUST_BACKTRACE=1 cargo run
 thread 'main' panicked at 'index out of bounds: the len is 3 but the index is 99', /rustc/5e1a799842ba6ed4a57e91f7ab9435947482f7d8/src/libcore/slice/mod.rs:2806:10
 stack backtrace:

--- a/src/ch09-02-recoverable-errors-with-result.md
+++ b/src/ch09-02-recoverable-errors-with-result.md
@@ -53,7 +53,7 @@ isn’t of type `u32`, so let’s change the `let f` statement to this:
 
 Attempting to compile now gives us the following output:
 
-```text
+```console
 {{#include ../listings/ch09-error-handling/no-listing-02-ask-compiler-for-type/output.txt}}
 ```
 
@@ -400,7 +400,7 @@ which you’ll recall has a return type of `()`:
 
 When we compile this code, we get the following error message:
 
-```text
+```console
 {{#include ../listings/ch09-error-handling/no-listing-06-question-mark-in-main/output.txt}}
 ```
 

--- a/src/ch10-01-syntax.md
+++ b/src/ch10-01-syntax.md
@@ -67,7 +67,7 @@ uses generic type parameters but doesn’t compile yet</span>
 
 If we compile this code right now, we’ll get this error:
 
-```text
+```console
 {{#include ../listings/ch10-generic-types-traits-and-lifetimes/listing-10-05/output.txt}}
 ```
 
@@ -123,7 +123,7 @@ compiler know that the generic type `T` will be an integer for this instance of
 `Point<T>`. Then when we specify 4.0 for `y`, which we’ve defined to have the
 same type as `x`, we’ll get a type mismatch error like this:
 
-```text
+```console
 {{#include ../listings/ch10-generic-types-traits-and-lifetimes/listing-10-07/output.txt}}
 ```
 

--- a/src/ch10-02-traits.md
+++ b/src/ch10-02-traits.md
@@ -360,7 +360,7 @@ look like this:
 
 This time when we compile the code, we get a different set of errors:
 
-```text
+```console
 {{#include ../listings/ch10-generic-types-traits-and-lifetimes/no-listing-07-fixing-listing-10-05/output.txt}}
 ```
 

--- a/src/ch10-03-lifetime-syntax.md
+++ b/src/ch10-03-lifetime-syntax.md
@@ -45,7 +45,7 @@ the inner scope ends, and we attempt to print the value in `r`. This code won’
 compile because the value `r` is referring to has gone out of scope before we
 try to use it. Here is the error message:
 
-```text
+```console
 {{#include ../listings/ch10-generic-types-traits-and-lifetimes/listing-10-17/output.txt}}
 ```
 
@@ -136,7 +136,7 @@ compile</span>
 
 Instead, we get the following error that talks about lifetimes:
 
-```text
+```console
 {{#include ../listings/ch10-generic-types-traits-and-lifetimes/listing-10-21/output.txt}}
 ```
 
@@ -282,7 +282,7 @@ has gone out of scope</span>
 
 When we try to compile this code, we’ll get this error:
 
-```text
+```console
 {{#include ../listings/ch10-generic-types-traits-and-lifetimes/listing-10-24/output.txt}}
 ```
 
@@ -341,7 +341,7 @@ type, this implementation will fail to compile because the return value
 lifetime is not related to the lifetime of the parameters at all. Here is the
 error message we get:
 
-```text
+```console
 {{#include ../listings/ch10-generic-types-traits-and-lifetimes/no-listing-09-unrelated-lifetime/output.txt}}
 ```
 

--- a/src/ch11-01-writing-tests.md
+++ b/src/ch11-01-writing-tests.md
@@ -35,7 +35,7 @@ behavior is correct.
 
 Let’s create a new library project called `adder`:
 
-```text
+```console
 $ cargo new adder --lib
      Created library `adder` project
 $ cd adder
@@ -67,7 +67,7 @@ it to see that this test passes.
 The `cargo test` command runs all tests in our project, as shown in Listing
 11-2.
 
-```text
+```console
 {{#include ../listings/ch11-writing-automated-tests/listing-11-01/output.txt}}
 ```
 
@@ -114,7 +114,7 @@ so:
 Then run `cargo test` again. The output now shows `exploration` instead of
 `it_works`:
 
-```text
+```console
 {{#include ../listings/ch11-writing-automated-tests/no-listing-01-changing-test-name/output.txt}}
 ```
 
@@ -213,7 +213,7 @@ We’ve named our test `larger_can_hold_smaller`, and we’ve created the two
 passed it the result of calling `larger.can_hold(&smaller)`. This expression
 is supposed to return `true`, so our test should pass. Let’s find out!
 
-```text
+```console
 {{#include ../listings/ch11-writing-automated-tests/listing-11-06/output.txt}}
 ```
 
@@ -230,7 +230,7 @@ Because the correct result of the `can_hold` function in this case is `false`,
 we need to negate that result before we pass it to the `assert!` macro. As a
 result, our test will pass if `can_hold` returns `false`:
 
-```text
+```console
 {{#include ../listings/ch11-writing-automated-tests/no-listing-02-adding-another-rectangle-test/output.txt}}
 ```
 
@@ -245,7 +245,7 @@ compares the widths:
 
 Running the tests now produces the following:
 
-```text
+```console
 {{#include ../listings/ch11-writing-automated-tests/no-listing-03-introducing-a-bug/output.txt}}
 ```
 
@@ -281,7 +281,7 @@ parameter and returns the result. Then we test this function using the
 
 Let’s check that it passes!
 
-```text
+```console
 {{#include ../listings/ch11-writing-automated-tests/listing-11-07/output.txt}}
 ```
 
@@ -299,7 +299,7 @@ instead add `3`:
 
 Run the tests again:
 
-```text
+```console
 {{#include ../listings/ch11-writing-automated-tests/no-listing-04-bug-in-add-two/output.txt}}
 ```
 
@@ -378,7 +378,7 @@ Let’s introduce a bug into this code by changing `greeting` to not include
 
 Running this test produces the following:
 
-```text
+```console
 {{#include ../listings/ch11-writing-automated-tests/no-listing-06-greeter-with-bug/output.txt}}
 ```
 
@@ -394,7 +394,7 @@ filled in with the actual value we got from the `greeting` function:
 
 Now when we run the test, we’ll get a more informative error message:
 
-```text
+```console
 {{#include ../listings/ch11-writing-automated-tests/no-listing-07-custom-failure-message/output.txt}}
 ```
 
@@ -431,7 +431,7 @@ We place the `#[should_panic]` attribute after the `#[test]` attribute and
 before the test function it applies to. Let’s look at the result when this test
 passes:
 
-```text
+```console
 {{#include ../listings/ch11-writing-automated-tests/listing-11-08/output.txt}}
 ```
 
@@ -444,7 +444,7 @@ that the `new` function will panic if the value is greater than 100:
 
 When we run the test in Listing 11-8, it will fail:
 
-```text
+```console
 {{#include ../listings/ch11-writing-automated-tests/no-listing-08-guess-with-bug/output.txt}}
 ```
 
@@ -490,7 +490,7 @@ fails, let’s again introduce a bug into our code by swapping the bodies of the
 
 This time when we run the `should_panic` test, it will fail:
 
-```text
+```console
 {{#include ../listings/ch11-writing-automated-tests/no-listing-09-guess-with-panic-msg-bug/output.txt}}
 ```
 

--- a/src/ch11-02-running-tests.md
+++ b/src/ch11-02-running-tests.md
@@ -39,7 +39,7 @@ control over the number of threads used, you can send the `--test-threads` flag
 and the number of threads you want to use to the test binary. Take a look at
 the following example:
 
-```text
+```console
 $ cargo test -- --test-threads=1
 ```
 
@@ -70,7 +70,7 @@ parameter and returns 10, as well as a test that passes and a test that fails.
 
 When we run these tests with `cargo test`, we’ll see the following output:
 
-```text
+```console
 {{#include ../listings/ch11-writing-automated-tests/listing-11-10/output.txt}}
 ```
 
@@ -82,14 +82,14 @@ of the test summary output, which also shows the cause of the test failure.
 If we want to see printed values for passing tests as well, we can tell Rust
 to also show the output of successful tests at the end with `--show-output`.
 
-```text
+```console
 $ cargo test -- --show-output
 ```
 
 When we run the tests in Listing 11-10 again with the `--show-output` flag, we
 see the following output:
 
-```text
+```console
 {{#include ../listings/ch11-writing-automated-tests/output-only-01-show-output/output.txt}}
 ```
 
@@ -115,7 +115,7 @@ names</span>
 If we run the tests without passing any arguments, as we saw earlier, all the
 tests will run in parallel:
 
-```text
+```console
 {{#include ../listings/ch11-writing-automated-tests/listing-11-11/output.txt}}
 ```
 
@@ -123,7 +123,7 @@ tests will run in parallel:
 
 We can pass the name of any test function to `cargo test` to run only that test:
 
-```text
+```console
 {{#include ../listings/ch11-writing-automated-tests/output-only-02-single-test/output.txt}}
 ```
 
@@ -140,7 +140,7 @@ We can specify part of a test name, and any test whose name matches that value
 will be run. For example, because two of our tests’ names contain `add`, we can
 run those two by running `cargo test add`:
 
-```text
+```console
 {{#include ../listings/ch11-writing-automated-tests/output-only-03-multiple-tests/output.txt}}
 ```
 
@@ -166,14 +166,14 @@ here:
 After `#[test]` we add the `#[ignore]` line to the test we want to exclude. Now
 when we run our tests, `it_works` runs, but `expensive_test` doesn’t:
 
-```text
+```console
 {{#include ../listings/ch11-writing-automated-tests/no-listing-11-ignore-a-test/output.txt}}
 ```
 
 The `expensive_test` function is listed as `ignored`. If we want to run only
 the ignored tests, we can use `cargo test -- --ignored`:
 
-```text
+```console
 {{#include ../listings/ch11-writing-automated-tests/output-only-04-running-ignored/output.txt}}
 ```
 

--- a/src/ch11-03-test-organization.md
+++ b/src/ch11-03-test-organization.md
@@ -110,7 +110,7 @@ We don’t need to annotate any code in *tests/integration_test.rs* with
 `#[cfg(test)]`. Cargo treats the `tests` directory specially and compiles files
 in this directory only when we run `cargo test`. Run `cargo test` now:
 
-```text
+```console
 {{#include ../listings/ch11-writing-automated-tests/listing-11-13/output.txt}}
 ```
 
@@ -136,7 +136,7 @@ function’s name as an argument to `cargo test`. To run all the tests in a
 particular integration test file, use the `--test` argument of `cargo test`
 followed by the name of the file:
 
-```text
+```console
 {{#include ../listings/ch11-writing-automated-tests/output-only-05-single-integration/output.txt}}
 ```
 
@@ -174,7 +174,7 @@ When we run the tests again, we’ll see a new section in the test output for th
 *common.rs* file, even though this file doesn’t contain any test functions nor
 did we call the `setup` function from anywhere:
 
-```text
+```console
 {{#include ../listings/ch11-writing-automated-tests/no-listing-12-shared-test-code-problem/output.txt}}
 ```
 

--- a/src/ch12-01-accepting-command-line-arguments.md
+++ b/src/ch12-01-accepting-command-line-arguments.md
@@ -4,7 +4,7 @@ Let’s create a new project with, as always, `cargo new`. We’ll call our proj
 `minigrep` to distinguish it from the `grep` tool that you might already have
 on your system.
 
-```text
+```console
 $ cargo new minigrep
      Created binary (application) `minigrep` project
 $ cd minigrep
@@ -15,7 +15,7 @@ filename and a string to search for. That is, we want to be able to run our
 program with `cargo run`, a string to search for, and a path to a file to
 search in, like so:
 
-```text
+```console
 $ cargo run searchstring example-filename.txt
 ```
 
@@ -77,11 +77,11 @@ isn’t able to infer the kind of collection you want.
 Finally, we print the vector using the debug formatter, `:?`. Let’s try running
 the code first with no arguments and then with two arguments:
 
-```text
+```console
 {{#include ../listings/ch12-an-io-project/listing-12-01/output.txt}}
 ```
 
-```text
+```console
 {{#include ../listings/ch12-an-io-project/output-only-01-with-args/output.txt}}
 ```
 
@@ -120,7 +120,7 @@ We temporarily print the values of these variables to prove that the code is
 working as we intend. Let’s run this program again with the arguments `test`
 and `sample.txt`:
 
-```text
+```console
 {{#include ../listings/ch12-an-io-project/listing-12-02/output.txt}}
 ```
 

--- a/src/ch12-02-reading-a-file.md
+++ b/src/ch12-02-reading-a-file.md
@@ -44,7 +44,7 @@ Let’s run this code with any string as the first command line argument (becaus
 we haven’t implemented the searching part yet) and the *poem.txt* file as the
 second argument:
 
-```text
+```console
 {{#rustdoc_include ../listings/ch12-an-io-project/listing-12-04/output.txt}}
 ```
 

--- a/src/ch12-03-improving-error-handling-and-modularity.md
+++ b/src/ch12-03-improving-error-handling-and-modularity.md
@@ -206,7 +206,7 @@ the values in the `args` vector at index 1 or index 2 will cause the program to
 panic if the vector contains fewer than three items. Try running the program
 without any arguments; it will look like this:
 
-```text
+```console
 {{#include ../listings/ch12-an-io-project/listing-12-07/output.txt}}
 ```
 
@@ -241,7 +241,7 @@ will be true, and we call the `panic!` macro to end the program immediately.
 With these extra few lines of code in `new`, let’s run the program without any
 arguments again to see what the error looks like now:
 
-```text
+```console
 {{#include ../listings/ch12-an-io-project/listing-12-08/output.txt}}
 ```
 
@@ -331,7 +331,7 @@ number that was passed as the exit status code. This is similar to the
 `panic!`-based handling we used in Listing 12-8, but we no longer get all the
 extra output. Let’s try it:
 
-```text
+```console
 {{#include ../listings/ch12-an-io-project/listing-12-10/output.txt}}
 ```
 
@@ -411,7 +411,7 @@ it doesn’t return a value we need.
 
 When you run this code, it will compile but will display a warning:
 
-```text
+```console
 {{#include ../listings/ch12-an-io-project/listing-12-12/output.txt}}
 ```
 

--- a/src/ch12-04-testing-the-librarys-functionality.md
+++ b/src/ch12-04-testing-the-librarys-functionality.md
@@ -85,7 +85,7 @@ incorrectly.
 If we forget the lifetime annotations and try to compile this function, we’ll
 get this error:
 
-```text
+```console
 {{#include ../listings/ch12-an-io-project/output-only-02-missing-lifetimes/output.txt}}
 ```
 
@@ -102,7 +102,7 @@ References with Lifetimes”][validating-references-with-lifetimes]<!-- ignore
 
 Now let’s run the test:
 
-```text
+```console
 {{#include ../listings/ch12-an-io-project/listing-12-16/output.txt}}
 ```
 
@@ -176,7 +176,7 @@ return them</span>
 Now the `search` function should return only the lines that contain `query`,
 and our test should pass. Let’s run the test:
 
-```text
+```console
 {{#include ../listings/ch12-an-io-project/listing-12-19/output.txt}}
 ```
 
@@ -207,20 +207,20 @@ We’re still using a `for` loop to return each line from `search` and print it.
 Now the entire program should work! Let’s try it out, first with a word that
 should return exactly one line from the Emily Dickinson poem, “frog”:
 
-```text
+```console
 {{#include ../listings/ch12-an-io-project/no-listing-02-using-search-in-run/output.txt}}
 ```
 
 Cool! Now let’s try a word that will match multiple lines, like “body”:
 
-```text
+```console
 {{#include ../listings/ch12-an-io-project/output-only-03-multiple-matches/output.txt}}
 ```
 
 And finally, let’s make sure that we don’t get any lines when we search for a
 word that isn’t anywhere in the poem, such as “monomorphization”:
 
-```text
+```console
 {{#include ../listings/ch12-an-io-project/output-only-04-no-matches/output.txt}}
 ```
 

--- a/src/ch12-05-working-with-environment-variables.md
+++ b/src/ch12-05-working-with-environment-variables.md
@@ -77,7 +77,7 @@ query is.
 
 Let’s see if this implementation passes the tests:
 
-```text
+```console
 {{#include ../listings/ch12-an-io-project/listing-12-21/output.txt}}
 ```
 
@@ -147,7 +147,7 @@ Let’s give it a try! First, we’ll run our program without the environment
 variable set and with the query `to`, which should match any line that contains
 the word “to” in all lowercase:
 
-```text
+```console
 {{#include ../listings/ch12-an-io-project/listing-12-23/output.txt}}
 ```
 
@@ -157,7 +157,7 @@ set to `1` but with the same query `to`.
 If you’re using PowerShell, you will need to set the environment variable and
 run the program in two commands rather than one:
 
-```text
+```console
 $ $env:CASE_INSENSITIVE=1
 $ cargo run to poem.txt
 ```
@@ -170,7 +170,7 @@ CASE_INSENSITIVE=1 cargo run to poem.txt
 can't extract because of the environment variable
 -->
 
-```text
+```console
 $ CASE_INSENSITIVE=1 cargo run to poem.txt
     Finished dev [unoptimized + debuginfo] target(s) in 0.0s
      Running `target/debug/minigrep to poem.txt`

--- a/src/ch12-06-writing-to-stderr-instead-of-stdout.md
+++ b/src/ch12-06-writing-to-stderr-instead-of-stdout.md
@@ -28,7 +28,7 @@ The way to demonstrate this behavior is by running the program with `>` and the
 filename, *output.txt*, that we want to redirect the standard output stream to.
 We won’t pass any arguments, which should cause an error:
 
-```text
+```console
 $ cargo run > output.txt
 ```
 
@@ -77,7 +77,7 @@ behavior we expect of command line programs.
 Let’s run the program again with arguments that don’t cause an error but still
 redirect standard output to a file, like so:
 
-```text
+```console
 $ cargo run to poem.txt > output.txt
 ```
 

--- a/src/ch13-01-closures.md
+++ b/src/ch13-01-closures.md
@@ -272,7 +272,7 @@ are inferred with two different types</span>
 
 The compiler gives us this error:
 
-```text
+```console
 {{#include ../listings/ch13-functional-features/listing-13-08/output.txt}}
 ```
 
@@ -425,7 +425,7 @@ passed into it. We call the `value` method on this `Cacher` instance with an
 Run this test with the `Cacher` implementation in Listing 13-9 and Listing
 13-10, and the test will fail on the `assert_eq!` with this message:
 
-```text
+```console
 {{#include ../listings/ch13-functional-features/no-listing-01-failing-cacher-test/output.txt}}
 ```
 
@@ -481,7 +481,7 @@ code won’t compile:
 
 We get an error:
 
-```text
+```console
 {{#include ../listings/ch13-functional-features/no-listing-02-functions-cant-capture/output.txt}}
 ```
 
@@ -534,7 +534,7 @@ yet compile.
 
 We receive the following error:
 
-```text
+```console
 {{#include ../listings/ch13-functional-features/no-listing-03-move-closures/output.txt}}
 ```
 

--- a/src/ch13-02-iterators.md
+++ b/src/ch13-02-iterators.md
@@ -150,7 +150,7 @@ create a new iterator</span>
 
 The warning we get is this:
 
-```text
+```console
 {{#include ../listings/ch13-functional-features/listing-13-17/output.txt}}
 ```
 

--- a/src/ch14-01-release-profiles.md
+++ b/src/ch14-01-release-profiles.md
@@ -19,7 +19,7 @@ cargo build --release
 and ensure output below is accurate
 -->
 
-```text
+```console
 $ cargo build
     Finished dev [unoptimized + debuginfo] target(s) in 0.0s
 $ cargo build --release

--- a/src/ch14-02-publishing-to-crates-io.md
+++ b/src/ch14-02-publishing-to-crates-io.md
@@ -277,7 +277,7 @@ you’re logged in, visit your account settings at
 [https://crates.io/me/](https://crates.io/me/)<!-- ignore --> and retrieve your
 API key. Then run the `cargo login` command with your API key, like this:
 
-```text
+```console
 $ cargo login abcdefghijklmnopqrstuvwxyz012345
 ```
 
@@ -318,7 +318,7 @@ cargo publish
 copy just the relevant lines below
 -->
 
-```text
+```console
 $ cargo publish
     Updating crates.io index
 warning: manifest has no description, license, license-file, documentation, homepage or repository.
@@ -405,7 +405,7 @@ cargo publish
 copy just the relevant lines below
 -->
 
-```text
+```console
 $ cargo publish
     Updating crates.io index
    Packaging guessing_game v0.1.0 (file:///projects/guessing_game)
@@ -445,14 +445,14 @@ not use the yanked version.
 To yank a version of a crate, run `cargo yank` and specify which version you
 want to yank:
 
-```text
+```console
 $ cargo yank --vers 1.0.1
 ```
 
 By adding `--undo` to the command, you can also undo a yank and allow projects
 to start depending on a version again:
 
-```text
+```console
 $ cargo yank --vers 1.0.1 --undo
 ```
 

--- a/src/ch14-03-cargo-workspaces.md
+++ b/src/ch14-03-cargo-workspaces.md
@@ -19,7 +19,7 @@ provide an `add_one` function, and a second library an `add_two` function.
 These three crates will be part of the same workspace. We’ll start by creating
 a new directory for the workspace:
 
-```text
+```console
 $ mkdir add
 $ cd add
 ```
@@ -46,7 +46,7 @@ cargo new adder
 copy output below
 -->
 
-```text
+```console
 $ cargo new adder
      Created binary (application) `adder` package
 ```
@@ -96,7 +96,7 @@ cargo new add-one --lib
 copy output below
 -->
 
-```text
+```console
 $ cargo new add-one --lib
      Created library `add-one` package
 ```
@@ -161,7 +161,7 @@ cargo build
 copy output below; the output updating script doesn't handle subdirectories in paths properly
 -->
 
-```text
+```console
 $ cargo build
    Compiling add-one v0.1.0 (file:///projects/add/add-one)
    Compiling adder v0.1.0 (file:///projects/add/adder)
@@ -178,7 +178,7 @@ cargo run -p adder
 copy output below; the output updating script doesn't handle subdirectories in paths properly
 -->
 
-```text
+```console
 $ cargo run -p adder
     Finished dev [unoptimized + debuginfo] target(s) in 0.0s
      Running `target/debug/adder`
@@ -222,7 +222,7 @@ cargo build
 copy output below; the output updating script doesn't handle subdirectories in paths properly
 -->
 
-```text
+```console
 $ cargo build
     Updating crates.io index
   Downloaded rand v0.5.5
@@ -245,7 +245,7 @@ cargo build
 copy output below; the output updating script doesn't handle subdirectories in paths properly
 -->
 
-```text
+```console
 $ cargo build
   --snip--
    Compiling adder v0.1.0 (file:///projects/add/adder)
@@ -284,7 +284,7 @@ cargo test
 copy output below; the output updating script doesn't handle subdirectories in paths properly
 -->
 
-```text
+```console
 $ cargo test
    Compiling add-one v0.1.0 (file:///projects/add/add-one)
    Compiling adder v0.1.0 (file:///projects/add/adder)
@@ -325,7 +325,7 @@ cargo test -p add-one
 copy output below; the output updating script doesn't handle subdirectories in paths properly
 -->
 
-```text
+```console
 $ cargo test -p add-one
     Finished test [unoptimized + debuginfo] target(s) in 0.00s
      Running target/debug/deps/add_one-b3235fea9a156f74

--- a/src/ch14-04-installing-binaries.md
+++ b/src/ch14-04-installing-binaries.md
@@ -25,7 +25,7 @@ the `grep` tool called `ripgrep` for searching files. If we want to install
 cargo install something you don't have, copy relevant output below
 -->
 
-```text
+```console
 $ cargo install ripgrep
     Updating crates.io index
   Downloaded ripgrep v11.0.2

--- a/src/ch15-01-box.md
+++ b/src/ch15-01-box.md
@@ -137,7 +137,7 @@ is one more `Cons` value that holds `3` and a `List` value, which is finally
 If we try to compile the code in Listing 15-3, we get the error shown in
 Listing 15-4:
 
-```text
+```console
 {{#include ../listings/ch15-smart-pointers/listing-15-03/output.txt}}
 ```
 

--- a/src/ch15-02-deref.md
+++ b/src/ch15-02-deref.md
@@ -45,7 +45,7 @@ we have access to the integer value `y` is pointing to that we can compare with
 If we tried to write `assert_eq!(5, y);` instead, we would get this compilation
 error:
 
-```text
+```console
 {{#include ../listings/ch15-smart-pointers/output-only-01-comparing-to-reference/output.txt}}
 ```
 
@@ -114,7 +114,7 @@ way we used references and `Box<T>`</span>
 
 Here’s the resulting compilation error:
 
-```text
+```console
 {{#include ../listings/ch15-smart-pointers/listing-15-09/output.txt}}
 ```
 

--- a/src/ch15-03-drop.md
+++ b/src/ch15-03-drop.md
@@ -51,7 +51,7 @@ call the `drop` method explicitly.
 
 When we run this program, we’ll see the following output:
 
-```text
+```console
 {{#include ../listings/ch15-smart-pointers/listing-15-14/output.txt}}
 ```
 
@@ -88,7 +88,7 @@ the `Drop` trait manually to clean up early</span>
 
 When we try to compile this code, we’ll get this error:
 
-```text
+```console
 {{#include ../listings/ch15-smart-pointers/listing-15-15/output.txt}}
 ```
 
@@ -123,7 +123,7 @@ drop a value before it goes out of scope</span>
 
 Running this code will print the following:
 
-```text
+```console
 {{#include ../listings/ch15-smart-pointers/listing-15-16/output.txt}}
 ```
 

--- a/src/ch15-04-rc.md
+++ b/src/ch15-04-rc.md
@@ -59,7 +59,7 @@ two lists using `Box<T>` that try to share ownership of a third list</span>
 
 When we compile this code, we get this error:
 
-```text
+```console
 {{#include ../listings/ch15-smart-pointers/listing-15-17/output.txt}}
 ```
 
@@ -136,7 +136,7 @@ type also has a `weak_count`; we’ll see what `weak_count` is used for in the
 
 This code prints the following:
 
-```text
+```console
 {{#include ../listings/ch15-smart-pointers/listing-15-19/output.txt}}
 ```
 

--- a/src/ch15-05-interior-mutability.md
+++ b/src/ch15-05-interior-mutability.md
@@ -81,7 +81,7 @@ you can’t borrow it mutably. For example, this code won’t compile:
 
 If you tried to compile this code, you’d get the following error:
 
-```text
+```console
 {{#include ../listings/ch15-smart-pointers/no-listing-01-cant-borrow-immutable-as-mutable/output.txt}}
 ```
 
@@ -257,7 +257,7 @@ variable `two_borrow`. This makes two mutable references in the same scope,
 which isn’t allowed. When we run the tests for our library, the code in Listing
 15-23 will compile without any errors, but the test will fail:
 
-```text
+```console
 {{#include ../listings/ch15-smart-pointers/listing-15-23/output.txt}}
 ```
 
@@ -320,7 +320,7 @@ on it and change the inner value.
 When we print `a`, `b`, and `c`, we can see that they all have the modified
 value of 15 rather than 5:
 
-```text
+```console
 {{#include ../listings/ch15-smart-pointers/listing-15-24/output.txt}}
 ```
 

--- a/src/ch15-06-reference-cycles.md
+++ b/src/ch15-06-reference-cycles.md
@@ -60,7 +60,7 @@ from an `Rc<List>` that holds a `Nil` value to the `Rc<List>` in `b`.
 When we run this code, keeping the last `println!` commented out for the
 moment, we’ll get this output:
 
-```text
+```console
 {{#include ../listings/ch15-smart-pointers/listing-15-26/output.txt}}
 ```
 

--- a/src/ch16-01-threads.md
+++ b/src/ch16-01-threads.md
@@ -229,7 +229,7 @@ environment. Because `thread::spawn` runs this closure in a new thread, we
 should be able to access `v` inside that new thread. But when we compile this
 example, we get the following error:
 
-```text
+```console
 {{#include ../listings/ch16-fearless-concurrency/listing-16-03/output.txt}}
 ```
 
@@ -292,7 +292,7 @@ isn’t allowed for a different reason. If we added `move` to the closure, we
 would move `v` into the closure’s environment, and we could no longer call
 `drop` on it in the main thread. We would get this compiler error instead:
 
-```text
+```console
 {{#include ../listings/ch16-fearless-concurrency/output-only-01-move-drop/output.txt}}
 ```
 

--- a/src/ch16-02-message-passing.md
+++ b/src/ch16-02-message-passing.md
@@ -157,7 +157,7 @@ again. Potentially, the other thread’s modifications could cause errors or
 unexpected results due to inconsistent or nonexistent data. However, Rust gives
 us an error if we try to compile the code in Listing 16-9:
 
-```text
+```console
 {{#include ../listings/ch16-fearless-concurrency/listing-16-09/output.txt}}
 ```
 

--- a/src/ch16-03-shared-state.md
+++ b/src/ch16-03-shared-state.md
@@ -120,7 +120,7 @@ program.
 
 We hinted that this example wouldn’t compile. Now let’s find out why!
 
-```text
+```console
 {{#include ../listings/ch16-fearless-concurrency/listing-16-13/output.txt}}
 ```
 
@@ -150,7 +150,7 @@ multiple threads to own the `Mutex<T>`</span>
 Once again, we compile and get... different errors! The compiler is teaching us
 a lot.
 
-```text
+```console
 {{#include ../listings/ch16-fearless-concurrency/listing-16-14/output.txt}}
 ```
 

--- a/src/ch17-02-trait-objects.md
+++ b/src/ch17-02-trait-objects.md
@@ -219,7 +219,7 @@ implement the trait object’s trait</span>
 
 We’ll get this error because `String` doesn’t implement the `Draw` trait:
 
-```text
+```console
 {{#include ../listings/ch17-oop/listing-17-10/output.txt}}
 ```
 
@@ -300,7 +300,7 @@ implement the `Clone` trait instead of the `Draw` trait, like this:
 
 We would get this error:
 
-```text
+```console
 {{#include ../listings/ch17-oop/no-listing-01-trait-object-of-clone/output.txt}}
 ```
 

--- a/src/ch18-01-all-the-places-for-patterns.md
+++ b/src/ch18-01-all-the-places-for-patterns.md
@@ -121,7 +121,7 @@ destructure a tuple</span>
 
 The code in Listing 18-3 will print the following:
 
-```text
+```console
 {{#include ../listings/ch18-patterns-and-matching/listing-18-03/output.txt}}
 ```
 
@@ -186,7 +186,7 @@ variables don’t match the number of elements in the tuple</span>
 
 Attempting to compile this code results in this type error:
 
-```text
+```console
 {{#include ../listings/ch18-patterns-and-matching/listing-18-05/output.txt}}
 ```
 

--- a/src/ch18-02-refutability.md
+++ b/src/ch18-02-refutability.md
@@ -40,7 +40,7 @@ only accept an irrefutable pattern because there is nothing valid the code can
 do with a `None` value. At compile time, Rust will complain that we’ve tried to
 use a refutable pattern where an irrefutable pattern is required:
 
-```text
+```console
 {{#include ../listings/ch18-patterns-and-matching/listing-18-08/output.txt}}
 ```
 
@@ -75,7 +75,7 @@ with `if let`</span>
 Rust complains that it doesn’t make sense to use `if let` with an irrefutable
 pattern:
 
-```text
+```console
 {{#include ../listings/ch18-patterns-and-matching/listing-18-10/output.txt}}
 ```
 

--- a/src/ch18-03-pattern-syntax.md
+++ b/src/ch18-03-pattern-syntax.md
@@ -438,7 +438,7 @@ way</span>
 
 When we compile this example, we get this error:
 
-```text
+```console
 {{#include ../listings/ch18-patterns-and-matching/listing-18-25/output.txt}}
 ```
 

--- a/src/ch19-01-unsafe-rust.md
+++ b/src/ch19-01-unsafe-rust.md
@@ -172,7 +172,7 @@ body:
 We must call the `dangerous` function within a separate `unsafe` block. If we
 try to call `dangerous` without the `unsafe` block, we’ll get an error:
 
-```text
+```console
 {{#include ../listings/ch19-advanced-features/output-only-01-missing-unsafe/output.txt}}
 ```
 
@@ -226,7 +226,7 @@ slice.
 
 When we try to compile the code in Listing 19-5, we’ll get an error.
 
-```text
+```console
 {{#include ../listings/ch19-advanced-features/listing-19-05/output.txt}}
 ```
 

--- a/src/ch19-03-advanced-traits.md
+++ b/src/ch19-03-advanced-traits.md
@@ -229,7 +229,7 @@ disambiguate.
 
 Running this code prints the following:
 
-```text
+```console
 {{#include ../listings/ch19-advanced-features/listing-19-18/output.txt}}
 ```
 
@@ -264,7 +264,7 @@ is expressed in the implementation of the `Animal` trait on `Dog` in the
 In `main`, we call the `Dog::baby_name` function, which calls the associated
 function defined on `Dog` directly. This code prints the following:
 
-```text
+```console
 {{#include ../listings/ch19-advanced-features/listing-19-19/output.txt}}
 ```
 
@@ -288,7 +288,7 @@ Because `Animal::baby_name` is an associated function rather than a method, and
 thus doesn’t have a `self` parameter, Rust can’t figure out which
 implementation of `Animal::baby_name` we want. We’ll get this compiler error:
 
-```text
+```console
 {{#include ../listings/ch19-advanced-features/listing-19-20/output.txt}}
 ```
 
@@ -311,7 +311,7 @@ indicates we want to call the `baby_name` method from the `Animal` trait as
 implemented on `Dog` by saying that we want to treat the `Dog` type as an
 `Animal` for this function call. This code will now print what we want:
 
-```text
+```console
 {{#include ../listings/ch19-advanced-features/listing-19-21/output.txt}}
 ```
 
@@ -383,7 +383,7 @@ doesn’t implement `Display`, such as the `Point` struct:
 
 We get an error saying that `Display` is required but not implemented:
 
-```text
+```console
 {{#include ../listings/ch19-advanced-features/no-listing-02-impl-outlineprint-for-point/output.txt}}
 ```
 

--- a/src/ch19-05-advanced-functions-and-closures.md
+++ b/src/ch19-05-advanced-functions-and-closures.md
@@ -97,7 +97,7 @@ The following code tries to return a closure directly, but it won’t compile:
 
 The compiler error is as follows:
 
-```text
+```console
 {{#include ../listings/ch19-advanced-features/no-listing-18-returns-closure/output.txt}}
 ```
 

--- a/src/ch19-06-macros.md
+++ b/src/ch19-06-macros.md
@@ -222,7 +222,7 @@ to write when using our procedural macro</span>
 This code will print `Hello, Macro! My name is Pancakes!` when we’re done. The
 first step is to make a new library crate, like this:
 
-```text
+```console
 $ cargo new hello_macro --lib
 ```
 
@@ -257,7 +257,7 @@ follows: for a crate named `foo`, a custom derive procedural macro crate is
 called `foo_derive`. Let’s start a new crate called `hello_macro_derive` inside
 our `hello_macro` project:
 
-```text
+```console
 $ cargo new hello_macro_derive --lib
 ```
 

--- a/src/ch20-01-single-threaded.md
+++ b/src/ch20-01-single-threaded.md
@@ -25,7 +25,7 @@ Our web server needs to listen to a TCP connection, so that’s the first part
 we’ll work on. The standard library offers a `std::net` module that lets us do
 this. Let’s make a new project in the usual fashion:
 
-```text
+```console
 $ cargo new hello
      Created binary (application) `hello` project
 $ cd hello
@@ -168,7 +168,7 @@ Let’s try this code! Start the program and make a request in a web browser
 again. Note that we’ll still get an error page in the browser, but our
 program’s output in the terminal will now look similar to this:
 
-```text
+```console
 $ cargo run
    Compiling hello v0.1.0 (file:///projects/hello)
     Finished dev [unoptimized + debuginfo] target(s) in 0.42s

--- a/src/ch20-02-multithreaded.md
+++ b/src/ch20-02-multithreaded.md
@@ -140,7 +140,7 @@ Make the changes in Listing 20-12 to *src/main.rs*, and then let’s use the
 compiler errors from `cargo check` to drive our development. Here is the first
 error we get:
 
-```text
+```console
 {{#include ../listings/ch20-web-server/listing-20-12/output.txt}}
 ```
 
@@ -177,7 +177,7 @@ following code to the top of *src/bin/main.rs*:
 This code still won’t work, but let’s check it again to get the next error that
 we need to address:
 
-```text
+```console
 {{#include ../listings/ch20-web-server/no-listing-01-define-threadpool-struct/output.txt}}
 ```
 
@@ -201,7 +201,7 @@ ignore --> section of Chapter 3.
 
 Let’s check the code again:
 
-```text
+```console
 {{#include ../listings/ch20-web-server/no-listing-02-impl-threadpool-new/output.txt}}
 ```
 
@@ -258,7 +258,7 @@ have no parameters, we still need the parentheses.
 Again, this is the simplest implementation of the `execute` method: it does
 nothing, but we’re trying only to make our code compile. Let’s check it again:
 
-```text
+```console
 {{#include ../listings/ch20-web-server/no-listing-03-define-execute/output.txt}}
 ```
 
@@ -488,7 +488,7 @@ the channel into `Worker::new`, and then we use it inside the closure.
 
 When we try to check this code, we get this error:
 
-```text
+```console
 {{#include ../listings/ch20-web-server/listing-20-17/output.txt}}
 ```
 
@@ -593,7 +593,7 @@ make some requests to 127.0.0.1:7878
 Can't automate because the output depends on making requests
 -->
 
-```text
+```console
 $ cargo run
    Compiling hello v0.1.0 (file:///projects/hello)
 warning: field is never read: `workers`

--- a/src/ch20-03-graceful-shutdown-and-cleanup.md
+++ b/src/ch20-03-graceful-shutdown-and-cleanup.md
@@ -39,7 +39,7 @@ into an ungraceful shutdown.
 
 Here is the error we get when we compile this code:
 
-```text
+```console
 {{#include ../listings/ch20-web-server/listing-20-22/output.txt}}
 ```
 
@@ -65,7 +65,7 @@ So we know we want to update the definition of `Worker` like this:
 Now let’s lean on the compiler to find the other places that need to change.
 Checking this code, we get two errors:
 
-```text
+```console
 {{#include ../listings/ch20-web-server/no-listing-04-update-worker-definition/output.txt}}
 ```
 
@@ -210,7 +210,7 @@ copy output below
 Can't automate because the output depends on making requests
 -->
 
-```text
+```console
 $ cargo run
    Compiling hello v0.1.0 (file:///projects/hello)
     Finished dev [unoptimized + debuginfo] target(s) in 1.0s


### PR DESCRIPTION
The "text" style is just plain text, but we were also using it for
command line examples. Turns out that highlight.js has a style for this,
called "console."

This commit updates all instances of using text for a command line
example to use console instead.

Fixes #1449