### PR TITLE
Reword number of library crates a package contains

### DIFF
--- a/src/ch07-01-packages-and-crates.md
+++ b/src/ch07-01-packages-and-crates.md
@@ -8,8 +8,8 @@ Privacy”][modules]<!-- ignore --> section). A *package* is one or more crates
 that provide a set of functionality. A package contains a *Cargo.toml* file
 that describes how to build those crates.
 
-Several rules determine what a package can contain. A package *must* contain
-zero or one library crates, and no more. It can contain as many binary crates
+Several rules determine what a package can contain. A package can contain
+at most one library crate. It can contain as many binary crates
 as you’d like, but it must contain at least one crate (either library or
 binary).
 


### PR DESCRIPTION
Previous wording is confusing because
1. "zero or one" and "no more" are redundant.
2. "must" and "zero or one" are contradictory. If one is not required, why is there a "must"?