### PR TITLE
Clarify the immutability of a reference

### DIFF
--- a/src/ch16-04-extensible-concurrency-sync-and-send.md
+++ b/src/ch16-04-extensible-concurrency-sync-and-send.md
@@ -33,9 +33,9 @@ we’ll discuss in Chapter 19.
 
 The `Sync` marker trait indicates that it is safe for the type implementing
 `Sync` to be referenced from multiple threads. In other words, any type `T` is
-`Sync` if `&T` (a reference to `T`) is `Send`, meaning the reference can be
-sent safely to another thread. Similar to `Send`, primitive types are `Sync`,
-and types composed entirely of types that are `Sync` are also `Sync`.
+`Sync` if `&T` (an immutable reference to `T`) is `Send`, meaning the reference
+can be sent safely to another thread. Similar to `Send`, primitive types are
+`Sync`, and types composed entirely of types that are `Sync` are also `Sync`.
 
 The smart pointer `Rc<T>` is also not `Sync` for the same reasons that it’s not
 `Send`. The `RefCell<T>` type (which we talked about in Chapter 15) and the


### PR DESCRIPTION
The clarification of immutability helped me a great deal with understanding when I was reading through the Tokio [tutorial](https://tokio.rs/tokio/tutorial/async#updating-mini-tokio).