### PR TITLE
Get 'attribute' and '#' in table of contents

### DIFF
--- a/src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md
+++ b/src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md
@@ -288,4 +288,4 @@ library documentation](../std/prelude/index.html#other-preludes)<!-- ignore -->
 for more information on that pattern.
 
 [rand]: ch02-00-guessing-game-tutorial.html#generating-a-random-number
-[writing-tests]: ch11-01-writing-tests.html#how-to-write-tests
+[writing-tests]: ch11-01-writing-tests.html#how-to-write-tests---the-test-attribute

--- a/src/ch11-01-writing-tests.md
+++ b/src/ch11-01-writing-tests.md
@@ -1,4 +1,4 @@
-## How to Write Tests
+## How to Write Tests - the #[test] Attribute
 
 Tests are Rust functions that verify that the non-test code is functioning in
 the expected manner. The bodies of test functions typically perform these three


### PR DESCRIPTION
This simple change in the title of "How to Write Tests" allows newbies to search for either `#` or `attribute` in any copy of the book and find a starting point for understanding attributes, "[Those pound sign thingies](https://wh0.github.io/2017/11/28/rust-pound.html)"

Related to #1333 