### PR TITLE
link to stdlib atomic docs

### DIFF
--- a/src/ch16-03-shared-state.md
+++ b/src/ch16-03-shared-state.md
@@ -176,9 +176,11 @@ Fortunately, `Arc<T>` *is* a type like `Rc<T>` that is safe to use in
 concurrent situations. The *a* stands for *atomic*, meaning it’s an *atomically
 reference counted* type. Atomics are an additional kind of concurrency
 primitive that we won’t cover in detail here: see the standard library
-documentation for `std::sync::atomic` for more details. At this point, you just
+documentation for [`std::sync::atomic`] for more details. At this point, you just
 need to know that atomics work like primitive types but are safe to share
 across threads.
+
+[`std::sync::atomic`]: ../std/sync/atomic/index.html
 
 You might then wonder why all primitive types aren’t atomic and why standard
 library types aren’t implemented to use `Arc<T>` by default. The reason is that


### PR DESCRIPTION
I realize there are many links one could add in this chapter, but given that the text specifically tells the reader to go read that text, it seems really rather odd to not have a link.