### PR TITLE
Use same naming for Rhs as libcore/ops

### DIFF
--- a/src/ch19-03-advanced-traits.md
+++ b/src/ch19-03-advanced-traits.md
@@ -116,30 +116,30 @@ The default generic type in this code is within the `Add` trait. Here is its
 definition:
 
 ```rust
-trait Add<RHS=Self> {
+trait Add<Rhs=Self> {
     type Output;
 
-    fn add(self, rhs: RHS) -> Self::Output;
+    fn add(self, rhs: Rhs) -> Self::Output;
 }
 ```
 
 This code should look generally familiar: a trait with one method and an
-associated type. The new part is `RHS=Self`: this syntax is called *default
-type parameters*. The `RHS` generic type parameter (short for “right hand
+associated type. The new part is `Rhs=Self`: this syntax is called *default
+type parameters*. The `Rhs` generic type parameter (short for “right hand
 side”) defines the type of the `rhs` parameter in the `add` method. If we don’t
-specify a concrete type for `RHS` when we implement the `Add` trait, the type
-of `RHS` will default to `Self`, which will be the type we’re implementing
+specify a concrete type for `Rhs` when we implement the `Add` trait, the type
+of `Rhs` will default to `Self`, which will be the type we’re implementing
 `Add` on.
 
-When we implemented `Add` for `Point`, we used the default for `RHS` because we
+When we implemented `Add` for `Point`, we used the default for `Rhs` because we
 wanted to add two `Point` instances. Let’s look at an example of implementing
-the `Add` trait where we want to customize the `RHS` type rather than using the
+the `Add` trait where we want to customize the `Rhs` type rather than using the
 default.
 
 We have two structs, `Millimeters` and `Meters`, holding values in different
 units. We want to add values in millimeters to values in meters and have the
 implementation of `Add` do the conversion correctly. We can implement `Add` for
-`Millimeters` with `Meters` as the `RHS`, as shown in Listing 19-15.
+`Millimeters` with `Meters` as the `Rhs`, as shown in Listing 19-15.
 
 <span class="filename">Filename: src/lib.rs</span>
 
@@ -151,7 +151,7 @@ implementation of `Add` do the conversion correctly. We can implement `Add` for
 `Millimeters` to add `Millimeters` to `Meters`</span>
 
 To add `Millimeters` and `Meters`, we specify `impl Add<Meters>` to set the
-value of the `RHS` type parameter instead of using the default of `Self`.
+value of the `Rhs` type parameter instead of using the default of `Self`.
 
 You’ll use default type parameters in two main ways:
 


### PR DESCRIPTION
Use same naming scheme as libcore/ops

RHS changed to Rhs in [consistent naming for Rhs type parameter in libcore/ops ](https://github.com/rust-lang/rust/commit/fec0ff2ce83ca771eabb61fcf449a5380cf98de0)