### PR TITLE
Replace 'which'.

### DIFF
--- a/src/ch15-04-rc.md
+++ b/src/ch15-04-rc.md
@@ -9,9 +9,9 @@ edges pointing to it.
 
 To enable multiple ownership, Rust has a type called `Rc<T>`, which is an
 abbreviation for *reference counting*. The `Rc<T>` type keeps track of the
-number of references to a value which determines whether or not a value is
-still in use. If there are zero references to a value, the value can be cleaned
-up without any references becoming invalid.
+number of references to a value to determine whether or not the value is still
+in use. If there are zero references to a value, the value can be cleaned up
+without any references becoming invalid.
 
 Imagine `Rc<T>` as a TV in a family room. When one person enters to watch TV,
 they turn it on. Others can come into the room and watch the TV. When the last


### PR DESCRIPTION
The lack of a comma before `which` almost suggests that there are two values: the user value and a second value, references to which are being counted (although in this case, `which` should be `that`.)

Adding a comma before `which` is better, but it looks awkward because what follows is typically a [nonrestrictive phrase](https://www.grammarly.com/blog/comma-before-which/).

The proposed change is to say `to determine`, which addresses the confusion and keeps the reading fast by removing the need for a comma (the comma before `which` in this sentence is an accidental pun, sorry.) Also, replacing the second use of `a value` with `the value` makes it clear that we are still talking about the same value.