### PR TITLE
minor clarification about deriving Copy and Clone

### DIFF
--- a/src/appendix-03-derivable-traits.md
+++ b/src/appendix-03-derivable-traits.md
@@ -134,10 +134,10 @@ overloading those methods and violating the assumption that no arbitrary code
 is being run. That way, all programmers can assume that copying a value will be
 very fast.
 
-You can derive `Copy` on any type whose parts all implement `Copy`. You can
-only apply the `Copy` trait to types that also implement `Clone`, because a
-type that implements `Copy` has a trivial implementation of `Clone` that
-performs the same task as `Copy`.
+You can derive `Copy` on any type whose parts all implement `Copy`. A type that
+implements `Copy` must also implement `Clone`, because a type that implements
+`Copy` has a trivial implementation of `Clone` that performs the same task as
+`Copy`.
 
 The `Copy` trait is rarely required; types that implement `Copy` have
 optimizations available, meaning you don’t have to call `clone`, which makes


### PR DESCRIPTION
Please feel free to reject this, but I found this sentence to be very confusing. I didn't understand the connection between the first sentence ("You can derive Copy on any type whose ...") with the next ("You can only apply the Copy trait ..."). I had to read the reference, and found its explanation to be clearer:

https://doc.rust-lang.org/std/marker/trait.Copy.html

"Clone is a supertrait of Copy, so everything which is Copy must also implement Clone. If a type is Copy then its Clone implementation only needs to return *self (see the example above)."

I'm not sure we need to get into the supertrait part, but I tried to make the explanation here similar to the reference versions.