### PR TITLE
Use GITHUB_PATH instead of add-path

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       run: |
         mkdir bin
         curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.3.7/mdbook-v0.3.7-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=bin
-        echo "##[add-path]$(pwd)/bin"
+        echo "$(pwd)/bin" >> ${GITHUB_PATH}
     - name: Report versions
       run: |
         rustup --version
@@ -42,7 +42,7 @@ jobs:
       run: |
         mkdir bin
         curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.3.7/mdbook-v0.3.7-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=bin
-        echo "##[add-path]$(pwd)/bin"
+        echo "$(pwd)/bin" >> ${GITHUB_PATH}
     - name: Report versions
       run: |
         rustup --version


### PR DESCRIPTION
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

> Action and workflow authors who are setting environment variables via stdout should update any usage of the set-env and add-path workflow commands to use the new environment files.