### PR TITLE
Update Chapter 3.2 Data types

### DIFF
--- a/src/ch03-02-data-types.md
+++ b/src/ch03-02-data-types.md
@@ -29,7 +29,7 @@ You’ll see different type annotations for other data types.
 ### Scalar Types
 
 A *scalar* type represents a single value. Rust has five primary scalar types:
-integers, floating-point numbers, Booleans, and characters. You may recognize
+integers, floating-point numbers, booleans, and characters. You may recognize
 these from other programming languages. Let’s jump into how they work in Rust.
 
 #### Integer Types

--- a/src/ch03-02-data-types.md
+++ b/src/ch03-02-data-types.md
@@ -28,7 +28,7 @@ You’ll see different type annotations for other data types.
 
 ### Scalar Types
 
-A *scalar* type represents a single value. Rust has four primary scalar types:
+A *scalar* type represents a single value. Rust has five primary scalar types:
 integers, floating-point numbers, Booleans, and characters. You may recognize
 these from other programming languages. Let’s jump into how they work in Rust.
 


### PR DESCRIPTION
Hello rust community 👋🏼 

I'm new to Rust and as I was reading Chapter 3.2 I found a few inconsistencies?

The chapter says: 
> Rust has four primary scalar types: integers, floating-point numbers, Booleans, and characters

I count that as five scalar types, this PR wants to correct this, and also patch the capital B in boolean to be lower-cased.

If my assumptions are wrong I'm sorry, feel free to just close this PR then.