### PR TITLE
Clarify code example ch6.3

### DIFF
--- a/listings/ch06-enums-and-pattern-matching/no-listing-12-if-let/src/main.rs
+++ b/listings/ch06-enums-and-pattern-matching/no-listing-12-if-let/src/main.rs
@@ -1,6 +1,6 @@
 fn main() {
-    let some_u8_value = Some(0u8);
     // ANCHOR: here
+    let some_u8_value = Some(0u8);
     if let Some(3) = some_u8_value {
         println!("three");
     }


### PR DESCRIPTION
I feel as if the line `let some_u8_value = Some(0u8);` should be included in the code example that follows Listing 6-6A for consistency and clarity reasons and not hidden.  Without this line, readers may not understand immediately that `some_u8_value` still needs to be instantiated (as this line is now hidden) and may instead think that `some_u8_value` is set to `Some(3)` within the if let statement.  

A screenshot of what I propose:

![image](https://user-images.githubusercontent.com/8109538/97206240-d7e78000-178e-11eb-82ea-31d7bf8b81f5.png)

Instead of:

![image](https://user-images.githubusercontent.com/8109538/97206294-e6359c00-178e-11eb-9328-add19084f99d.png)
