### PR TITLE
correct the signature of the `deref` method

### DIFF
--- a/listings/ch15-smart-pointers/listing-15-10/src/main.rs
+++ b/listings/ch15-smart-pointers/listing-15-10/src/main.rs
@@ -4,7 +4,7 @@ use std::ops::Deref;
 impl<T> Deref for MyBox<T> {
     type Target = T;
 
-    fn deref(&self) -> &T {
+    fn deref(&self) -> &Self::Target {
         &self.0
     }
 }


### PR DESCRIPTION
change `fn deref(&self) -> &T` to `fn deref(&self) -> &Self::Target`.