### PR TITLE
A note on the checked_* methods

### DIFF
--- a/src/ch03-02-data-types.md
+++ b/src/ch03-02-data-types.md
@@ -112,6 +112,9 @@ which you’d use `isize` or `usize` is when indexing some sort of collection.
 > value that probably isn’t what you were expecting it to have. Relying on
 > integer overflow’s wrapping behavior is considered an error. If you want to
 > wrap explicitly, you can use the standard library type [`Wrapping`][wrapping].
+>
+> Integer overflow checking can be performed with the `checked_*` methods from
+> the standard library, for example `checked_add()`.
 
 #### Floating-Point Types
 


### PR DESCRIPTION
It can be confusing for an inexperienced reader why this is the case,
and how to avoid it, should you want to. For this reason, it can be
helpful to point out that this issue can be avoided by using methods
from the standard library.

Code example from
https://stackoverflow.com/questions/52646755/checking-for-integer-overflow-in-rust

```
let x = u32::max_value() - 2; let y = 3;

match x.checked_add(y) {
    Some(v) => {
        println!("{} + {} = {}", x, y, v);
    } None => {
        println!("overflow!");
    }
};
```