### PR TITLE
Chapter 5.2 remove reference in struct example

### DIFF
--- a/listings/ch05-using-structs-to-structure-related-data/listing-05-10/src/main.rs
+++ b/listings/ch05-using-structs-to-structure-related-data/listing-05-10/src/main.rs
@@ -11,10 +11,10 @@ fn main() {
 
     println!(
         "The area of the rectangle is {} square pixels.",
-        area(&rect1)
+        area(rect1)
     );
 }
 
-fn area(rectangle: &Rectangle) -> u32 {
+fn area(rectangle: Rectangle) -> u32 {
     rectangle.width * rectangle.height
 }


### PR DESCRIPTION
Reading the book and learning about Rust I encountered the example Listing 5-10 where we pass the struct by reference to the function, which is not necessary here. Furthermore removing the reference keeps it consistent with the Listing 5-9 with immutable tuples.