### PR TITLE
Clarify the meaning of a sentence in ch10-03

### DIFF
--- a/src/ch10-03-lifetime-syntax.md
+++ b/src/ch10-03-lifetime-syntax.md
@@ -588,10 +588,11 @@ This is the `longest` function from Listing 10-22 that returns the longer of
 two string slices. But now it has an extra parameter named `ann` of the generic
 type `T`, which can be filled in by any type that implements the `Display`
 trait as specified by the `where` clause. This extra parameter will be printed
-before the function compares the lengths of the string slices, which is why the
-`Display` trait bound is necessary. Because lifetimes are a type of generic,
-the declarations of the lifetime parameter `'a` and the generic type parameter
-`T` go in the same list inside the angle brackets after the function name.
+using `{}`, which is why the `Display` trait bound is necessary.  The `ann`
+parameter is printed before the function compares the lengths of the string slices.
+Because lifetimes are a type of generic, the declarations of the lifetime parameter
+`'a` and the generic type parameter `T` go in the same list inside the angle brackets
+after the function name.
 
 ## Summary
 


### PR DESCRIPTION
I'm new to Rust and reading the original sentence made me wonder if we need `Display` because the parameter is printed before the comparison or just because it is printed.
It's a small thing and maybe not so critical, hope I got it right.