### PR TITLE
Correct chapter 20 final listing

### DIFF
--- a/listings/ch20-web-server/listing-20-25/src/bin/main.rs
+++ b/listings/ch20-web-server/listing-20-25/src/bin/main.rs
@@ -12,7 +12,7 @@ fn main() {
     let listener = TcpListener::bind("127.0.0.1:7878").unwrap();
     let pool = ThreadPool::new(4);
 
-    for stream in listener.incoming().take(2) {
+    for stream in listener.incoming() {
         let stream = stream.unwrap();
 
         pool.execute(|| {


### PR DESCRIPTION
In chapter 20 on writing a web server, one of the listings includes `.take(2)` on the TCP stream iterator to only handle 2 requests and then quit. This is as an example to demonstrate that the web server shuts down gracefully. However, this has slipped into the final code listing, which I don't think should include this arbitrary restriction. This pull request amends this error.