### PR TITLE
Make sentence in ch17-02 clearer

### DIFF
--- a/src/ch17-02-trait-objects.md
+++ b/src/ch17-02-trait-objects.md
@@ -147,8 +147,8 @@ might have fields for `width`, `height`, and `label`, as shown in Listing 17-7:
 
 The `width`, `height`, and `label` fields on `Button` will differ from the
 fields on other components, such as a `TextField` type, that might instead have
-have those fields plus a `placeholder` field. Each of the types we want to draw
-on the screen will implement the `Draw` trait but will use different code in the
+those fields plus a `placeholder` field. Each of the types we want to draw on
+the screen will implement the `Draw` trait but will use different code in the
 `draw` method to define how to draw that particular type, as `Button` has here
 (without the actual GUI code, which is beyond the scope of this chapter). The
 `Button` type, for instance, might have an additional `impl` block containing

--- a/src/ch17-02-trait-objects.md
+++ b/src/ch17-02-trait-objects.md
@@ -146,9 +146,9 @@ might have fields for `width`, `height`, and `label`, as shown in Listing 17-7:
 `Draw` trait</span>
 
 The `width`, `height`, and `label` fields on `Button` will differ from the
-fields on other components, such as a `TextField` type, that might have those
-fields plus a `placeholder` field instead. Each of the types we want to draw on
-the screen will implement the `Draw` trait but will use different code in the
+fields on other components, such as a `TextField` type, that might instead have
+have those fields plus a `placeholder` field. Each of the types we want to draw
+on the screen will implement the `Draw` trait but will use different code in the
 `draw` method to define how to draw that particular type, as `Button` has here
 (without the actual GUI code, which is beyond the scope of this chapter). The
 `Button` type, for instance, might have an additional `impl` block containing


### PR DESCRIPTION
Move the word "instead" within a sentence.

Original sentence:

> The width, height, and label fields on Button will differ from the fields on other components, such as a TextField type, that might have those fields plus a placeholder field instead.

On my first reading of this sentence, I interpreted it as follows:

"The width, height, and label fields on Button will differ from the fields on other components, such as a TextField type. A TextField type might have the same fields as a Button. Or another option is that a TextField has a placeholder field."

I propose moving the "instead" within the sentence, to read as follows:

> The width, height, and label fields on Button will differ from the fields on other components, such as a TextField type, that might instead have those fields plus a placeholder field.

In this way it's clear that the "instead" refers to all of (those fields plus a placeholder field), and not just to (plus a placeholder field).