### PR TITLE
Remove visible ANCHOR comments

### DIFF
--- a/listings/ch14-more-about-cargo/listing-14-03/src/lib.rs
+++ b/listings/ch14-more-about-cargo/listing-14-03/src/lib.rs
@@ -25,8 +25,6 @@ pub mod utils {
     /// a secondary color.
     pub fn mix(c1: PrimaryColor, c2: PrimaryColor) -> SecondaryColor {
         // --snip--
-        // ANCHOR_END: here
         SecondaryColor::Orange
-        // ANCHOR: here
     }
 }


### PR DESCRIPTION
There are currently visible `ANCHOR_END: here`/`ANCHOR: here` comments in "Publishing a Crate to Crates.io":

<img width="356" alt="Screen Shot 2021-05-28 at 12 35 28 PM" src="https://user-images.githubusercontent.com/440230/120017241-a4363800-bfb3-11eb-9aaa-da8a27ba1562.png">

This PR removes those comments entirely since it seems correct for that code listing to show the entire `kinds` + `utils` modules and from a bit of reading I see that `ANCHOR`/`ANCHOR_END` would be used to only show that subsection of the code snippet (also the `ANCHOR_END` comment currently _precedes_ the `ANCHOR` comment, so I don't think they'd be usable as-is anyway?)