### PR TITLE
Updated use of range to use .. notation

### DIFF
--- a/listings/ch02-guessing-game-tutorial/listing-02-03/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/listing-02-03/src/main.rs
@@ -8,7 +8,7 @@ fn main() {
     println!("Guess the number!");
 
     // ANCHOR: ch07-04
-    let secret_number = rand::thread_rng().gen_range(1, 101);
+    let secret_number = rand::thread_rng().gen_range(1..101);
     // ANCHOR_END: ch07-04
 
     println!("The secret number is: {}", secret_number);

--- a/listings/ch02-guessing-game-tutorial/listing-02-04/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/listing-02-04/src/main.rs
@@ -8,7 +8,7 @@ fn main() {
     // ANCHOR_END: here
     println!("Guess the number!");
 
-    let secret_number = rand::thread_rng().gen_range(1, 101);
+    let secret_number = rand::thread_rng().gen_range(1..101);
 
     println!("The secret number is: {}", secret_number);
 

--- a/listings/ch02-guessing-game-tutorial/listing-02-05/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/listing-02-05/src/main.rs
@@ -5,7 +5,7 @@ use std::io;
 fn main() {
     println!("Guess the number!");
 
-    let secret_number = rand::thread_rng().gen_range(1, 101);
+    let secret_number = rand::thread_rng().gen_range(1..101);
 
     println!("The secret number is: {}", secret_number);
 

--- a/listings/ch02-guessing-game-tutorial/listing-02-06/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/listing-02-06/src/main.rs
@@ -5,7 +5,7 @@ use std::io;
 fn main() {
     println!("Guess the number!");
 
-    let secret_number = rand::thread_rng().gen_range(1, 101);
+    let secret_number = rand::thread_rng().gen_range(1..101);
 
     loop {
         println!("Please input your guess.");

--- a/listings/ch02-guessing-game-tutorial/no-listing-03-convert-string-to-number/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/no-listing-03-convert-string-to-number/src/main.rs
@@ -5,7 +5,7 @@ use std::io;
 fn main() {
     println!("Guess the number!");
 
-    let secret_number = rand::thread_rng().gen_range(1, 101);
+    let secret_number = rand::thread_rng().gen_range(1..101);
 
     println!("The secret number is: {}", secret_number);
 

--- a/listings/ch02-guessing-game-tutorial/no-listing-04-looping/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/no-listing-04-looping/src/main.rs
@@ -5,7 +5,7 @@ use std::io;
 fn main() {
     println!("Guess the number!");
 
-    let secret_number = rand::thread_rng().gen_range(1, 101);
+    let secret_number = rand::thread_rng().gen_range(1..101);
 
     // ANCHOR: here
     // --snip--

--- a/listings/ch02-guessing-game-tutorial/no-listing-05-quitting/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/no-listing-05-quitting/src/main.rs
@@ -5,7 +5,7 @@ use std::io;
 fn main() {
     println!("Guess the number!");
 
-    let secret_number = rand::thread_rng().gen_range(1, 101);
+    let secret_number = rand::thread_rng().gen_range(1..101);
 
     println!("The secret number is: {}", secret_number);
 


### PR DESCRIPTION
Working through the book online and noticed an error with the `gen_range()` function. It expects a single argument using `..` notation but the guide uses a `,` and thus provides 2 arguments, this fixes that and removes any errors on running.