### PR TITLE
Change 'text' formatting to 'console' on console code blocks

### DIFF
--- a/src/ch01-02-hello-world.md
+++ b/src/ch01-02-hello-world.md
@@ -155,7 +155,7 @@ entering the `ls` command in your shell. On Linux and macOS, you’ll see two
 files. With PowerShell on Windows, you’ll see the same three files that you
 would see using CMD.
 
-```text
+```console
 $ ls
 main  main.rs
 ```

--- a/src/ch12-06-writing-to-stderr-instead-of-stdout.md
+++ b/src/ch12-06-writing-to-stderr-instead-of-stdout.md
@@ -66,7 +66,7 @@ instead of standard output using `eprintln!`</span>
 After changing `println!` to `eprintln!`, let’s run the program again in the
 same way, without any arguments and redirecting standard output with `>`:
 
-```text
+```console
 $ cargo run > output.txt
 Problem parsing arguments: not enough arguments
 ```


### PR DESCRIPTION
Now, we can see the red `$` element :-)

<img width="766" alt="image" src="https://user-images.githubusercontent.com/1079279/107881850-6d498400-6ee6-11eb-8fdd-5f7ed791a74f.png">

<img width="764" alt="image" src="https://user-images.githubusercontent.com/1079279/107881814-3ffcd600-6ee6-11eb-8919-b007db0b6ae4.png">

