### PR TITLE
Remove leftover reference to previously removed code example in Ch 16-03.

### DIFF
--- a/src/ch16-03-shared-state.md
+++ b/src/ch16-03-shared-state.md
@@ -134,9 +134,7 @@ multiple-ownership method we discussed in Chapter 15.
 In Chapter 15, we gave a value multiple owners by using the smart pointer
 `Rc<T>` to create a reference counted value. Let’s do the same here and see
 what happens. We’ll wrap the `Mutex<T>` in `Rc<T>` in Listing 16-14 and clone
-the `Rc<T>` before moving ownership to the thread. Now that we’ve seen the
-errors, we’ll also switch back to using the `for` loop, and we’ll keep the
-`move` keyword with the closure.
+the `Rc<T>` before moving ownership to the thread.
 
 <span class="filename">Filename: src/main.rs</span>
 


### PR DESCRIPTION
When the _Sharing a Mutex Between Multiple Threads_ section was updated in #1779 a reference to the now removed unrolled example was leaked in the following section. This pull request addresses that by also removing this dangling reference.