### PR TITLE
Removed 'of' between type alias in Ch 19-04.

### DIFF
--- a/src/ch19-04-advanced-types.md
+++ b/src/ch19-04-advanced-types.md
@@ -105,7 +105,7 @@ the `Write` trait:
 {{#rustdoc_include ../listings/ch19-advanced-features/no-listing-05-write-trait/src/lib.rs}}
 ```
 
-The `Result<..., Error>` is repeated a lot. As such, `std::io` has this type of
+The `Result<..., Error>` is repeated a lot. As such, `std::io` has this type
 alias declaration:
 
 ```rust,noplayground


### PR DESCRIPTION
The existing syntax may not be incorrect, but the 'of' is unnecessary and slightly erroneous.