### PR TITLE
Unit test in chp 12-04 and 12-05 will fail based on "duct" query term

### DIFF
--- a/listings/ch12-an-io-project/listing-12-15/src/lib.rs
+++ b/listings/ch12-an-io-project/listing-12-15/src/lib.rs
@@ -36,7 +36,8 @@ mod tests {
         let contents = "\
 Rust:
 safe, fast, productive.
-Pick three.";
+Pick three.
+Duct tape.";
 
         assert_eq!(vec!["safe, fast, productive."], search(query, contents));
     }


### PR DESCRIPTION
Missing line in contents "Duct tape."  Without it, the test will still fail when search functionality is complete.  Ch12-05 shows the omitted line.