### PR TITLE
fixed ferris in ch03-02 - code now compiles but panics

### DIFF
--- a/src/ch03-02-data-types.md
+++ b/src/ch03-02-data-types.md
@@ -329,7 +329,7 @@ similar to the guessing game in Chapter 2 to get an array index from the user:
 
 <span class="filename">Filename: src/main.rs</span>
 
-```rust,ignore,does_not_compile
+```rust,ignore,panics
 {{#rustdoc_include ../listings/ch03-common-programming-concepts/no-listing-15-invalid-array-access/src/main.rs}}
 ```
 


### PR DESCRIPTION
The index-out-of bounds example in ch3-02 was recently changed and now compiles but panics. Changed Ferris to match.