### PR TITLE
add a comment to clarify to simplify enums

### DIFF
--- a/listings/ch06-enums-and-pattern-matching/no-listing-05-methods-on-enums/src/main.rs
+++ b/listings/ch06-enums-and-pattern-matching/no-listing-05-methods-on-enums/src/main.rs
@@ -13,6 +13,7 @@ fn main() {
         }
     }
 
+    // recall that the Write variant of Message requires a String
     let m = Message::Write(String::from("hello"));
     m.call();
     // ANCHOR_END: here


### PR DESCRIPTION
This snippet follows an aside contrasting enums with structs. To get the reader back on track, a code comment here reminding them of how the enum was defined before may assist with clarity.