### PR TITLE
Drop unneeded .tail() call from ref cycle example

### DIFF
--- a/listings/ch15-smart-pointers/listing-15-26/src/main.rs
+++ b/listings/ch15-smart-pointers/listing-15-26/src/main.rs
@@ -39,6 +39,6 @@ fn main() {
 
     // Uncomment the next line to see that we have a cycle;
     // it will overflow the stack
-    // println!("a next item = {:?}", a.tail());
+    // println!("a = {:?}", a);
 }
 // ANCHOR_END: here


### PR DESCRIPTION
Even without tail the example will smash the stack when uncommented.

It is better to avoid the unneeded .tail() as the reader might wonder why it is needed.