### PR TITLE
Not mandatory with cargo 1.41.0-nightly

### DIFF
--- a/src/ch14-03-cargo-workspaces.md
+++ b/src/ch14-03-cargo-workspaces.md
@@ -168,8 +168,8 @@ $ cargo build
     Finished dev [unoptimized + debuginfo] target(s) in 0.68s
 ```
 
-To run the binary crate from the *add* directory, we need to specify which
-package in the workspace we want to use by using the `-p` argument and the
+To run the binary crate from the *add* directory, we can specify which
+package in the workspace we want to run by using the `-p` argument and the
 package name with `cargo run`:
 
 <!-- manual-regeneration


### PR DESCRIPTION
```bash
$ cargo run
    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
     Running `target/debug/adder`
Hello, world! 10 plus one is 11!
```