### PR TITLE
Clarify that `move` closures are somewhat distinct from just implementing `FnOnce` traits

### DIFF
--- a/src/ch13-01-closures.md
+++ b/src/ch13-01-closures.md
@@ -520,6 +520,11 @@ environment, you can use the `move` keyword before the parameter list. This
 technique is mostly useful when passing a closure to a new thread to move the
 data so it’s owned by the new thread.
 
+> Note: `move` closures may still implement [`Fn`] or [`FnMut`], even though
+> they capture variables by move. This is because the traits implemented by a
+> closure type are determined by what the closure does with captured values,
+> not how it captures them. The `move` keyword only specifies the latter.
+
 We’ll have more examples of `move` closures in Chapter 16 when we talk about
 concurrency. For now, here’s the code from Listing 13-12 with the `move`
 keyword added to the closure definition and using vectors instead of integers,


### PR DESCRIPTION
I have found that what `move` actually means is confusing. 
I made https://play.rust-lang.org/?version=nightly&mode=debug&edition=2018&gist=bd408754d822e9c14a656a249964b1a2 the other day to try to figure out what was going on, and I found myself more confused. From my comments, you can see I found things inconsistent.

After asking around, it became clear the `move` actually has very consistent semantics, but that the USAGE of moved values is different than the move into the closure object. I found that the rust book doesn't really mention (clearly) this distinction, which led me to my confusion. Someone pointed me to the note in the reference: https://doc.rust-lang.org/reference/types/closure.html#call-traits-and-coercions , which explains the difference succinctly. 

I think its important here to be clear about what `move` is actually doing, so I copied the note from the reference into the book (most people I believe will usually go to the book when confused by something. I added an extra sentence at the end to drive home the point.

Let me know if you think there is a better way to teach this!