### PR TITLE
Correct no-listing-10-result-in-tests: Take tests module out of the main function

### DIFF
--- a/listings/ch11-writing-automated-tests/no-listing-10-result-in-tests/src/lib.rs
+++ b/listings/ch11-writing-automated-tests/no-listing-10-result-in-tests/src/lib.rs
@@ -1,3 +1,7 @@
+#![allow(unused_variables)]
+fn main() {}
+
+// ANCHOR: here
 #[cfg(test)]
 mod tests {
     #[test]
@@ -9,3 +13,4 @@ mod tests {
         }
     }
 }
+// ANCHOR_END: here

--- a/src/ch11-01-writing-tests.md
+++ b/src/ch11-01-writing-tests.md
@@ -507,7 +507,7 @@ that use `Result<T, E>`! Here’s the test from Listing 11-1, rewritten to use
 `Result<T, E>` and return an `Err` instead of panicking:
 
 ```rust
-{{#rustdoc_include ../listings/ch11-writing-automated-tests/no-listing-10-result-in-tests/src/lib.rs}}
+{{#rustdoc_include ../listings/ch11-writing-automated-tests/no-listing-10-result-in-tests/src/lib.rs:here}}
 ```
 
 The `it_works` function now has a return type, `Result<(), String>`. In the


### PR DESCRIPTION
no-listing-10-result-in-tests causes "warning: cannot test inner items". 
Taking the tests module out of the main function fixes this.