### PR TITLE
Updated dead link.

### DIFF
--- a/second-edition/src/appendix-06-newest-features.md
+++ b/second-edition/src/appendix-06-newest-features.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](https://doc.rust-lang.org/1.30.0/book/second-edition/) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust


### PR DESCRIPTION
[Link](https://github.com/rust-lang/book/blob/master/second-edition/index.html) is dead, hence updated.