### PR TITLE
Update ch05-02-example-structs.md

### DIFF
--- a/src/ch05-02-example-structs.md
+++ b/src/ch05-02-example-structs.md
@@ -191,7 +191,7 @@ When we use the `{:#?}` style in the example, the output will look like this:
 
 Rust has provided a number of traits for us to use with the `derive` annotation
 that can add useful behavior to our custom types. Those traits and their
-behaviors are listed in [Appendix C][app-c]<!-- ignore -->. We’ll cover how to
+behaviors are listed in [Appendix C][appendix_c]<!-- ignore -->. We’ll cover how to
 implement these traits with custom behavior as well as how to create your own
 traits in Chapter 10.
 
@@ -202,4 +202,4 @@ continue to refactor this code by turning the `area` function into an `area`
 *method* defined on our `Rectangle` type.
 
 [the-tuple-type]: ch03-02-data-types.html#the-tuple-type
-[app-c]: appendix-03-derivable-traits.md
+[appendix_c: appendix-03-derivable-traits.md


### PR DESCRIPTION
Making reference to Appendix C for continuous reading without having to look for Appendix C this resembles what has been done in the previous sections. e.g. see https://github.com/rust-lang/book/blob/master/src/ch03-00-common-programming-concepts.md and, currently Appendix C doesn't reference to the page of Appendix C when it is clicked, see https://doc.rust-lang.org/book/ch05-02-example-structs.html second last paragraph to test it