### PR TITLE
Tweak example in chapter 10

### DIFF
--- a/listings/ch10-generic-types-traits-and-lifetimes/listing-10-03/src/main.rs
+++ b/listings/ch10-generic-types-traits-and-lifetimes/listing-10-03/src/main.rs
@@ -1,8 +1,8 @@
 // ANCHOR: here
-fn largest(list: &[i32]) -> i32 {
-    let mut largest = list[0];
+fn largest(list: &[i32]) -> &i32 {
+    let mut largest = &list[0];
 
-    for &item in list {
+    for item in list {
         if item > largest {
             largest = item;
         }
@@ -17,7 +17,7 @@ fn main() {
     let result = largest(&number_list);
     println!("The largest number is {}", result);
     // ANCHOR_END: here
-    assert_eq!(result, 100);
+    assert_eq!(result, &100);
     // ANCHOR: here
 
     let number_list = vec![102, 34, 6000, 89, 54, 2, 43, 8];
@@ -25,7 +25,7 @@ fn main() {
     let result = largest(&number_list);
     println!("The largest number is {}", result);
     // ANCHOR_END: here
-    assert_eq!(result, 6000);
+    assert_eq!(result, &6000);
     // ANCHOR: here
 }
 // ANCHOR_END: here

--- a/listings/ch10-generic-types-traits-and-lifetimes/listing-10-04/src/main.rs
+++ b/listings/ch10-generic-types-traits-and-lifetimes/listing-10-04/src/main.rs
@@ -1,8 +1,8 @@
 // ANCHOR: here
-fn largest_i32(list: &[i32]) -> i32 {
-    let mut largest = list[0];
+fn largest_i32(list: &[i32]) -> &i32 {
+    let mut largest = &list[0];
 
-    for &item in list {
+    for item in list {
         if item > largest {
             largest = item;
         }
@@ -11,10 +11,10 @@ fn largest_i32(list: &[i32]) -> i32 {
     largest
 }
 
-fn largest_char(list: &[char]) -> char {
-    let mut largest = list[0];
+fn largest_char(list: &[char]) -> &char {
+    let mut largest = &list[0];
 
-    for &item in list {
+    for item in list {
         if item > largest {
             largest = item;
         }
@@ -29,7 +29,7 @@ fn main() {
     let result = largest_i32(&number_list);
     println!("The largest number is {}", result);
     // ANCHOR_END: here
-    assert_eq!(result, 100);
+    assert_eq!(result, &100);
     // ANCHOR: here
 
     let char_list = vec!['y', 'm', 'a', 'q'];
@@ -37,7 +37,7 @@ fn main() {
     let result = largest_char(&char_list);
     println!("The largest char is {}", result);
     // ANCHOR_END: here
-    assert_eq!(result, 'y');
+    assert_eq!(result, &'y');
     // ANCHOR: here
 }
 // ANCHOR_END: here

--- a/listings/ch10-generic-types-traits-and-lifetimes/listing-10-05/src/main.rs
+++ b/listings/ch10-generic-types-traits-and-lifetimes/listing-10-05/src/main.rs
@@ -1,7 +1,7 @@
-fn largest<T>(list: &[T]) -> T {
+fn largest<T>(list: &[T]) -> &T {
     let mut largest = list[0];
 
-    for &item in list {
+    for item in list {
         if item > largest {
             largest = item;
         }

--- a/src/ch10-01-syntax.md
+++ b/src/ch10-01-syntax.md
@@ -44,12 +44,13 @@ to declare the type parameter name before we use it. To define the generic
 between the name of the function and the parameter list, like this:
 
 ```rust,ignore
-fn largest<T>(list: &[T]) -> T {
+fn largest<T>(list: &[T]) -> &T {
 ```
 
 We read this definition as: the function `largest` is generic over some type
 `T`. This function has one parameter named `list`, which is a slice of values
-of type `T`. The `largest` function will return a value of the same type `T`.
+of type `T`. The `largest` function will return a reference to a value of the
+same type `T`.
 
 Listing 10-5 shows the combined `largest` function definition using the generic
 data type in its signature. The listing also shows how we can call the function


### PR DESCRIPTION
We were cheating due to Copy, and that made this example awkward.
Returning a reference is probably better here anyway, and it makes
everything flow a bit nicer.

FIxes #1761