### PR TITLE
Fix typo

### DIFF
--- a/src/ch19-03-advanced-traits.md
+++ b/src/ch19-03-advanced-traits.md
@@ -318,7 +318,7 @@ implemented on `Dog` by saying that we want to treat the `Dog` type as an
 In general, fully qualified syntax is defined as follows:
 
 ```rust,ignore
-<Type as Trait>::function(receiver_if_method, next_arg, ...);
+<Type as Trait>::function(receiver_of_method, next_arg, ...);
 ```
 
 For associated functions, there would not be a `receiver`: there would only be


### PR DESCRIPTION
Fix a typo in `ch19-03-advanced-traits.md` example code in where `receiver_if_method` was written but probably meant to write `receiver_of_method`.