### PR TITLE
Complementing the list of types that implement the Copy trait

### DIFF
--- a/src/ch04-01-what-is-ownership.md
+++ b/src/ch04-01-what-is-ownership.md
@@ -401,6 +401,7 @@ implement `Copy`:
 * The character type, `char`.
 * Tuples, if they only contain types that also implement `Copy`. For example,
   `(i32, i32)` implements `Copy`, but `(i32, String)` does not.
+* Arrays, if the element type implement `Copy`.
 
 ### Ownership and Functions
 


### PR DESCRIPTION
Since the array type already has been introduced at this point in the book, I think it is wrong not to mention it in this introductory list of Copy trait types.