### PR TITLE
Improve example

### DIFF
--- a/src/ch02-00-guessing-game-tutorial.md
+++ b/src/ch02-00-guessing-game-tutorial.md
@@ -711,7 +711,7 @@ comparison will be between two values of the same type!
 [parse]: ../std/primitive.str.html#method.parse
 
 The call to `parse` could easily cause an error. If, for example, the string
-contained `A👍%`, there would be no way to convert that to a number. Because it
+contained a `👍`, there would be no way to convert that to a number. Because it
 might fail, the `parse` method returns a `Result` type, much as the `read_line`
 method does (discussed earlier in [“Handling Potential Failure with the
 `Result` Type”](#handling-potential-failure-with-the-result-type)<!-- ignore


### PR DESCRIPTION
I don't know if this was intentional or a typo, but, as a beginner, I thought `A👍%` was kinda weird as an exemple. Am I missing something?