### PR TITLE
ch15-03-drop: use underscore for unused variable

### DIFF
--- a/listings/ch15-smart-pointers/listing-15-14/src/main.rs
+++ b/listings/ch15-smart-pointers/listing-15-14/src/main.rs
@@ -9,10 +9,10 @@ impl Drop for CustomSmartPointer {
 }
 
 fn main() {
-    let c = CustomSmartPointer {
+    let _c = CustomSmartPointer {
         data: String::from("my stuff"),
     };
-    let d = CustomSmartPointer {
+    let _d = CustomSmartPointer {
         data: String::from("other stuff"),
     };
     println!("CustomSmartPointers created.");


### PR DESCRIPTION
Fix 2 warnings about unused variable `c` and `d`.

Signed-off-by: Wei Fu <fuweid89@gmail.com>