### PR TITLE
ch14-03: Fix rand crate version mismatch in build log

### DIFF
--- a/src/ch14-03-cargo-workspaces.md
+++ b/src/ch14-03-cargo-workspaces.md
@@ -227,7 +227,7 @@ copy output below; the output updating script doesn't handle subdirectories in p
 ```console
 $ cargo build
     Updating crates.io index
-  Downloaded rand v0.5.5
+  Downloaded rand v0.5.6
    --snip--
    Compiling rand v0.5.6
    Compiling add-one v0.1.0 (file:///projects/add/add-one)


### PR DESCRIPTION
Note that following the comment's instructions give me a quite different output which I assume is meant to be cut manually to keep only what's relevant, so I just changed the version number:
```
$ cargo build
    Updating crates.io index
  Downloaded libc v0.2.77
  Downloaded rand v0.5.6
  Downloaded rand_core v0.3.1
  Downloaded rand_core v0.4.2
  Downloaded 4 crates (680.2 KB) in 0.62s
   Compiling libc v0.2.77
   Compiling rand_core v0.4.2
   Compiling rand_core v0.3.1
   Compiling rand v0.5.6
   Compiling add-one v0.1.0 (/home/akien/tmp/rust/book/listings/ch14-more-about-cargo/no-listing-03-workspace-with-external-dependency/add/add-one)
warning: unused import: `rand`
 --> add-one/src/lib.rs:1:5
  |
1 | use rand;
  |     ^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: 1 warning emitted

   Compiling adder v0.1.0 (/home/akien/tmp/rust/book/listings/ch14-more-about-cargo/no-listing-03-workspace-with-external-dependency/add/adder)
    Finished dev [unoptimized + debuginfo] target(s) in 3.27s
```