### PR TITLE
Fix type mismatch in listing 10-5

### DIFF
--- a/listings/ch10-generic-types-traits-and-lifetimes/listing-10-05/src/main.rs
+++ b/listings/ch10-generic-types-traits-and-lifetimes/listing-10-05/src/main.rs
@@ -1,5 +1,5 @@
 fn largest<T>(list: &[T]) -> &T {
-    let mut largest = list[0];
+    let mut largest = &list[0];
 
     for item in list {
         if item > largest {


### PR DESCRIPTION
This pull request fixes a type mismatch in listing 10-5 caused by 43565d343bc4ca9a63896995031cd5c25591aa07.