### PR TITLE
Remove dead code from chp 12 code listings

### DIFF
--- a/listings/ch12-an-io-project/listing-12-15/src/lib.rs
+++ b/listings/ch12-an-io-project/listing-12-15/src/lib.rs
@@ -42,5 +42,3 @@ Pick three.";
     }
 }
 // ANCHOR_END: here
-
-fn main() {}

--- a/listings/ch12-an-io-project/listing-12-16/src/lib.rs
+++ b/listings/ch12-an-io-project/listing-12-16/src/lib.rs
@@ -46,5 +46,3 @@ Pick three.";
         assert_eq!(vec!["safe, fast, productive."], search(query, contents));
     }
 }
-
-fn main() {}

--- a/listings/ch12-an-io-project/listing-12-20/src/lib.rs
+++ b/listings/ch12-an-io-project/listing-12-20/src/lib.rs
@@ -74,5 +74,3 @@ Trust me.";
     }
 }
 // ANCHOR_END: here
-
-fn main() {}

--- a/listings/ch12-an-io-project/listing-12-21/src/lib.rs
+++ b/listings/ch12-an-io-project/listing-12-21/src/lib.rs
@@ -90,5 +90,3 @@ Trust me.";
         );
     }
 }
-
-fn main() {}

--- a/listings/ch12-an-io-project/listing-12-22/src/lib.rs
+++ b/listings/ch12-an-io-project/listing-12-22/src/lib.rs
@@ -99,5 +99,3 @@ Trust me.";
         );
     }
 }
-
-fn main() {}

--- a/listings/ch12-an-io-project/listing-12-23/src/lib.rs
+++ b/listings/ch12-an-io-project/listing-12-23/src/lib.rs
@@ -108,5 +108,3 @@ Trust me.";
         );
     }
 }
-
-fn main() {}

--- a/listings/ch13-functional-features/listing-12-23-reproduced/src/lib.rs
+++ b/listings/ch13-functional-features/listing-12-23-reproduced/src/lib.rs
@@ -104,5 +104,3 @@ Trust me.";
         );
     }
 }
-
-fn main() {}

--- a/listings/ch13-functional-features/listing-13-27/src/lib.rs
+++ b/listings/ch13-functional-features/listing-13-27/src/lib.rs
@@ -109,5 +109,3 @@ Trust me.";
         );
     }
 }
-
-fn main() {}


### PR DESCRIPTION
Unnecessary trailing "fn main() {}" present in multiple listings for lib.rs