### PR TITLE
fixes #2407

### DIFF
--- a/listings/ch19-advanced-features/no-listing-01-unsafe-fn/src/main.rs
+++ b/listings/ch19-advanced-features/no-listing-01-unsafe-fn/src/main.rs
@@ -2,8 +2,6 @@ fn main() {
     // ANCHOR: here
     unsafe fn dangerous() {}
 
-    unsafe {
-        dangerous();
-    }
+    dangerous();
     // ANCHOR_END: here
 }


### PR DESCRIPTION
Fixes #2407: removed `unsafe` block around the call to `dangerous()` 