### PR TITLE
Showing wrong ferris for code block `ch03-02-data-types`

### DIFF
--- a/src/ch03-02-data-types.md
+++ b/src/ch03-02-data-types.md
@@ -329,7 +329,7 @@ similar to the guessing game in Chapter 2 to get an array index from the user:
 
 <span class="filename">Filename: src/main.rs</span>
 
-```rust,ignore,panics
+```rust,panics,noplayground
 {{#rustdoc_include ../listings/ch03-common-programming-concepts/no-listing-15-invalid-array-access/src/main.rs}}
 ```
 


### PR DESCRIPTION
On [3.2 Data Types](https://doc.rust-lang.org/stable/book/ch03-02-data-types.html) at the bottom there is a code block that explicitly states that it compiles and that it causes a panic, and the [markdown](https://raw.githubusercontent.com/rust-lang/book/master/src/ch03-02-data-types.md) agrees, but the Ferris that is shown is one that is for a compile error.

```
'''rust,ignore,panics
{{#rustdoc_include ../listings/ch03-common-programming-concepts/no-listing-15-invalid-array-access/src/main.rs}}
'''
```

Yet the class applied to the code block for ferris.js is actually `does_not_compile`.

**Looking at [11.1](https://raw.githubusercontent.com/rust-lang/book/master/src/ch11-01-writing-tests.md) and [11.2](https://raw.githubusercontent.com/rust-lang/book/master/src/ch11-02-running-tests.md) they both have playground disabled and show panicked Ferris correctly with `rust,panics,noplayground`.**  
However I don't know why this would solve the issue, but I couldn't find any other instances of using `ignore` with a non-compile error Ferris to get the wrong one.

_[8.1](https://raw.githubusercontent.com/rust-lang/book/master/src/ch08-01-vectors.md) and [9.1](https://raw.githubusercontent.com/rust-lang/book/master/src/ch09-01-unrecoverable-errors-with-panic.md) panic and allow playground with `rust,should_panic,panics`_