### PR TITLE
Update ch02-00-guessing-game-tutorial.md

### DIFF
--- a/src/ch02-00-guessing-game-tutorial.md
+++ b/src/ch02-00-guessing-game-tutorial.md
@@ -520,7 +520,12 @@ number</span>
 
 First, we add a `use` line: `use rand::Rng`. The `Rng` trait defines
 methods that random number generators implement, and this trait must be in
-scope for us to use those methods. Chapter 10 will cover traits in detail.
+scope for us to use those methods. Chapter 10 will cover traits in detail. 
+
+> The underlying reason for the presence of `crate::` when calling operations from 
+> crates, such as `rand::`, is to prevent the compiler from mistaking crate-operations
+> with our defined operation, which happens to share the same name. 
+> Further information will be introduced in Chapter 5, 6 & 7.
 
 Next, we’re adding two lines in the middle. The `rand::thread_rng` function
 will give us the particular random number generator that we’re going to use:


### PR DESCRIPTION
The reason behind this change is to explain why one has to included `rand::` in the example after one has imported the crate library to their project, through`use Rand::Rng;`. 

This caused me confusion which lasted for a while until I had asked on the discord server for others to clarify the objective behind this and it finally made sense, even more so after I had arrived at the seventh chapter where the intent behind this design concept was explained furtherly. Thus I thought to myself, why not reduce the confusion which could arise from this absence and include it in the second chapter?

I tried rewriting it several times and managed to reduce the complexity of my writing to an understandable manner. If it still remains somewhat complex, do notify me to re-attempt reducing the complexity of this text! :relaxed: 