### PR TITLE
updates the rand gen range example

### DIFF
--- a/listings/ch02-guessing-game-tutorial/listing-02-03/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/listing-02-03/src/main.rs
@@ -8,7 +8,7 @@ fn main() {
     println!("Guess the number!");
 
     // ANCHOR: ch07-04
-    let secret_number = rand::thread_rng().gen_range(1, 101);
+    let secret_number = rand::thread_rng().gen_range(1..101);
     // ANCHOR_END: ch07-04
 
     println!("The secret number is: {}", secret_number);


### PR DESCRIPTION
It looks like this line:

    let secret_number = rand::thread_rng().gen_range(1, 101);

Does not work in the most recent Rust version:

latest update on 2020-11-19, rust version 1.48.0 (7eac88abb 2020-11-16)

I updated it based on this page and on the fact that it works correctly:

https://docs.rs/rand/0.8.1/rand/trait.Rng.html#example-1

Let me know if I did something wrong!