### PR TITLE
Override toolchain to nightly for run lints action.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
       run: |
         rustup set profile minimal
         rustup toolchain install nightly -c rust-docs
-        rustup default nightly
+        rustup override set nightly
     - name: Install mdbook
       run: |
         mkdir bin


### PR DESCRIPTION
The run lints action fails at the _Check for broken links_ step. This happens because the `linkchecker` crate uses features only available on nightly but the toolchain in use is 1.48. The default toolchain is set in the _Install Rust_ step as nightly but this is overridden by the 1.48 toolchain set in the `rust-toolchain` file. Instead of setting the default toolchain, the toolchain needs to be overridden to overwrite the toolchain set by the `rust-toolchain` file.