### PR TITLE
Edit description of semantic versioning in chapter 2

### DIFF
--- a/src/ch02-00-guessing-game-tutorial.md
+++ b/src/ch02-00-guessing-game-tutorial.md
@@ -362,8 +362,8 @@ versions of those crates you require. In this case, we’ll specify the `rand`
 crate with the semantic version specifier `0.5.5`. Cargo understands [Semantic
 Versioning][semver]<!-- ignore --> (sometimes called *SemVer*), which is a
 standard for writing version numbers. The number `0.5.5` is actually shorthand
-for `^0.5.5`, which means “any version that has a public API compatible with
-version 0.5.5.”
+for `^0.5.5`, which means any version that is at least `0.5.5`, but below `0.6.0`.
+These versions are public API compatible with version 0.5.5.
 
 [semver]: http://semver.org
 


### PR DESCRIPTION
fixes #2435.

Should we add explanation about `=0.5.5`?