### PR TITLE
Compiler error messages: reduce assertiveness of message E0384

### DIFF
--- a/listings/ch03-common-programming-concepts/no-listing-01-variables-are-immutable/output.txt
+++ b/listings/ch03-common-programming-concepts/no-listing-01-variables-are-immutable/output.txt
@@ -7,7 +7,7 @@ error[E0384]: cannot assign twice to immutable variable `x`
   |         -
   |         |
   |         first assignment to `x`
-  |         help: make this binding mutable: `mut x`
+  |         help: consider making this binding mutable: `mut x`
 3 |     println!("The value of x is: {}", x);
 4 |     x = 6;
   |     ^^^^^ cannot assign twice to immutable variable


### PR DESCRIPTION
This message is emitted as guidance by the compiler when a developer attempts to reassign a value to an immutable variable.  Following the message will always currently work, but it may not always be the best course of action; following the 'consider ...' messaging pattern provides a hint to the developer that it could be wise to explore other alternatives.

Relates to rust-lang/rust#84144