### PR TITLE
Consistently use commas

### DIFF
--- a/listings/ch02-guessing-game-tutorial/listing-02-05/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/listing-02-05/src/main.rs
@@ -39,7 +39,7 @@ fn main() {
             Ordering::Equal => {
                 println!("You win!");
                 break;
-            }
+            },
         }
     }
 }


### PR DESCRIPTION
Earlier there was a comma after the Ordering::Equal case

![image](https://user-images.githubusercontent.com/22038419/87227920-e2ab1000-c36b-11ea-8bea-4695c5964164.png)

To keep consistent I added it in here too.
