### PR TITLE
Update ch01-02-hello-world.md

### DIFF
--- a/src/ch01-02-hello-world.md
+++ b/src/ch01-02-hello-world.md
@@ -68,16 +68,16 @@ $ ./main
 Hello, world!
 ```
 
-On Windows, enter the command `.\main.exe` instead of `./main`:
+On Windows, enter the command `main` instead of `./main`:
 
 ```powershell
 > rustc main.rs
-> .\main.exe
+> main
 Hello, world!
 ```
 
-Regardless of your operating system, the string `Hello, world!` should print to
-the terminal. If you don’t see this output, refer back to the
+Regardless of your operating system, the string `Hello, world!` should display
+on ("print to") the terminal. If you don’t see this output, refer back to the
 [“Troubleshooting”][troubleshooting]<!-- ignore --> part of the Installation
 section for ways to get help.
 


### PR DESCRIPTION
I’d like to suggest two changes to the Hello World example.

1) _On Windows, enter the command .\main.exe instead of ./main:_

This is using a Unix idiom rather than a generic Windows idiom for how to run a program. It works, but it ain’t the Windows way. 

It should be changed to:

On Windows, enter the command main instead of ./main:

> rustc main.rs
> main

2) The term “print to” is really a left-over from another era of I/O devices. It's been incorporated into the name of the "println" command, so that cannot be changed, but it is worth pointing out at least once what the command actually does in 99.999% of all scenarios, which is to display something on the screen.

_Regardless of your operating system, the string Hello, world! should print to the terminal._
could become:
Regardless of your operating system, the string Hello, world! should display on (“print to”) the terminal.

Kurt