### PR TITLE
Provide a link to API docs regarding intrinsics safety mechanisms

### DIFF
--- a/src/ch03-02-data-types.md
+++ b/src/ch03-02-data-types.md
@@ -115,7 +115,7 @@ which you’d use `isize` or `usize` is when indexing some sort of collection.
 > To explicitly handle the possibility of overflow, you can use these families
 > of methods that the standard library provides on primitive numeric types:
 >
-> - Wrap in all modes with the `wrapping_*` methods, such as `wrapping_add`
+> - Wrap in all modes with the `wrapping_*` methods, such as [`wrapping_add`](https://doc.rust-lang.org/std/intrinsics/fn.wrapping_add.html)
 > - Return the `None` value if there is overflow with the `checked_*` methods
 > - Return the value and a boolean indicating whether there was overflow with
 >   the `overflowing_*` methods


### PR DESCRIPTION
Added a link for the rust-docs relating to wrapping_add, which helps disambiguate a developer std::intrinsics version to the u8:: / u32:: version.

This tripped me up, I tried to use, simply, wrapping_add(x, 1) to understand the usage, because the compiler produced an error that pointed me to the generic, and only the generic (whose doc is linked)

When I drilled down to the definition for the generic with some frantic, frustrated Googling, it highlighted to me that the function I wanted, u8::wrapping_add(a, b), may have existed as a static function of the type, u8. Maybe this breadcrumb will help -- because this link is how I learned of the probable existence of u8::wrapping_add(a,b)