### PR TITLE
Change SipHash not found (404) link to SipHash in Wikipedia

### DIFF
--- a/src/ch08-03-hash-maps.md
+++ b/src/ch08-03-hash-maps.md
@@ -219,7 +219,7 @@ necessarily have to implement your own hasher from scratch;
 [crates.io](https://crates.io/) has libraries shared by other Rust users that
 provide hashers implementing many common hashing algorithms.
 
-[^siphash]: [https://www.131002.net/siphash/siphash.pdf](https://www.131002.net/siphash/siphash.pdf)
+[^siphash]: [https://en.wikipedia.org/wiki/SipHash](https://en.wikipedia.org/wiki/SipHash)
 
 ## Summary
 


### PR DESCRIPTION
#2502 Change link of SipHash PDF (404s) to Wikipedia.