### PR TITLE
off-by-one error

### DIFF
--- a/src/ch04-03-slices.md
+++ b/src/ch04-03-slices.md
@@ -119,7 +119,7 @@ in the slice and `ending_index` is one more than the last position in the
 slice. Internally, the slice data structure stores the starting position and
 the length of the slice, which corresponds to `ending_index` minus
 `starting_index`. So in the case of `let world = &s[6..11];`, `world` would be
-a slice that contains a pointer to the 7th byte (counting from 1) of `s` with a length value of 5.
+a slice that contains a pointer to the 7th byte (counting from 0) of `s` with a length value of 5.
 
 Figure 4-6 shows this in a diagram.
 


### PR DESCRIPTION
`let world = &s[6.11];`, 6 is the 7th byte from 0, not from 1