### PR TITLE
Change someurl.com to example.org

### DIFF
--- a/src/ch01-03-hello-cargo.md
+++ b/src/ch01-03-hello-cargo.md
@@ -223,7 +223,7 @@ existing projects, you can use the following commands to check out the code
 using Git, change to that project’s directory, and build:
 
 ```console
-$ git clone someurl.com/someproject
+$ git clone example.org/someproject
 $ cd someproject
 $ cargo build
 ```


### PR DESCRIPTION
Using `example.org` is more appropriate as it is reserved by IANA for use in documentation.