### PR TITLE
mdbook version used is now 0.4.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ See the [releases] to download just the code of all the code listings that appea
 
 ## Requirements
 
-Building the book requires [mdBook], ideally the same 0.3.x version that
+Building the book requires [mdBook], ideally the same 0.4.x version that
 rust-lang/rust uses in [this file][rust-mdbook]. To get it:
 
 [mdBook]: https://github.com/rust-lang-nursery/mdBook


### PR DESCRIPTION
We should update the documentation in README.md with the correct version of mdbook needed to compile the book.