### PR TITLE
Add 'Content-Type' header to ch20-05 listing

### DIFF
--- a/listings/ch20-web-server/listing-20-05/src/main.rs
+++ b/listings/ch20-web-server/listing-20-05/src/main.rs
@@ -25,7 +25,7 @@ fn handle_connection(mut stream: TcpStream) {
     let contents = fs::read_to_string("hello.html").unwrap();
 
     let response = format!(
-        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nContent-Type: text/html\r\n\r\n{}",
+        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nContent-Type: text/html\r\nContent-Type: text/html\r\n\r\n{}",
         contents.len(),
         contents
     );

--- a/listings/ch20-web-server/listing-20-05/src/main.rs
+++ b/listings/ch20-web-server/listing-20-05/src/main.rs
@@ -25,7 +25,7 @@ fn handle_connection(mut stream: TcpStream) {
     let contents = fs::read_to_string("hello.html").unwrap();
 
     let response = format!(
-        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}",
+        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nContent-Type: text/html\r\n\r\n{}",
         contents.len(),
         contents
     );

--- a/listings/ch20-web-server/listing-20-06/src/main.rs
+++ b/listings/ch20-web-server/listing-20-06/src/main.rs
@@ -26,7 +26,7 @@ fn handle_connection(mut stream: TcpStream) {
         let contents = fs::read_to_string("hello.html").unwrap();
 
         let response = format!(
-            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}",
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nContent-Type: text/html\r\n\r\n{}",
             contents.len(),
             contents
         );

--- a/listings/ch20-web-server/listing-20-07/src/main.rs
+++ b/listings/ch20-web-server/listing-20-07/src/main.rs
@@ -23,7 +23,7 @@ fn handle_connection(mut stream: TcpStream) {
         let contents = fs::read_to_string("hello.html").unwrap();
 
         let response = format!(
-            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}",
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nContent-Type: text/html\r\n\r\n{}",
             contents.len(),
             contents
         );
@@ -37,7 +37,7 @@ fn handle_connection(mut stream: TcpStream) {
         let contents = fs::read_to_string("404.html").unwrap();
 
         let response = format!(
-            "{}\r\nContent-Length: {}\r\n\r\n{}",
+            "{}\r\nContent-Length: {}\r\nContent-Type: text/html\r\n\r\n{}",
             status_line,
             contents.len(),
             contents

--- a/listings/ch20-web-server/listing-20-08/src/main.rs
+++ b/listings/ch20-web-server/listing-20-08/src/main.rs
@@ -23,7 +23,7 @@ fn handle_connection(mut stream: TcpStream) {
         let contents = fs::read_to_string("hello.html").unwrap();
 
         let response = format!(
-            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}",
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nContent-Type: text/html\r\n\r\n{}",
             contents.len(),
             contents
         );
@@ -35,7 +35,7 @@ fn handle_connection(mut stream: TcpStream) {
         let contents = fs::read_to_string("404.html").unwrap();
 
         let response = format!(
-            "{}\r\nContent-Length: {}\r\n\r\n{}",
+            "{}\r\nContent-Length: {}\r\nContent-Type: text/html\r\n\r\n{}",
             status_line,
             contents.len(),
             contents

--- a/listings/ch20-web-server/listing-20-09/src/main.rs
+++ b/listings/ch20-web-server/listing-20-09/src/main.rs
@@ -35,7 +35,7 @@ fn handle_connection(mut stream: TcpStream) {
     let contents = fs::read_to_string(filename).unwrap();
 
     let response = format!(
-        "{}\r\nContent-Length: {}\r\n\r\n{}",
+        "{}\r\nContent-Length: {}\r\nContent-Type: text/html\r\n\r\n{}",
         status_line,
         contents.len(),
         contents

--- a/listings/ch20-web-server/listing-20-10/src/main.rs
+++ b/listings/ch20-web-server/listing-20-10/src/main.rs
@@ -45,7 +45,7 @@ fn handle_connection(mut stream: TcpStream) {
     let contents = fs::read_to_string(filename).unwrap();
 
     let response = format!(
-        "{}\r\nContent-Length: {}\r\n\r\n{}",
+        "{}\r\nContent-Length: {}\r\nContent-Type: text/html\r\n\r\n{}",
         status_line,
         contents.len(),
         contents

--- a/listings/ch20-web-server/listing-20-11/src/main.rs
+++ b/listings/ch20-web-server/listing-20-11/src/main.rs
@@ -38,7 +38,7 @@ fn handle_connection(mut stream: TcpStream) {
     let contents = fs::read_to_string(filename).unwrap();
 
     let response = format!(
-        "{}\r\nContent-Length: {}\r\n\r\n{}",
+        "{}\r\nContent-Length: {}\r\nContent-Type: text/html\r\n\r\n{}",
         status_line,
         contents.len(),
         contents

--- a/listings/ch20-web-server/listing-20-12/src/main.rs
+++ b/listings/ch20-web-server/listing-20-12/src/main.rs
@@ -39,7 +39,7 @@ fn handle_connection(mut stream: TcpStream) {
     let contents = fs::read_to_string(filename).unwrap();
 
     let response = format!(
-        "{}\r\nContent-Length: {}\r\n\r\n{}",
+        "{}\r\nContent-Length: {}\r\nContent-Type: text/html\r\n\r\n{}",
         status_line,
         contents.len(),
         contents

--- a/listings/ch20-web-server/listing-20-13/src/bin/main.rs
+++ b/listings/ch20-web-server/listing-20-13/src/bin/main.rs
@@ -38,7 +38,7 @@ fn handle_connection(mut stream: TcpStream) {
     let contents = fs::read_to_string(filename).unwrap();
 
     let response = format!(
-        "{}\r\nContent-Length: {}\r\n\r\n{}",
+        "{}\r\nContent-Length: {}\r\nContent-Type: text/html\r\n\r\n{}",
         status_line,
         contents.len(),
         contents

--- a/listings/ch20-web-server/listing-20-14/src/bin/main.rs
+++ b/listings/ch20-web-server/listing-20-14/src/bin/main.rs
@@ -38,7 +38,7 @@ fn handle_connection(mut stream: TcpStream) {
     let contents = fs::read_to_string(filename).unwrap();
 
     let response = format!(
-        "{}\r\nContent-Length: {}\r\n\r\n{}",
+        "{}\r\nContent-Length: {}\r\nContent-Type: text/html\r\n\r\n{}",
         status_line,
         contents.len(),
         contents

--- a/listings/ch20-web-server/listing-20-15/src/bin/main.rs
+++ b/listings/ch20-web-server/listing-20-15/src/bin/main.rs
@@ -38,7 +38,7 @@ fn handle_connection(mut stream: TcpStream) {
     let contents = fs::read_to_string(filename).unwrap();
 
     let response = format!(
-        "{}\r\nContent-Length: {}\r\n\r\n{}",
+        "{}\r\nContent-Length: {}\r\nContent-Type: text/html\r\n\r\n{}",
         status_line,
         contents.len(),
         contents

--- a/listings/ch20-web-server/listing-20-16/src/bin/main.rs
+++ b/listings/ch20-web-server/listing-20-16/src/bin/main.rs
@@ -38,7 +38,7 @@ fn handle_connection(mut stream: TcpStream) {
     let contents = fs::read_to_string(filename).unwrap();
 
     let response = format!(
-        "{}\r\nContent-Length: {}\r\n\r\n{}",
+        "{}\r\nContent-Length: {}\r\nContent-Type: text/html\r\n\r\n{}",
         status_line,
         contents.len(),
         contents

--- a/listings/ch20-web-server/listing-20-17/src/bin/main.rs
+++ b/listings/ch20-web-server/listing-20-17/src/bin/main.rs
@@ -38,7 +38,7 @@ fn handle_connection(mut stream: TcpStream) {
     let contents = fs::read_to_string(filename).unwrap();
 
     let response = format!(
-        "{}\r\nContent-Length: {}\r\n\r\n{}",
+        "{}\r\nContent-Length: {}\r\nContent-Type: text/html\r\n\r\n{}",
         status_line,
         contents.len(),
         contents

--- a/listings/ch20-web-server/listing-20-18/src/bin/main.rs
+++ b/listings/ch20-web-server/listing-20-18/src/bin/main.rs
@@ -38,7 +38,7 @@ fn handle_connection(mut stream: TcpStream) {
     let contents = fs::read_to_string(filename).unwrap();
 
     let response = format!(
-        "{}\r\nContent-Length: {}\r\n\r\n{}",
+        "{}\r\nContent-Length: {}\r\nContent-Type: text/html\r\n\r\n{}",
         status_line,
         contents.len(),
         contents

--- a/listings/ch20-web-server/listing-20-19/src/bin/main.rs
+++ b/listings/ch20-web-server/listing-20-19/src/bin/main.rs
@@ -38,7 +38,7 @@ fn handle_connection(mut stream: TcpStream) {
     let contents = fs::read_to_string(filename).unwrap();
 
     let response = format!(
-        "{}\r\nContent-Length: {}\r\n\r\n{}",
+        "{}\r\nContent-Length: {}\r\nContent-Type: text/html\r\n\r\n{}",
         status_line,
         contents.len(),
         contents

--- a/listings/ch20-web-server/listing-20-20/src/bin/main.rs
+++ b/listings/ch20-web-server/listing-20-20/src/bin/main.rs
@@ -38,7 +38,7 @@ fn handle_connection(mut stream: TcpStream) {
     let contents = fs::read_to_string(filename).unwrap();
 
     let response = format!(
-        "{}\r\nContent-Length: {}\r\n\r\n{}",
+        "{}\r\nContent-Length: {}\r\nContent-Type: text/html\r\n\r\n{}",
         status_line,
         contents.len(),
         contents

--- a/listings/ch20-web-server/listing-20-21/src/bin/main.rs
+++ b/listings/ch20-web-server/listing-20-21/src/bin/main.rs
@@ -38,7 +38,7 @@ fn handle_connection(mut stream: TcpStream) {
     let contents = fs::read_to_string(filename).unwrap();
 
     let response = format!(
-        "{}\r\nContent-Length: {}\r\n\r\n{}",
+        "{}\r\nContent-Length: {}\r\nContent-Type: text/html\r\n\r\n{}",
         status_line,
         contents.len(),
         contents

--- a/listings/ch20-web-server/listing-20-22/src/bin/main.rs
+++ b/listings/ch20-web-server/listing-20-22/src/bin/main.rs
@@ -38,7 +38,7 @@ fn handle_connection(mut stream: TcpStream) {
     let contents = fs::read_to_string(filename).unwrap();
 
     let response = format!(
-        "{}\r\nContent-Length: {}\r\n\r\n{}",
+        "{}\r\nContent-Length: {}\r\nContent-Type: text/html\r\n\r\n{}",
         status_line,
         contents.len(),
         contents

--- a/listings/ch20-web-server/listing-20-23/src/bin/main.rs
+++ b/listings/ch20-web-server/listing-20-23/src/bin/main.rs
@@ -38,7 +38,7 @@ fn handle_connection(mut stream: TcpStream) {
     let contents = fs::read_to_string(filename).unwrap();
 
     let response = format!(
-        "{}\r\nContent-Length: {}\r\n\r\n{}",
+        "{}\r\nContent-Length: {}\r\nContent-Type: text/html\r\n\r\n{}",
         status_line,
         contents.len(),
         contents

--- a/listings/ch20-web-server/listing-20-24/src/bin/main.rs
+++ b/listings/ch20-web-server/listing-20-24/src/bin/main.rs
@@ -38,7 +38,7 @@ fn handle_connection(mut stream: TcpStream) {
     let contents = fs::read_to_string(filename).unwrap();
 
     let response = format!(
-        "{}\r\nContent-Length: {}\r\n\r\n{}",
+        "{}\r\nContent-Length: {}\r\nContent-Type: text/html\r\n\r\n{}",
         status_line,
         contents.len(),
         contents

--- a/listings/ch20-web-server/listing-20-25/src/bin/main.rs
+++ b/listings/ch20-web-server/listing-20-25/src/bin/main.rs
@@ -42,7 +42,7 @@ fn handle_connection(mut stream: TcpStream) {
     let contents = fs::read_to_string(filename).unwrap();
 
     let response = format!(
-        "{}\r\nContent-Length: {}\r\n\r\n{}",
+        "{}\r\nContent-Length: {}\r\nContent-Type: text/html\r\n\r\n{}",
         status_line,
         contents.len(),
         contents

--- a/listings/ch20-web-server/no-listing-01-define-threadpool-struct/src/bin/main.rs
+++ b/listings/ch20-web-server/no-listing-01-define-threadpool-struct/src/bin/main.rs
@@ -40,7 +40,7 @@ fn handle_connection(mut stream: TcpStream) {
     let contents = fs::read_to_string(filename).unwrap();
 
     let response = format!(
-        "{}\r\nContent-Length: {}\r\n\r\n{}",
+        "{}\r\nContent-Length: {}\r\nContent-Type: text/html\r\n\r\n{}",
         status_line,
         contents.len(),
         contents

--- a/listings/ch20-web-server/no-listing-02-impl-threadpool-new/src/bin/main.rs
+++ b/listings/ch20-web-server/no-listing-02-impl-threadpool-new/src/bin/main.rs
@@ -38,7 +38,7 @@ fn handle_connection(mut stream: TcpStream) {
     let contents = fs::read_to_string(filename).unwrap();
 
     let response = format!(
-        "{}\r\nContent-Length: {}\r\n\r\n{}",
+        "{}\r\nContent-Length: {}\r\nContent-Type: text/html\r\n\r\n{}",
         status_line,
         contents.len(),
         contents

--- a/listings/ch20-web-server/no-listing-03-define-execute/src/bin/main.rs
+++ b/listings/ch20-web-server/no-listing-03-define-execute/src/bin/main.rs
@@ -38,7 +38,7 @@ fn handle_connection(mut stream: TcpStream) {
     let contents = fs::read_to_string(filename).unwrap();
 
     let response = format!(
-        "{}\r\nContent-Length: {}\r\n\r\n{}",
+        "{}\r\nContent-Length: {}\r\nContent-Type: text/html\r\n\r\n{}",
         status_line,
         contents.len(),
         contents

--- a/listings/ch20-web-server/no-listing-04-update-worker-definition/src/bin/main.rs
+++ b/listings/ch20-web-server/no-listing-04-update-worker-definition/src/bin/main.rs
@@ -38,7 +38,7 @@ fn handle_connection(mut stream: TcpStream) {
     let contents = fs::read_to_string(filename).unwrap();
 
     let response = format!(
-        "{}\r\nContent-Length: {}\r\n\r\n{}",
+        "{}\r\nContent-Length: {}\r\nContent-Type: text/html\r\n\r\n{}",
         status_line,
         contents.len(),
         contents

--- a/listings/ch20-web-server/no-listing-05-fix-worker-new/src/bin/main.rs
+++ b/listings/ch20-web-server/no-listing-05-fix-worker-new/src/bin/main.rs
@@ -38,7 +38,7 @@ fn handle_connection(mut stream: TcpStream) {
     let contents = fs::read_to_string(filename).unwrap();
 
     let response = format!(
-        "{}\r\nContent-Length: {}\r\n\r\n{}",
+        "{}\r\nContent-Length: {}\r\nContent-Type: text/html\r\n\r\n{}",
         status_line,
         contents.len(),
         contents

--- a/listings/ch20-web-server/no-listing-06-fix-threadpool-drop/src/bin/main.rs
+++ b/listings/ch20-web-server/no-listing-06-fix-threadpool-drop/src/bin/main.rs
@@ -38,7 +38,7 @@ fn handle_connection(mut stream: TcpStream) {
     let contents = fs::read_to_string(filename).unwrap();
 
     let response = format!(
-        "{}\r\nContent-Length: {}\r\n\r\n{}",
+        "{}\r\nContent-Length: {}\r\nContent-Type: text/html\r\n\r\n{}",
         status_line,
         contents.len(),
         contents

--- a/listings/ch20-web-server/no-listing-07-define-message-enum/src/bin/main.rs
+++ b/listings/ch20-web-server/no-listing-07-define-message-enum/src/bin/main.rs
@@ -38,7 +38,7 @@ fn handle_connection(mut stream: TcpStream) {
     let contents = fs::read_to_string(filename).unwrap();
 
     let response = format!(
-        "{}\r\nContent-Length: {}\r\n\r\n{}",
+        "{}\r\nContent-Length: {}\r\nContent-Type: text/html\r\n\r\n{}",
         status_line,
         contents.len(),
         contents

--- a/listings/ch20-web-server/no-listing-08-final-code/src/bin/main.rs
+++ b/listings/ch20-web-server/no-listing-08-final-code/src/bin/main.rs
@@ -40,7 +40,7 @@ fn handle_connection(mut stream: TcpStream) {
     let contents = fs::read_to_string(filename).unwrap();
 
     let response = format!(
-        "{}\r\nContent-Length: {}\r\n\r\n{}",
+        "{}\r\nContent-Length: {}\r\nContent-Type: text/html\r\n\r\n{}",
         status_line,
         contents.len(),
         contents

--- a/src/ch20-01-single-threaded.md
+++ b/src/ch20-01-single-threaded.md
@@ -326,8 +326,9 @@ familiar; we used it in Chapter 12 when we read the contents of a file for our
 I/O project in Listing 12-4.
 
 Next, we use `format!` to add the file’s contents as the body of the success
-response. To ensure a valid HTTP response, we add the `Content-Length` header
-which is set to the size of our response body, in this case the size of `hello.html`.
+response. To ensure a valid HTTP response, we add the `Content-Length` and
+`Content-Type` headers which are set to the size and type of our response body,
+in this case the size of `hello.html` and type `text/html`.
 
 Run this code with `cargo run` and load *127.0.0.1:7878* in your browser; you
 should see your HTML rendered!


### PR DESCRIPTION
As modern browsers appear not to render a response correctly without
this header, the header is added to the response.

For issue #2803 