### PR TITLE
Change "appendixes" to "appendices" in intro.

### DIFF
--- a/src/ch00-00-introduction.md
+++ b/src/ch00-00-introduction.md
@@ -153,7 +153,7 @@ more about lifetimes, traits, types, functions, and closures.
 In Chapter 20, we’ll complete a project in which we’ll implement a low-level
 multithreaded web server!
 
-Finally, some appendixes contain useful information about the language in a
+Finally, some appendices contain useful information about the language in a
 more reference-like format. Appendix A covers Rust’s keywords, Appendix B
 covers Rust’s operators and symbols, Appendix C covers derivable traits
 provided by the standard library, Appendix D covers some useful development


### PR DESCRIPTION
As per https://en.wiktionary.org/wiki/appendix, the OED states that:

> Appendix typically has the plural appendixes in the anatomical sense, and appendices when referring to a part of a book or document.

To me, the use of "appendixes" in the text reads as incorrect. However, Mirriam-Webster doesn't seem to make a strong recommendation between the two, so it's possible that this sense of incorrectness stems from the fact that I'm a native British-English speaker.

I like to try to contribute small spelling and grammar fixes when I'm reading docs. However, this correction is perhaps a matter of personal style to some degree. I'd argue that fewer people will have the nagging sense of "that's a mistake" when reading "appendices" than "appendixes" though, so I'll put this change to the maintainers for consideration.