### PR TITLE
Clarify Copy trait, "l" letter to quoted

### DIFF
--- a/src/ch04-01-what-is-ownership.md
+++ b/src/ch04-01-what-is-ownership.md
@@ -388,10 +388,13 @@ we add the `Copy` annotation to that type, we’ll get a compile-time error. To
 learn about how to add the `Copy` annotation to your type, see [“Derivable
 Traits”][derivable-traits]<!-- ignore --> in Appendix C.
 
-So what types are `Copy`? You can check the documentation for the given type to
-be sure, but as a general rule, any group of simple scalar values can be
-`Copy`, and nothing that requires allocation or is some form of resource is
-`Copy`. Here are some of the types that are `Copy`:
+So what types are `Copy`able? You can check the documentation for the given type to
+be sure, but as a general rule: 
+
+1. Any group of simple scalar values can have the `Copy` trait, 
+2. Nothing that requires allocation or is some form of resource is `Copy`able. 
+
+Here are some of the types that are `Copy`able:
 
 * All the integer types, such as `u32`.
 * The Boolean type, `bool`, with values `true` and `false`.

--- a/src/ch08-02-strings.md
+++ b/src/ch08-02-strings.md
@@ -130,7 +130,7 @@ If the `push_str` method took ownership of `s2`, we wouldn’t be able to print
 its value on the last line. However, this code works as we’d expect!
 
 The `push` method takes a single character as a parameter and adds it to the
-`String`. Listing 8-17 shows code that adds the letter *l* to a `String` using
+`String`. Listing 8-17 shows code that adds the letter "l" to a `String` using
 the `push` method.
 
 ```rust


### PR DESCRIPTION
Coming from a Python background, the trait system is still mostly a mystery for me, this wonderful book helping me along in the learning process. My unfamiliarity is why I needed to re-read this section again to see what was meant. A type as *being* "Copy" as an adjective collides with the common sense word "copy" being either a verb or a noun. Something is a copy of, or you copy from something to something else. The documentation should (I feel) reflect this not to confuse readers (as I was). I'm not sure whether the "ˋCopyˋable" semantics is congruent with Rust traits, having no experience with it, but I think it adds to the readability of this section.

Minor: remove italics to prevent letter "l" to appear as a slash.