### PR TITLE
Use format strings for panic! calls of tools

### DIFF
--- a/tools/src/bin/convert_quotes.rs
+++ b/tools/src/bin/convert_quotes.rs
@@ -8,7 +8,7 @@ fn main() {
 
     let mut buffer = String::new();
     if let Err(e) = io::stdin().read_to_string(&mut buffer) {
-        panic!(e);
+        panic!("{}", e);
     }
 
     for line in buffer.lines() {

--- a/tools/src/bin/link2print.rs
+++ b/tools/src/bin/link2print.rs
@@ -14,7 +14,7 @@ fn read_md() -> String {
     let mut buffer = String::new();
     match io::stdin().read_to_string(&mut buffer) {
         Ok(_) => buffer,
-        Err(error) => panic!(error),
+        Err(error) => panic!("{}", error),
     }
 }
 

--- a/tools/src/bin/remove_hidden_lines.rs
+++ b/tools/src/bin/remove_hidden_lines.rs
@@ -9,7 +9,7 @@ fn read_md() -> String {
     let mut buffer = String::new();
     match io::stdin().read_to_string(&mut buffer) {
         Ok(_) => buffer,
-        Err(error) => panic!(error),
+        Err(error) => panic!("{}", error),
     }
 }
 

--- a/tools/src/bin/remove_links.rs
+++ b/tools/src/bin/remove_links.rs
@@ -8,7 +8,7 @@ use std::io::{Read, Write};
 fn main() {
     let mut buffer = String::new();
     if let Err(e) = io::stdin().read_to_string(&mut buffer) {
-        panic!(e);
+        panic!("{}", e);
     }
 
     let mut refs = HashSet::new();

--- a/tools/src/bin/remove_markup.rs
+++ b/tools/src/bin/remove_markup.rs
@@ -12,7 +12,7 @@ fn read_md() -> String {
     let mut buffer = String::new();
     match io::stdin().read_to_string(&mut buffer) {
         Ok(_) => buffer,
-        Err(error) => panic!(error),
+        Err(error) => panic!("{}", error),
     }
 }
 


### PR DESCRIPTION
Calling `panic!` with an arbitrary payload instead of a format string is currently a warning, and will be an error in the Rust 2021 Edition. 