### PR TITLE
Replace ChangeColor definition with actual RGB-compatible types

### DIFF
--- a/listings/ch06-enums-and-pattern-matching/no-listing-04-structs-similar-to-message-enum/src/main.rs
+++ b/listings/ch06-enums-and-pattern-matching/no-listing-04-structs-similar-to-message-enum/src/main.rs
@@ -5,7 +5,7 @@ struct MoveMessage {
     y: i32,
 }
 struct WriteMessage(String); // tuple struct
-struct ChangeColorMessage(i32, i32, i32); // tuple struct
+struct ChangeColorMessage(u8, u8, u8); // tuple struct
                                           // ANCHOR_END: here
 
 fn main() {}

--- a/listings/ch06-enums-and-pattern-matching/no-listing-05-methods-on-enums/src/main.rs
+++ b/listings/ch06-enums-and-pattern-matching/no-listing-05-methods-on-enums/src/main.rs
@@ -3,7 +3,7 @@ fn main() {
         Quit,
         Move { x: i32, y: i32 },
         Write(String),
-        ChangeColor(i32, i32, i32),
+        ChangeColor(u8, u8, u8),
     }
 
     // ANCHOR: here


### PR DESCRIPTION
In section 6.1, there are references to `ChangeColor` structs that accept `i32` values.
As we are probably talking about RGB values here, I believe these should be referred to as `u8` values.