### PR TITLE
Link to the object safety section in the reference

### DIFF
--- a/src/ch17-02-trait-objects.md
+++ b/src/ch17-02-trait-objects.md
@@ -305,10 +305,12 @@ We would get this error:
 ```
 
 This error means you can’t use this trait as a trait object in this way. If
-you’re interested in more details on object safety, see [Rust RFC 255].
+you’re interested in more details on object safety, see [Rust RFC 255] or check the
+object safety section in the [reference][object-safety-reference].
 
 [Rust RFC 255]: https://github.com/rust-lang/rfcs/blob/master/text/0255-object-safety.md
 
 [performance-of-code-using-generics]:
 ch10-01-syntax.html#performance-of-code-using-generics
 [dynamically-sized]: ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait
+[object-safety-reference]: https://doc.rust-lang.org/reference/items/traits.html#object-safety


### PR DESCRIPTION
This makes it easier to find the [reference](https://doc.rust-lang.org/reference/items/traits.html#object-safety)'s section on object safety. I found this section very helpful, as it gives clear examples on what is allowed and isn't.