### PR TITLE
Unnecessarily long type name in Ch 13

### DIFF
--- a/listings/ch13-functional-features/listing-13-26/src/lib.rs
+++ b/listings/ch13-functional-features/listing-13-26/src/lib.rs
@@ -10,7 +10,7 @@ pub struct Config {
 
 // ANCHOR: here
 impl Config {
-    pub fn new(mut args: std::env::Args) -> Result<Config, &'static str> {
+    pub fn new(mut args: env::Args) -> Result<Config, &'static str> {
         // --snip--
         // ANCHOR_END: here
         if args.len() < 3 {

--- a/listings/ch13-functional-features/listing-13-27/src/lib.rs
+++ b/listings/ch13-functional-features/listing-13-27/src/lib.rs
@@ -10,7 +10,7 @@ pub struct Config {
 
 // ANCHOR: here
 impl Config {
-    pub fn new(mut args: std::env::Args) -> Result<Config, &'static str> {
+    pub fn new(mut args: env::Args) -> Result<Config, &'static str> {
         args.next();
 
         let query = match args.next() {


### PR DESCRIPTION
Removed Unnecessarily long type name in Ch 13 #1869 

fixes #1869 