### PR TITLE
fix typo: missing "type" after generic

### DIFF
--- a/src/ch10-02-traits.md
+++ b/src/ch10-02-traits.md
@@ -2,8 +2,8 @@
 
 A *trait* tells the Rust compiler about functionality a particular type has and
 can share with other types. We can use traits to define shared behavior in an
-abstract way. We can use trait bounds to specify that a generic can be any type
-that has certain behavior.
+abstract way. We can use trait bounds to specify that a generic type can be any
+type that has certain behavior.
 
 > Note: Traits are similar to a feature often called *interfaces* in other
 > languages, although with some differences.


### PR DESCRIPTION
"generic" isn't a noun. Did you mean "generic type"?