### PR TITLE
fix misleading hash claim

### DIFF
--- a/src/ch08-03-hash-maps.md
+++ b/src/ch08-03-hash-maps.md
@@ -207,8 +207,8 @@ loop, so all of these changes are safe and allowed by the borrowing rules.
 
 ### Hashing Functions
 
-By default, `HashMap` uses a “cryptographically strong”[^siphash] hashing
-function that can provide resistance to Denial of Service (DoS) attacks. This
+By default, `HashMap` uses a hashing function called SipHash that can provide 
+resistance to Denial of Service (DoS) attacks involving hash tables[^siphash]. This
 is not the fastest hashing algorithm available, but the trade-off for better
 security that comes with the drop in performance is worth it. If you profile
 your code and find that the default hash function is too slow for your


### PR DESCRIPTION
I am concerned that this statement will mislead users about the security properties of SipHash, causing them to introduce security flaws in their implementations. I would assume based on the "cryptographically strong" claim that it was a general-purpose cryptographically secure hashing function, but the second sentence in the reference contradicts this conclusion: "SipHash is fundamentally different from cryptographic hash functions like SHA in that it is only suitable as a message authentication code". Indeed, SipHash depends on a private key for its security claims and therefore is inappropriate in many hashing applications.