### PR TITLE
Fix visible "ANCHOR: here" in listing 13-21

### DIFF
--- a/src/ch13-02-iterators.md
+++ b/src/ch13-02-iterators.md
@@ -262,7 +262,7 @@ iterator is used, as shown in Listing 13-21:
 <span class="filename">Filename: src/lib.rs</span>
 
 ```rust,noplayground
-{{#rustdoc_include ../listings/ch13-functional-features/listing-13-21/src/lib.rs}}
+{{#rustdoc_include ../listings/ch13-functional-features/listing-13-21/src/lib.rs:here}}
 ```
 
 <span class="caption">Listing 13-21: Implementing the `Iterator` trait on our


### PR DESCRIPTION
Listing 13-21 in Chapter 13.2 is currently showing `ANCHOR: here` and `ANCHOR_END: here` markers, perhaps unintentionally so: https://doc.rust-lang.org/book/ch13-02-iterators.html
```rust
struct Counter {
    count: u32,
}

impl Counter {
    fn new() -> Counter {
        Counter { count: 0 }
    }
}

// ANCHOR: here
impl Iterator for Counter {
    type Item = u32;

    fn next(&mut self) -> Option<Self::Item> {
        if self.count < 5 {
            self.count += 1;
            Some(self.count)
        } else {
            None
        }
    }
}
// ANCHOR_END: here
```

I'm not familiar with the `#rustdoc_include` semantics, so this is my attempt to suggest a fix based on how the neighboring listings appear to be set up.