### PR TITLE
ch09-error-handling Fix file open example with match.

### DIFF
--- a/listings/ch09-error-handling/listing-09-04/src/main.rs
+++ b/listings/ch09-error-handling/listing-09-04/src/main.rs
@@ -3,7 +3,7 @@ use std::fs::File;
 fn main() {
     let f = File::open("hello.txt");
 
-    let f = match f {
+    match f {
         Ok(file) => file,
         Err(error) => panic!("Problem opening the file: {:?}", error),
     };

--- a/listings/ch09-error-handling/listing-09-05/src/main.rs
+++ b/listings/ch09-error-handling/listing-09-05/src/main.rs
@@ -4,7 +4,7 @@ use std::io::ErrorKind;
 fn main() {
     let f = File::open("hello.txt");
 
-    let f = match f {
+    match f {
         Ok(file) => file,
         Err(error) => match error.kind() {
             ErrorKind::NotFound => match File::create("hello.txt") {


### PR DESCRIPTION
Code was throwing an unused variable warning with `let f =` in front of match