### PR TITLE
fn returns_summarizable()

### DIFF
--- a/listings/ch10-generic-types-traits-and-lifetimes/no-listing-05-returning-impl-trait/src/lib.rs
+++ b/listings/ch10-generic-types-traits-and-lifetimes/no-listing-05-returning-impl-trait/src/lib.rs
@@ -33,8 +33,7 @@ fn returns_summarizable() -> impl Summary {
     Tweet {
         username: String::from("horse_ebooks"),
         content: String::from(
-            "of course, as you probably already know, people",
-        ),
+            "of course, as you probably already know, people"),
         reply: false,
         retweet: false,
     }


### PR DESCRIPTION
The listing in Returning Types that Implement Traits has a slight change.
The code given is :
fn returns_summarizable() -> impl Summary {
    Tweet {
        username: String::from("horse_ebooks"),
        content: String::from(
            "of course, as you probably already know, people",
        ),
        reply: false,
        retweet: false,
    }
}

The correction should be: 
fn returns_summarizable() -> impl Summary {
    Tweet {
        username: String::from("horse_ebooks"),
        content: String::from(
            "of course, as you probably already know, people"),
        reply: false,
        retweet: false,
    }
}