### PR TITLE
Fix rc borrowck example

### DIFF
--- a/src/ch15-04-rc.md
+++ b/src/ch15-04-rc.md
@@ -71,8 +71,9 @@ We could change the definition of `Cons` to hold references instead, but then
 we would have to specify lifetime parameters. By specifying lifetime
 parameters, we would be specifying that every element in the list will live at
 least as long as the entire list. The borrow checker wouldn’t let us compile
-`let a = Cons(10, &Nil);` for example, because the temporary `Nil` value would
-be dropped before `a` could take a reference to it.
+`return Cons(4, &other_list);` for example, because the `Cons` borrows from
+`other_list`. `other_list` is owned by the current function, so it can't live
+after the function returns.
 
 Instead, we’ll change our definition of `List` to use `Rc<T>` in place of
 `Box<T>`, as shown in Listing 15-18. Each `Cons` variant will now hold a value

--- a/src/ch15-04-rc.md
+++ b/src/ch15-04-rc.md
@@ -72,7 +72,7 @@ we would have to specify lifetime parameters. By specifying lifetime
 parameters, we would be specifying that every element in the list will live at
 least as long as the entire list. The borrow checker wouldn’t let us compile
 `return Cons(4, &other_list);` for example, because the `Cons` borrows from
-`other_list`. `other_list` is owned by the current function, so it can't live
+`other_list`. `other_list` is owned by the current function, so it can’t live
 after the function returns.
 
 Instead, we’ll change our definition of `List` to use `Rc<T>` in place of


### PR DESCRIPTION
This change implements a different example of code the compiler would reject if the linked list example from the Rc chapter was written with references and lifetime parameters instead.

The previous example was incorrect, because (as I understand it) it was written before rust could static-promote unit variants. This change replaced it with an example that still fails on the latest stable: creating a list that references data owned by the current function.

Closes #1656. Closes #2742.