### PR TITLE
Correct listing 11-10: Take tests module out of main function.

### DIFF
--- a/listings/ch11-writing-automated-tests/listing-11-10/src/lib.rs
+++ b/listings/ch11-writing-automated-tests/listing-11-10/src/lib.rs
@@ -1,3 +1,6 @@
+fn main() {}
+
+// ANCHOR: here
 fn prints_and_returns_10(a: i32) -> i32 {
     println!("I got the value {}", a);
     10
@@ -19,3 +22,4 @@ mod tests {
         assert_eq!(5, value);
     }
 }
+// ANCHOR_END: here

--- a/src/ch11-02-running-tests.md
+++ b/src/ch11-02-running-tests.md
@@ -62,7 +62,7 @@ parameter and returns 10, as well as a test that passes and a test that fails.
 <span class="filename">Filename: src/lib.rs</span>
 
 ```rust,panics
-{{#rustdoc_include ../listings/ch11-writing-automated-tests/listing-11-10/src/lib.rs}}
+{{#rustdoc_include ../listings/ch11-writing-automated-tests/listing-11-10/src/lib.rs:here}}
 ```
 
 <span class="caption">Listing 11-10: Tests for a function that calls


### PR DESCRIPTION
Listing 11-10 causes error[E0425]: cannot find function `prints_and_returns_10` in this scope. Taking the 'tests' module and the 'prints_and_returns_10' function out of the main function fixes this.