### PR TITLE
Newtype fixes

### DIFF
--- a/src/ch19-03-advanced-traits.md
+++ b/src/ch19-03-advanced-traits.md
@@ -137,8 +137,10 @@ the `Add` trait where we want to customize the `Rhs` type rather than using the
 default.
 
 We have two structs, `Millimeters` and `Meters`, holding values in different
-units. We want to add values in millimeters to values in meters and have the
-implementation of `Add` do the conversion correctly. We can implement `Add` for
+units. (This thin wrapping of an existing type in another struct is known as
+the *newtype pattern*, which we describe in more detail later.) We want
+to add values in millimeters to values in meters and have the implementation
+of `Add` do the conversion correctly. We can implement `Add` for
 `Millimeters` with `Meters` as the `Rhs`, as shown in Listing 19-15.
 
 <span class="filename">Filename: src/lib.rs</span>

--- a/src/ch19-03-advanced-traits.md
+++ b/src/ch19-03-advanced-traits.md
@@ -416,7 +416,8 @@ will have one field and be a thin wrapper around the type we want to implement
 a trait for. Then the wrapper type is local to our crate, and we can implement
 the trait on the wrapper. *Newtype* is a term that originates from the Haskell
 programming language. There is no runtime performance penalty for using this
-pattern, and the wrapper type is elided at compile time.
+pattern, and the wrapper type is elided at compile time. (Although Haskell
+*does* have dedicated syntax for creating a newtype, Rust does not.)
 
 As an example, let’s say we want to implement `Display` on `Vec<T>`, which the
 orphan rule prevents us from doing directly because the `Display` trait and the

--- a/src/ch19-04-advanced-types.md
+++ b/src/ch19-04-advanced-types.md
@@ -6,11 +6,11 @@ examine why newtypes are useful as types. Then we’ll move on to type aliases, 
 feature similar to newtypes but with slightly different semantics. We’ll also
 discuss the `!` type and dynamically sized types.
 
-> Note: The next section assumes you’ve read the earlier section [“Using the
+### Using the Newtype Pattern for Type Safety and Abstraction
+
+> Note: This section assumes you’ve read the earlier section [“Using the
 > Newtype Pattern to Implement External Traits on External
 > Types.”][using-the-newtype-pattern]<!-- ignore -->
-
-### Using the Newtype Pattern for Type Safety and Abstraction
 
 The newtype pattern is useful for tasks beyond those we’ve discussed so far,
 including statically enforcing that values are never confused and indicating


### PR DESCRIPTION
Improve cross-references related to the newtype pattern. Mention that Rust (unlike Haskell) doesn't have dedicated syntax for newtype.

Closes #2726.