### PR TITLE
Precise that the `...` inclusive range pattern has been replaces

### DIFF
--- a/src/appendix-02-operators.md
+++ b/src/appendix-02-operators.md
@@ -42,7 +42,7 @@ overload that operator is listed.
 | `..=` | `..=expr`, `expr..=expr` | Right-inclusive range literal | |
 | `..` | `..expr` | Struct literal update syntax | |
 | `..` | `variant(x, ..)`, `struct_type { x, .. }` | “And the rest” pattern binding | |
-| `...` | `expr...expr` | In a pattern: inclusive range pattern | |
+| `...` | `expr...expr` | In a pattern: inclusive range pattern (now replaced with `..=`) | |
 | `/` | `expr / expr` | Arithmetic division | `Div` |
 | `/=` | `var /= expr` | Arithmetic division and assignment | `DivAssign` |
 | `:` | `pat: type`, `ident: type` | Constraints | |


### PR DESCRIPTION
It has been deprecated and the compiler suggests to replace it.

Having it without warning in the list is source of confusion. See https://stackoverflow.com/q/67370919/263525