### PR TITLE
Added an example of slicing result

### DIFF
--- a/src/ch04-03-slices.md
+++ b/src/ch04-03-slices.md
@@ -281,6 +281,8 @@ to part of an array. We’d do so like this:
 let a = [1, 2, 3, 4, 5];
 
 let slice = &a[1..3];
+
+assert_eq!(slice, &[2, 3]);
 ```
 
 This slice has the type `&[i32]`. It works the same way as string slices do, by


### PR DESCRIPTION
This should make it clearer how slicing works.

Context: I woke up recently with my head hurting and wanted to do some coding in Rust. Strangely, despite years of Rust experience I couldn't remember whether `arr[a..b].len() == b` or `arr[a..b].len() == b - a` and surprisingly I couldn't find quick and clear answer that my hurting head could understand.

It seems that almost everyone including me does `[..pos]` and `[pos..]` most of the time until we don't... Yes, I know I shouldn't probably do coding in my mental state and maybe not even contribute but I love this language too much to stay quiet when I see something missing in the docs...