### PR TITLE
Balance curly brackets

### DIFF
--- a/listings/ch02-guessing-game-tutorial/no-listing-03-convert-string-to-number/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/no-listing-03-convert-string-to-number/src/main.rs
@@ -29,5 +29,5 @@ fn main() {
         Ordering::Greater => println!("Too big!"),
         Ordering::Equal => println!("You win!"),
     }
+    // ANCHOR_END: here
 }
-// ANCHOR_END: here


### PR DESCRIPTION
Moved an ANCHOR_END to prevent a spurious } showing up in the listing.