### PR TITLE
Update 16-11 to use method call expression for `clone`

### DIFF
--- a/listings/ch16-fearless-concurrency/listing-16-11/src/main.rs
+++ b/listings/ch16-fearless-concurrency/listing-16-11/src/main.rs
@@ -8,7 +8,7 @@ fn main() {
 
     let (tx, rx) = mpsc::channel();
 
-    let tx1 = mpsc::Sender::clone(&tx);
+    let tx1 = tx.clone();
     thread::spawn(move || {
         let vals = vec![
             String::from("hi"),


### PR DESCRIPTION
Method call expressions:
```rust
let tx1 = tx.clone();
```
are more idiomatic that explicitly passing in `self`:
```rust
let tx1 = mpsc::Sender::clone(&tx);
```
So I updated the code snippet to reflect that. Note that this triggered [a question on stackoverflow](https://stackoverflow.com/questions/65024989/whats-the-differences-between-these-two-ways-of-cloning-a-sender-for-a-rust-cha/65025267#65025267) and the update should be more clear to beginners.