### PR TITLE
Remove authors field from all the manifests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "rust-book"
 version = "0.0.1"
-authors = ["Steve Klabnik <steve@steveklabnik.com>"]
 description = "The Rust Book"
 edition = "2018"
 

--- a/listings/ch02-guessing-game-tutorial/listing-02-01/Cargo.toml
+++ b/listings/ch02-guessing-game-tutorial/listing-02-01/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "guessing_game"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/listings/ch02-guessing-game-tutorial/listing-02-03/Cargo.toml
+++ b/listings/ch02-guessing-game-tutorial/listing-02-03/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "guessing_game"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/listings/ch02-guessing-game-tutorial/listing-02-04/Cargo.toml
+++ b/listings/ch02-guessing-game-tutorial/listing-02-04/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "guessing_game"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/listings/ch02-guessing-game-tutorial/listing-02-05/Cargo.toml
+++ b/listings/ch02-guessing-game-tutorial/listing-02-05/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "guessing_game"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/listings/ch02-guessing-game-tutorial/listing-02-06/Cargo.toml
+++ b/listings/ch02-guessing-game-tutorial/listing-02-06/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "guessing_game"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/listings/ch02-guessing-game-tutorial/no-listing-02-without-expect/Cargo.toml
+++ b/listings/ch02-guessing-game-tutorial/no-listing-02-without-expect/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "guessing_game"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/listings/ch02-guessing-game-tutorial/no-listing-03-convert-string-to-number/Cargo.toml
+++ b/listings/ch02-guessing-game-tutorial/no-listing-03-convert-string-to-number/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "guessing_game"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/listings/ch02-guessing-game-tutorial/no-listing-04-looping/Cargo.toml
+++ b/listings/ch02-guessing-game-tutorial/no-listing-04-looping/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "guessing_game"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/listings/ch02-guessing-game-tutorial/no-listing-05-quitting/Cargo.toml
+++ b/listings/ch02-guessing-game-tutorial/no-listing-05-quitting/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "guessing_game"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/listings/ch03-common-programming-concepts/listing-03-01/Cargo.toml
+++ b/listings/ch03-common-programming-concepts/listing-03-01/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "functions"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch03-common-programming-concepts/listing-03-02/Cargo.toml
+++ b/listings/ch03-common-programming-concepts/listing-03-02/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "branches"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch03-common-programming-concepts/listing-03-03/Cargo.toml
+++ b/listings/ch03-common-programming-concepts/listing-03-03/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "loops"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch03-common-programming-concepts/listing-03-04/Cargo.toml
+++ b/listings/ch03-common-programming-concepts/listing-03-04/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "loops"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch03-common-programming-concepts/listing-03-05/Cargo.toml
+++ b/listings/ch03-common-programming-concepts/listing-03-05/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "loops"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch03-common-programming-concepts/no-listing-01-variables-are-immutable/Cargo.toml
+++ b/listings/ch03-common-programming-concepts/no-listing-01-variables-are-immutable/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "variables"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch03-common-programming-concepts/no-listing-02-adding-mut/Cargo.toml
+++ b/listings/ch03-common-programming-concepts/no-listing-02-adding-mut/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "variables"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch03-common-programming-concepts/no-listing-03-shadowing/Cargo.toml
+++ b/listings/ch03-common-programming-concepts/no-listing-03-shadowing/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "variables"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch03-common-programming-concepts/no-listing-04-shadowing-can-change-types/Cargo.toml
+++ b/listings/ch03-common-programming-concepts/no-listing-04-shadowing-can-change-types/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "variables"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch03-common-programming-concepts/no-listing-05-mut-cant-change-types/Cargo.toml
+++ b/listings/ch03-common-programming-concepts/no-listing-05-mut-cant-change-types/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "variables"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch03-common-programming-concepts/no-listing-06-floating-point/Cargo.toml
+++ b/listings/ch03-common-programming-concepts/no-listing-06-floating-point/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "floating-point"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch03-common-programming-concepts/no-listing-07-numeric-operations/Cargo.toml
+++ b/listings/ch03-common-programming-concepts/no-listing-07-numeric-operations/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "numeric-operations"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch03-common-programming-concepts/no-listing-08-boolean/Cargo.toml
+++ b/listings/ch03-common-programming-concepts/no-listing-08-boolean/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "boolean"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch03-common-programming-concepts/no-listing-09-char/Cargo.toml
+++ b/listings/ch03-common-programming-concepts/no-listing-09-char/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "char"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch03-common-programming-concepts/no-listing-10-tuples/Cargo.toml
+++ b/listings/ch03-common-programming-concepts/no-listing-10-tuples/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "tuples"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch03-common-programming-concepts/no-listing-11-destructuring-tuples/Cargo.toml
+++ b/listings/ch03-common-programming-concepts/no-listing-11-destructuring-tuples/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "tuples"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch03-common-programming-concepts/no-listing-12-tuple-indexing/Cargo.toml
+++ b/listings/ch03-common-programming-concepts/no-listing-12-tuple-indexing/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "tuples"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch03-common-programming-concepts/no-listing-13-arrays/Cargo.toml
+++ b/listings/ch03-common-programming-concepts/no-listing-13-arrays/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "arrays"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch03-common-programming-concepts/no-listing-14-array-indexing/Cargo.toml
+++ b/listings/ch03-common-programming-concepts/no-listing-14-array-indexing/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "arrays"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch03-common-programming-concepts/no-listing-15-invalid-array-access/Cargo.toml
+++ b/listings/ch03-common-programming-concepts/no-listing-15-invalid-array-access/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "arrays"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch03-common-programming-concepts/no-listing-16-functions/Cargo.toml
+++ b/listings/ch03-common-programming-concepts/no-listing-16-functions/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "functions"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch03-common-programming-concepts/no-listing-17-functions-with-parameters/Cargo.toml
+++ b/listings/ch03-common-programming-concepts/no-listing-17-functions-with-parameters/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "functions"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch03-common-programming-concepts/no-listing-18-functions-with-multiple-parameters/Cargo.toml
+++ b/listings/ch03-common-programming-concepts/no-listing-18-functions-with-multiple-parameters/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "functions"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch03-common-programming-concepts/no-listing-19-statements-vs-expressions/Cargo.toml
+++ b/listings/ch03-common-programming-concepts/no-listing-19-statements-vs-expressions/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "functions"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch03-common-programming-concepts/no-listing-20-blocks-are-expressions/Cargo.toml
+++ b/listings/ch03-common-programming-concepts/no-listing-20-blocks-are-expressions/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "functions"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch03-common-programming-concepts/no-listing-21-function-return-values/Cargo.toml
+++ b/listings/ch03-common-programming-concepts/no-listing-21-function-return-values/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "functions"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch03-common-programming-concepts/no-listing-22-function-parameter-and-return/Cargo.toml
+++ b/listings/ch03-common-programming-concepts/no-listing-22-function-parameter-and-return/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "functions"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch03-common-programming-concepts/no-listing-23-statements-dont-return-values/Cargo.toml
+++ b/listings/ch03-common-programming-concepts/no-listing-23-statements-dont-return-values/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "functions"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch03-common-programming-concepts/no-listing-24-comments-end-of-line/Cargo.toml
+++ b/listings/ch03-common-programming-concepts/no-listing-24-comments-end-of-line/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "comments"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch03-common-programming-concepts/no-listing-25-comments-above-line/Cargo.toml
+++ b/listings/ch03-common-programming-concepts/no-listing-25-comments-above-line/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "comments"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch03-common-programming-concepts/no-listing-26-if-true/Cargo.toml
+++ b/listings/ch03-common-programming-concepts/no-listing-26-if-true/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "branches"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch03-common-programming-concepts/no-listing-27-if-false/Cargo.toml
+++ b/listings/ch03-common-programming-concepts/no-listing-27-if-false/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "branches"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch03-common-programming-concepts/no-listing-28-if-condition-must-be-bool/Cargo.toml
+++ b/listings/ch03-common-programming-concepts/no-listing-28-if-condition-must-be-bool/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "branches"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch03-common-programming-concepts/no-listing-29-if-not-equal-0/Cargo.toml
+++ b/listings/ch03-common-programming-concepts/no-listing-29-if-not-equal-0/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "branches"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch03-common-programming-concepts/no-listing-30-else-if/Cargo.toml
+++ b/listings/ch03-common-programming-concepts/no-listing-30-else-if/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "branches"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch03-common-programming-concepts/no-listing-31-arms-must-return-same-type/Cargo.toml
+++ b/listings/ch03-common-programming-concepts/no-listing-31-arms-must-return-same-type/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "branches"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch03-common-programming-concepts/no-listing-32-loop/Cargo.toml
+++ b/listings/ch03-common-programming-concepts/no-listing-32-loop/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "loops"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch03-common-programming-concepts/no-listing-33-return-value-from-loop/Cargo.toml
+++ b/listings/ch03-common-programming-concepts/no-listing-33-return-value-from-loop/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "loops"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch03-common-programming-concepts/no-listing-34-for-range/Cargo.toml
+++ b/listings/ch03-common-programming-concepts/no-listing-34-for-range/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "loops"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch03-common-programming-concepts/output-only-01-no-type-annotations/Cargo.toml
+++ b/listings/ch03-common-programming-concepts/output-only-01-no-type-annotations/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "no_type_annotations"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/listings/ch04-understanding-ownership/listing-04-01/Cargo.toml
+++ b/listings/ch04-understanding-ownership/listing-04-01/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ownership"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch04-understanding-ownership/listing-04-02/Cargo.toml
+++ b/listings/ch04-understanding-ownership/listing-04-02/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ownership"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch04-understanding-ownership/listing-04-03/Cargo.toml
+++ b/listings/ch04-understanding-ownership/listing-04-03/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ownership"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch04-understanding-ownership/listing-04-04/Cargo.toml
+++ b/listings/ch04-understanding-ownership/listing-04-04/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ownership"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch04-understanding-ownership/listing-04-05/Cargo.toml
+++ b/listings/ch04-understanding-ownership/listing-04-05/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ownership"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch04-understanding-ownership/listing-04-06/Cargo.toml
+++ b/listings/ch04-understanding-ownership/listing-04-06/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ownership"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch04-understanding-ownership/listing-04-07/Cargo.toml
+++ b/listings/ch04-understanding-ownership/listing-04-07/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ownership"
 version = "0.1.0"
-authors = ["Carol (Nichols || Goulding) <carol.nichols@gmail.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch04-understanding-ownership/listing-04-08/Cargo.toml
+++ b/listings/ch04-understanding-ownership/listing-04-08/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ownership"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch04-understanding-ownership/listing-04-09/Cargo.toml
+++ b/listings/ch04-understanding-ownership/listing-04-09/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ownership"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch04-understanding-ownership/no-listing-01-can-mutate-string/Cargo.toml
+++ b/listings/ch04-understanding-ownership/no-listing-01-can-mutate-string/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ownership"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch04-understanding-ownership/no-listing-02-string-scope/Cargo.toml
+++ b/listings/ch04-understanding-ownership/no-listing-02-string-scope/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ownership"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch04-understanding-ownership/no-listing-03-string-move/Cargo.toml
+++ b/listings/ch04-understanding-ownership/no-listing-03-string-move/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ownership"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch04-understanding-ownership/no-listing-04-cant-use-after-move/Cargo.toml
+++ b/listings/ch04-understanding-ownership/no-listing-04-cant-use-after-move/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ownership"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch04-understanding-ownership/no-listing-05-clone/Cargo.toml
+++ b/listings/ch04-understanding-ownership/no-listing-05-clone/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ownership"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch04-understanding-ownership/no-listing-06-copy/Cargo.toml
+++ b/listings/ch04-understanding-ownership/no-listing-06-copy/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ownership"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch04-understanding-ownership/no-listing-07-reference/Cargo.toml
+++ b/listings/ch04-understanding-ownership/no-listing-07-reference/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ownership"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch04-understanding-ownership/no-listing-08-reference-with-annotations/Cargo.toml
+++ b/listings/ch04-understanding-ownership/no-listing-08-reference-with-annotations/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ownership"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch04-understanding-ownership/no-listing-09-fixes-listing-04-06/Cargo.toml
+++ b/listings/ch04-understanding-ownership/no-listing-09-fixes-listing-04-06/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ownership"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch04-understanding-ownership/no-listing-10-multiple-mut-not-allowed/Cargo.toml
+++ b/listings/ch04-understanding-ownership/no-listing-10-multiple-mut-not-allowed/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ownership"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch04-understanding-ownership/no-listing-11-muts-in-separate-scopes/Cargo.toml
+++ b/listings/ch04-understanding-ownership/no-listing-11-muts-in-separate-scopes/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ownership"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch04-understanding-ownership/no-listing-12-immutable-and-mutable-not-allowed/Cargo.toml
+++ b/listings/ch04-understanding-ownership/no-listing-12-immutable-and-mutable-not-allowed/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ownership"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch04-understanding-ownership/no-listing-13-reference-scope-ends/Cargo.toml
+++ b/listings/ch04-understanding-ownership/no-listing-13-reference-scope-ends/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ownership"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch04-understanding-ownership/no-listing-14-dangling-reference/Cargo.toml
+++ b/listings/ch04-understanding-ownership/no-listing-14-dangling-reference/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ownership"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch04-understanding-ownership/no-listing-15-dangling-reference-annotated/Cargo.toml
+++ b/listings/ch04-understanding-ownership/no-listing-15-dangling-reference-annotated/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ownership"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch04-understanding-ownership/no-listing-16-no-dangle/Cargo.toml
+++ b/listings/ch04-understanding-ownership/no-listing-16-no-dangle/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ownership"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch04-understanding-ownership/no-listing-17-slice/Cargo.toml
+++ b/listings/ch04-understanding-ownership/no-listing-17-slice/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ownership"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch04-understanding-ownership/no-listing-18-first-word-slice/Cargo.toml
+++ b/listings/ch04-understanding-ownership/no-listing-18-first-word-slice/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ownership"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch04-understanding-ownership/no-listing-19-slice-error/Cargo.toml
+++ b/listings/ch04-understanding-ownership/no-listing-19-slice-error/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ownership"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch05-using-structs-to-structure-related-data/listing-05-01/Cargo.toml
+++ b/listings/ch05-using-structs-to-structure-related-data/listing-05-01/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "structs"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch05-using-structs-to-structure-related-data/listing-05-02/Cargo.toml
+++ b/listings/ch05-using-structs-to-structure-related-data/listing-05-02/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "structs"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch05-using-structs-to-structure-related-data/listing-05-03/Cargo.toml
+++ b/listings/ch05-using-structs-to-structure-related-data/listing-05-03/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "structs"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch05-using-structs-to-structure-related-data/listing-05-04/Cargo.toml
+++ b/listings/ch05-using-structs-to-structure-related-data/listing-05-04/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "structs"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch05-using-structs-to-structure-related-data/listing-05-05/Cargo.toml
+++ b/listings/ch05-using-structs-to-structure-related-data/listing-05-05/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "structs"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch05-using-structs-to-structure-related-data/listing-05-06/Cargo.toml
+++ b/listings/ch05-using-structs-to-structure-related-data/listing-05-06/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "structs"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch05-using-structs-to-structure-related-data/listing-05-07/Cargo.toml
+++ b/listings/ch05-using-structs-to-structure-related-data/listing-05-07/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "structs"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch05-using-structs-to-structure-related-data/listing-05-08/Cargo.toml
+++ b/listings/ch05-using-structs-to-structure-related-data/listing-05-08/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "rectangles"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch05-using-structs-to-structure-related-data/listing-05-09/Cargo.toml
+++ b/listings/ch05-using-structs-to-structure-related-data/listing-05-09/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "rectangles"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch05-using-structs-to-structure-related-data/listing-05-10/Cargo.toml
+++ b/listings/ch05-using-structs-to-structure-related-data/listing-05-10/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "rectangles"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch05-using-structs-to-structure-related-data/listing-05-11/Cargo.toml
+++ b/listings/ch05-using-structs-to-structure-related-data/listing-05-11/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "rectangles"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch05-using-structs-to-structure-related-data/listing-05-12/Cargo.toml
+++ b/listings/ch05-using-structs-to-structure-related-data/listing-05-12/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "rectangles"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch05-using-structs-to-structure-related-data/listing-05-13/Cargo.toml
+++ b/listings/ch05-using-structs-to-structure-related-data/listing-05-13/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "rectangles"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch05-using-structs-to-structure-related-data/listing-05-14/Cargo.toml
+++ b/listings/ch05-using-structs-to-structure-related-data/listing-05-14/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "rectangles"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch05-using-structs-to-structure-related-data/listing-05-15/Cargo.toml
+++ b/listings/ch05-using-structs-to-structure-related-data/listing-05-15/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "rectangles"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch05-using-structs-to-structure-related-data/listing-05-16/Cargo.toml
+++ b/listings/ch05-using-structs-to-structure-related-data/listing-05-16/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "rectangles"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch05-using-structs-to-structure-related-data/no-listing-01-tuple-structs/Cargo.toml
+++ b/listings/ch05-using-structs-to-structure-related-data/no-listing-01-tuple-structs/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "structs"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch05-using-structs-to-structure-related-data/no-listing-02-reference-in-struct/Cargo.toml
+++ b/listings/ch05-using-structs-to-structure-related-data/no-listing-02-reference-in-struct/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "structs"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/listings/ch05-using-structs-to-structure-related-data/no-listing-03-associated-functions/Cargo.toml
+++ b/listings/ch05-using-structs-to-structure-related-data/no-listing-03-associated-functions/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "rectangles"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch05-using-structs-to-structure-related-data/output-only-01-debug/Cargo.toml
+++ b/listings/ch05-using-structs-to-structure-related-data/output-only-01-debug/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "rectangles"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch05-using-structs-to-structure-related-data/output-only-02-pretty-debug/Cargo.toml
+++ b/listings/ch05-using-structs-to-structure-related-data/output-only-02-pretty-debug/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "rectangles"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch06-enums-and-pattern-matching/listing-06-01/Cargo.toml
+++ b/listings/ch06-enums-and-pattern-matching/listing-06-01/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "enums"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch06-enums-and-pattern-matching/listing-06-02/Cargo.toml
+++ b/listings/ch06-enums-and-pattern-matching/listing-06-02/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "enums"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch06-enums-and-pattern-matching/listing-06-03/Cargo.toml
+++ b/listings/ch06-enums-and-pattern-matching/listing-06-03/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "enums"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch06-enums-and-pattern-matching/listing-06-04/Cargo.toml
+++ b/listings/ch06-enums-and-pattern-matching/listing-06-04/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "enums"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch06-enums-and-pattern-matching/listing-06-05/Cargo.toml
+++ b/listings/ch06-enums-and-pattern-matching/listing-06-05/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "enums"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch06-enums-and-pattern-matching/listing-06-06/Cargo.toml
+++ b/listings/ch06-enums-and-pattern-matching/listing-06-06/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "enums"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch06-enums-and-pattern-matching/no-listing-01-defining-enums/Cargo.toml
+++ b/listings/ch06-enums-and-pattern-matching/no-listing-01-defining-enums/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "enums"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch06-enums-and-pattern-matching/no-listing-02-enum-with-data/Cargo.toml
+++ b/listings/ch06-enums-and-pattern-matching/no-listing-02-enum-with-data/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "enums"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch06-enums-and-pattern-matching/no-listing-03-variants-with-different-data/Cargo.toml
+++ b/listings/ch06-enums-and-pattern-matching/no-listing-03-variants-with-different-data/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "enums"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch06-enums-and-pattern-matching/no-listing-04-structs-similar-to-message-enum/Cargo.toml
+++ b/listings/ch06-enums-and-pattern-matching/no-listing-04-structs-similar-to-message-enum/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "enums"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch06-enums-and-pattern-matching/no-listing-05-methods-on-enums/Cargo.toml
+++ b/listings/ch06-enums-and-pattern-matching/no-listing-05-methods-on-enums/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "enums"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch06-enums-and-pattern-matching/no-listing-06-option-examples/Cargo.toml
+++ b/listings/ch06-enums-and-pattern-matching/no-listing-06-option-examples/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "enums"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch06-enums-and-pattern-matching/no-listing-07-cant-use-option-directly/Cargo.toml
+++ b/listings/ch06-enums-and-pattern-matching/no-listing-07-cant-use-option-directly/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "enums"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch06-enums-and-pattern-matching/no-listing-08-match-arm-multiple-lines/Cargo.toml
+++ b/listings/ch06-enums-and-pattern-matching/no-listing-08-match-arm-multiple-lines/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "enums"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch06-enums-and-pattern-matching/no-listing-09-variable-in-pattern/Cargo.toml
+++ b/listings/ch06-enums-and-pattern-matching/no-listing-09-variable-in-pattern/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "enums"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch06-enums-and-pattern-matching/no-listing-10-non-exhaustive-match/Cargo.toml
+++ b/listings/ch06-enums-and-pattern-matching/no-listing-10-non-exhaustive-match/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "enums"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch06-enums-and-pattern-matching/no-listing-11-underscore-placeholder/Cargo.toml
+++ b/listings/ch06-enums-and-pattern-matching/no-listing-11-underscore-placeholder/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "enums"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch06-enums-and-pattern-matching/no-listing-12-if-let/Cargo.toml
+++ b/listings/ch06-enums-and-pattern-matching/no-listing-12-if-let/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "enums"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch06-enums-and-pattern-matching/no-listing-13-count-and-announce-match/Cargo.toml
+++ b/listings/ch06-enums-and-pattern-matching/no-listing-13-count-and-announce-match/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "enums"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch06-enums-and-pattern-matching/no-listing-14-count-and-announce-if-let-else/Cargo.toml
+++ b/listings/ch06-enums-and-pattern-matching/no-listing-14-count-and-announce-if-let-else/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "enums"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch07-managing-growing-projects/listing-07-01/Cargo.toml
+++ b/listings/ch07-managing-growing-projects/listing-07-01/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "restaurant"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch07-managing-growing-projects/listing-07-03/Cargo.toml
+++ b/listings/ch07-managing-growing-projects/listing-07-03/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "restaurant"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch07-managing-growing-projects/listing-07-05/Cargo.toml
+++ b/listings/ch07-managing-growing-projects/listing-07-05/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "restaurant"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch07-managing-growing-projects/listing-07-07/Cargo.toml
+++ b/listings/ch07-managing-growing-projects/listing-07-07/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "restaurant"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch07-managing-growing-projects/listing-07-08/Cargo.toml
+++ b/listings/ch07-managing-growing-projects/listing-07-08/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "restaurant"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch07-managing-growing-projects/listing-07-09/Cargo.toml
+++ b/listings/ch07-managing-growing-projects/listing-07-09/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "restaurant"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch07-managing-growing-projects/listing-07-10/Cargo.toml
+++ b/listings/ch07-managing-growing-projects/listing-07-10/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "restaurant"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch07-managing-growing-projects/listing-07-11/Cargo.toml
+++ b/listings/ch07-managing-growing-projects/listing-07-11/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "restaurant"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch07-managing-growing-projects/listing-07-12/Cargo.toml
+++ b/listings/ch07-managing-growing-projects/listing-07-12/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "restaurant"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch07-managing-growing-projects/listing-07-13/Cargo.toml
+++ b/listings/ch07-managing-growing-projects/listing-07-13/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "restaurant"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch07-managing-growing-projects/listing-07-14/Cargo.toml
+++ b/listings/ch07-managing-growing-projects/listing-07-14/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "restaurant"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch07-managing-growing-projects/listing-07-15/Cargo.toml
+++ b/listings/ch07-managing-growing-projects/listing-07-15/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "restaurant"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch07-managing-growing-projects/listing-07-16/Cargo.toml
+++ b/listings/ch07-managing-growing-projects/listing-07-16/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "restaurant"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch07-managing-growing-projects/listing-07-17/Cargo.toml
+++ b/listings/ch07-managing-growing-projects/listing-07-17/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "restaurant"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch07-managing-growing-projects/listing-07-18/Cargo.toml
+++ b/listings/ch07-managing-growing-projects/listing-07-18/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "guessing_game"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch07-managing-growing-projects/listing-07-19/Cargo.toml
+++ b/listings/ch07-managing-growing-projects/listing-07-19/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "restaurant"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch07-managing-growing-projects/listing-07-20/Cargo.toml
+++ b/listings/ch07-managing-growing-projects/listing-07-20/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "restaurant"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch07-managing-growing-projects/listing-07-21-and-22/Cargo.toml
+++ b/listings/ch07-managing-growing-projects/listing-07-21-and-22/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "restaurant"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch07-managing-growing-projects/no-listing-01-use-std-unnested/Cargo.toml
+++ b/listings/ch07-managing-growing-projects/no-listing-01-use-std-unnested/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "guessing_game"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/listings/ch07-managing-growing-projects/no-listing-02-extracting-hosting/Cargo.toml
+++ b/listings/ch07-managing-growing-projects/no-listing-02-extracting-hosting/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "restaurant"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch08-common-collections/listing-08-01/Cargo.toml
+++ b/listings/ch08-common-collections/listing-08-01/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "collections"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch08-common-collections/listing-08-02/Cargo.toml
+++ b/listings/ch08-common-collections/listing-08-02/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "collections"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch08-common-collections/listing-08-03/Cargo.toml
+++ b/listings/ch08-common-collections/listing-08-03/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "collections"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch08-common-collections/listing-08-04/Cargo.toml
+++ b/listings/ch08-common-collections/listing-08-04/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "collections"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch08-common-collections/listing-08-05/Cargo.toml
+++ b/listings/ch08-common-collections/listing-08-05/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "collections"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch08-common-collections/listing-08-06/Cargo.toml
+++ b/listings/ch08-common-collections/listing-08-06/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "collections"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch08-common-collections/listing-08-07/Cargo.toml
+++ b/listings/ch08-common-collections/listing-08-07/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "collections"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch08-common-collections/listing-08-08/Cargo.toml
+++ b/listings/ch08-common-collections/listing-08-08/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "collections"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch08-common-collections/listing-08-09/Cargo.toml
+++ b/listings/ch08-common-collections/listing-08-09/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "collections"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch08-common-collections/listing-08-10/Cargo.toml
+++ b/listings/ch08-common-collections/listing-08-10/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "collections"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch08-common-collections/listing-08-11/Cargo.toml
+++ b/listings/ch08-common-collections/listing-08-11/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "collections"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch08-common-collections/listing-08-12/Cargo.toml
+++ b/listings/ch08-common-collections/listing-08-12/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "collections"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch08-common-collections/listing-08-13/Cargo.toml
+++ b/listings/ch08-common-collections/listing-08-13/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "collections"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch08-common-collections/listing-08-14/Cargo.toml
+++ b/listings/ch08-common-collections/listing-08-14/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "collections"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch08-common-collections/listing-08-15/Cargo.toml
+++ b/listings/ch08-common-collections/listing-08-15/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "collections"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch08-common-collections/listing-08-16/Cargo.toml
+++ b/listings/ch08-common-collections/listing-08-16/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "collections"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch08-common-collections/listing-08-17/Cargo.toml
+++ b/listings/ch08-common-collections/listing-08-17/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "collections"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch08-common-collections/listing-08-18/Cargo.toml
+++ b/listings/ch08-common-collections/listing-08-18/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "collections"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch08-common-collections/listing-08-19/Cargo.toml
+++ b/listings/ch08-common-collections/listing-08-19/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "collections"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch08-common-collections/listing-08-20/Cargo.toml
+++ b/listings/ch08-common-collections/listing-08-20/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "collections"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch08-common-collections/listing-08-21/Cargo.toml
+++ b/listings/ch08-common-collections/listing-08-21/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "collections"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch08-common-collections/listing-08-22/Cargo.toml
+++ b/listings/ch08-common-collections/listing-08-22/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "collections"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch08-common-collections/listing-08-23/Cargo.toml
+++ b/listings/ch08-common-collections/listing-08-23/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "collections"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch08-common-collections/listing-08-24/Cargo.toml
+++ b/listings/ch08-common-collections/listing-08-24/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "collections"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch08-common-collections/listing-08-25/Cargo.toml
+++ b/listings/ch08-common-collections/listing-08-25/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "collections"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch08-common-collections/listing-08-26/Cargo.toml
+++ b/listings/ch08-common-collections/listing-08-26/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "collections"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch08-common-collections/no-listing-01-concat-multiple-strings/Cargo.toml
+++ b/listings/ch08-common-collections/no-listing-01-concat-multiple-strings/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "collections"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch08-common-collections/no-listing-02-format/Cargo.toml
+++ b/listings/ch08-common-collections/no-listing-02-format/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "collections"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch08-common-collections/no-listing-03-iterate-over-hashmap/Cargo.toml
+++ b/listings/ch08-common-collections/no-listing-03-iterate-over-hashmap/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "collections"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch08-common-collections/output-only-01-not-char-boundary/Cargo.toml
+++ b/listings/ch08-common-collections/output-only-01-not-char-boundary/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "collections"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch09-error-handling/listing-09-01/Cargo.toml
+++ b/listings/ch09-error-handling/listing-09-01/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "panic"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch09-error-handling/listing-09-03/Cargo.toml
+++ b/listings/ch09-error-handling/listing-09-03/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "error-handling"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch09-error-handling/listing-09-04/Cargo.toml
+++ b/listings/ch09-error-handling/listing-09-04/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "error-handling"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch09-error-handling/listing-09-05/Cargo.toml
+++ b/listings/ch09-error-handling/listing-09-05/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "error-handling"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch09-error-handling/listing-09-06/Cargo.toml
+++ b/listings/ch09-error-handling/listing-09-06/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "error-handling"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch09-error-handling/listing-09-07/Cargo.toml
+++ b/listings/ch09-error-handling/listing-09-07/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "error-handling"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch09-error-handling/listing-09-08/Cargo.toml
+++ b/listings/ch09-error-handling/listing-09-08/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "error-handling"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch09-error-handling/listing-09-09/Cargo.toml
+++ b/listings/ch09-error-handling/listing-09-09/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "error-handling"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch09-error-handling/listing-09-10/Cargo.toml
+++ b/listings/ch09-error-handling/listing-09-10/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "guessing_game"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch09-error-handling/no-listing-01-panic/Cargo.toml
+++ b/listings/ch09-error-handling/no-listing-01-panic/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "panic"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch09-error-handling/no-listing-02-ask-compiler-for-type/Cargo.toml
+++ b/listings/ch09-error-handling/no-listing-02-ask-compiler-for-type/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "error-handling"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch09-error-handling/no-listing-03-closures/Cargo.toml
+++ b/listings/ch09-error-handling/no-listing-03-closures/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "error-handling"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch09-error-handling/no-listing-04-unwrap/Cargo.toml
+++ b/listings/ch09-error-handling/no-listing-04-unwrap/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "error-handling"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch09-error-handling/no-listing-05-expect/Cargo.toml
+++ b/listings/ch09-error-handling/no-listing-05-expect/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "error-handling"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch09-error-handling/no-listing-06-question-mark-in-main/Cargo.toml
+++ b/listings/ch09-error-handling/no-listing-06-question-mark-in-main/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "error-handling"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch09-error-handling/no-listing-07-main-returning-result/Cargo.toml
+++ b/listings/ch09-error-handling/no-listing-07-main-returning-result/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "error-handling"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch09-error-handling/no-listing-08-unwrap-that-cant-fail/Cargo.toml
+++ b/listings/ch09-error-handling/no-listing-08-unwrap-that-cant-fail/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "error-handling"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch09-error-handling/no-listing-09-guess-out-of-range/Cargo.toml
+++ b/listings/ch09-error-handling/no-listing-09-guess-out-of-range/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "guessing_game"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch10-generic-types-traits-and-lifetimes/listing-10-01/Cargo.toml
+++ b/listings/ch10-generic-types-traits-and-lifetimes/listing-10-01/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "chapter10"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch10-generic-types-traits-and-lifetimes/listing-10-02/Cargo.toml
+++ b/listings/ch10-generic-types-traits-and-lifetimes/listing-10-02/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "chapter10"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch10-generic-types-traits-and-lifetimes/listing-10-03/Cargo.toml
+++ b/listings/ch10-generic-types-traits-and-lifetimes/listing-10-03/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "chapter10"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch10-generic-types-traits-and-lifetimes/listing-10-04/Cargo.toml
+++ b/listings/ch10-generic-types-traits-and-lifetimes/listing-10-04/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "chapter10"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch10-generic-types-traits-and-lifetimes/listing-10-05/Cargo.toml
+++ b/listings/ch10-generic-types-traits-and-lifetimes/listing-10-05/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "chapter10"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch10-generic-types-traits-and-lifetimes/listing-10-06/Cargo.toml
+++ b/listings/ch10-generic-types-traits-and-lifetimes/listing-10-06/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "chapter10"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch10-generic-types-traits-and-lifetimes/listing-10-07/Cargo.toml
+++ b/listings/ch10-generic-types-traits-and-lifetimes/listing-10-07/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "chapter10"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch10-generic-types-traits-and-lifetimes/listing-10-08/Cargo.toml
+++ b/listings/ch10-generic-types-traits-and-lifetimes/listing-10-08/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "chapter10"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch10-generic-types-traits-and-lifetimes/listing-10-09/Cargo.toml
+++ b/listings/ch10-generic-types-traits-and-lifetimes/listing-10-09/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "chapter10"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch10-generic-types-traits-and-lifetimes/listing-10-10/Cargo.toml
+++ b/listings/ch10-generic-types-traits-and-lifetimes/listing-10-10/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "chapter10"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch10-generic-types-traits-and-lifetimes/listing-10-11/Cargo.toml
+++ b/listings/ch10-generic-types-traits-and-lifetimes/listing-10-11/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "chapter10"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch10-generic-types-traits-and-lifetimes/listing-10-12/Cargo.toml
+++ b/listings/ch10-generic-types-traits-and-lifetimes/listing-10-12/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "chapter10"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch10-generic-types-traits-and-lifetimes/listing-10-13/Cargo.toml
+++ b/listings/ch10-generic-types-traits-and-lifetimes/listing-10-13/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "chapter10"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch10-generic-types-traits-and-lifetimes/listing-10-14/Cargo.toml
+++ b/listings/ch10-generic-types-traits-and-lifetimes/listing-10-14/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "chapter10"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch10-generic-types-traits-and-lifetimes/listing-10-15/Cargo.toml
+++ b/listings/ch10-generic-types-traits-and-lifetimes/listing-10-15/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "chapter10"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch10-generic-types-traits-and-lifetimes/listing-10-16/Cargo.toml
+++ b/listings/ch10-generic-types-traits-and-lifetimes/listing-10-16/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "chapter10"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch10-generic-types-traits-and-lifetimes/listing-10-17/Cargo.toml
+++ b/listings/ch10-generic-types-traits-and-lifetimes/listing-10-17/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "chapter10"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch10-generic-types-traits-and-lifetimes/listing-10-18/Cargo.toml
+++ b/listings/ch10-generic-types-traits-and-lifetimes/listing-10-18/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "chapter10"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch10-generic-types-traits-and-lifetimes/listing-10-19/Cargo.toml
+++ b/listings/ch10-generic-types-traits-and-lifetimes/listing-10-19/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "chapter10"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch10-generic-types-traits-and-lifetimes/listing-10-20/Cargo.toml
+++ b/listings/ch10-generic-types-traits-and-lifetimes/listing-10-20/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "chapter10"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch10-generic-types-traits-and-lifetimes/listing-10-21/Cargo.toml
+++ b/listings/ch10-generic-types-traits-and-lifetimes/listing-10-21/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "chapter10"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch10-generic-types-traits-and-lifetimes/listing-10-22/Cargo.toml
+++ b/listings/ch10-generic-types-traits-and-lifetimes/listing-10-22/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "chapter10"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch10-generic-types-traits-and-lifetimes/listing-10-23/Cargo.toml
+++ b/listings/ch10-generic-types-traits-and-lifetimes/listing-10-23/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "chapter10"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch10-generic-types-traits-and-lifetimes/listing-10-24/Cargo.toml
+++ b/listings/ch10-generic-types-traits-and-lifetimes/listing-10-24/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "chapter10"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch10-generic-types-traits-and-lifetimes/listing-10-25/Cargo.toml
+++ b/listings/ch10-generic-types-traits-and-lifetimes/listing-10-25/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "chapter10"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch10-generic-types-traits-and-lifetimes/listing-10-26/Cargo.toml
+++ b/listings/ch10-generic-types-traits-and-lifetimes/listing-10-26/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ownership"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch10-generic-types-traits-and-lifetimes/no-listing-01-calling-trait-method/Cargo.toml
+++ b/listings/ch10-generic-types-traits-and-lifetimes/no-listing-01-calling-trait-method/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "chapter10"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch10-generic-types-traits-and-lifetimes/no-listing-02-calling-default-impl/Cargo.toml
+++ b/listings/ch10-generic-types-traits-and-lifetimes/no-listing-02-calling-default-impl/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "chapter10"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch10-generic-types-traits-and-lifetimes/no-listing-03-default-impl-calls-other-methods/Cargo.toml
+++ b/listings/ch10-generic-types-traits-and-lifetimes/no-listing-03-default-impl-calls-other-methods/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "chapter10"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch10-generic-types-traits-and-lifetimes/no-listing-04-traits-as-parameters/Cargo.toml
+++ b/listings/ch10-generic-types-traits-and-lifetimes/no-listing-04-traits-as-parameters/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "chapter10"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch10-generic-types-traits-and-lifetimes/no-listing-05-returning-impl-trait/Cargo.toml
+++ b/listings/ch10-generic-types-traits-and-lifetimes/no-listing-05-returning-impl-trait/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "chapter10"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch10-generic-types-traits-and-lifetimes/no-listing-06-impl-trait-returns-one-type/Cargo.toml
+++ b/listings/ch10-generic-types-traits-and-lifetimes/no-listing-06-impl-trait-returns-one-type/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "chapter10"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch10-generic-types-traits-and-lifetimes/no-listing-07-fixing-listing-10-05/Cargo.toml
+++ b/listings/ch10-generic-types-traits-and-lifetimes/no-listing-07-fixing-listing-10-05/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "chapter10"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch10-generic-types-traits-and-lifetimes/no-listing-08-only-one-reference-with-lifetime/Cargo.toml
+++ b/listings/ch10-generic-types-traits-and-lifetimes/no-listing-08-only-one-reference-with-lifetime/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "chapter10"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch10-generic-types-traits-and-lifetimes/no-listing-09-unrelated-lifetime/Cargo.toml
+++ b/listings/ch10-generic-types-traits-and-lifetimes/no-listing-09-unrelated-lifetime/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "chapter10"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch10-generic-types-traits-and-lifetimes/no-listing-10-lifetimes-on-methods/Cargo.toml
+++ b/listings/ch10-generic-types-traits-and-lifetimes/no-listing-10-lifetimes-on-methods/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "chapter10"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch10-generic-types-traits-and-lifetimes/no-listing-11-generics-traits-and-lifetimes/Cargo.toml
+++ b/listings/ch10-generic-types-traits-and-lifetimes/no-listing-11-generics-traits-and-lifetimes/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "chapter10"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch11-writing-automated-tests/listing-11-01/Cargo.toml
+++ b/listings/ch11-writing-automated-tests/listing-11-01/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "adder"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch11-writing-automated-tests/listing-11-03/Cargo.toml
+++ b/listings/ch11-writing-automated-tests/listing-11-03/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "adder"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch11-writing-automated-tests/listing-11-05/Cargo.toml
+++ b/listings/ch11-writing-automated-tests/listing-11-05/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "rectangle"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch11-writing-automated-tests/listing-11-06/Cargo.toml
+++ b/listings/ch11-writing-automated-tests/listing-11-06/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "rectangle"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch11-writing-automated-tests/listing-11-07/Cargo.toml
+++ b/listings/ch11-writing-automated-tests/listing-11-07/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "adder"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch11-writing-automated-tests/listing-11-08/Cargo.toml
+++ b/listings/ch11-writing-automated-tests/listing-11-08/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "guessing_game"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch11-writing-automated-tests/listing-11-09/Cargo.toml
+++ b/listings/ch11-writing-automated-tests/listing-11-09/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "guessing_game"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch11-writing-automated-tests/listing-11-10/Cargo.toml
+++ b/listings/ch11-writing-automated-tests/listing-11-10/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "silly-function"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch11-writing-automated-tests/listing-11-11/Cargo.toml
+++ b/listings/ch11-writing-automated-tests/listing-11-11/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "adder"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch11-writing-automated-tests/listing-11-12/Cargo.toml
+++ b/listings/ch11-writing-automated-tests/listing-11-12/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "adder"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch11-writing-automated-tests/listing-11-13/Cargo.toml
+++ b/listings/ch11-writing-automated-tests/listing-11-13/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "adder"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch11-writing-automated-tests/no-listing-01-changing-test-name/Cargo.toml
+++ b/listings/ch11-writing-automated-tests/no-listing-01-changing-test-name/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "adder"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch11-writing-automated-tests/no-listing-02-adding-another-rectangle-test/Cargo.toml
+++ b/listings/ch11-writing-automated-tests/no-listing-02-adding-another-rectangle-test/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "rectangle"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch11-writing-automated-tests/no-listing-03-introducing-a-bug/Cargo.toml
+++ b/listings/ch11-writing-automated-tests/no-listing-03-introducing-a-bug/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "rectangle"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch11-writing-automated-tests/no-listing-04-bug-in-add-two/Cargo.toml
+++ b/listings/ch11-writing-automated-tests/no-listing-04-bug-in-add-two/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "adder"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch11-writing-automated-tests/no-listing-05-greeter/Cargo.toml
+++ b/listings/ch11-writing-automated-tests/no-listing-05-greeter/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "greeter"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch11-writing-automated-tests/no-listing-06-greeter-with-bug/Cargo.toml
+++ b/listings/ch11-writing-automated-tests/no-listing-06-greeter-with-bug/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "greeter"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch11-writing-automated-tests/no-listing-07-custom-failure-message/Cargo.toml
+++ b/listings/ch11-writing-automated-tests/no-listing-07-custom-failure-message/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "greeter"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch11-writing-automated-tests/no-listing-08-guess-with-bug/Cargo.toml
+++ b/listings/ch11-writing-automated-tests/no-listing-08-guess-with-bug/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "guessing_game"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch11-writing-automated-tests/no-listing-09-guess-with-panic-msg-bug/Cargo.toml
+++ b/listings/ch11-writing-automated-tests/no-listing-09-guess-with-panic-msg-bug/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "guessing_game"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch11-writing-automated-tests/no-listing-10-result-in-tests/Cargo.toml
+++ b/listings/ch11-writing-automated-tests/no-listing-10-result-in-tests/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "adder"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch11-writing-automated-tests/no-listing-11-ignore-a-test/Cargo.toml
+++ b/listings/ch11-writing-automated-tests/no-listing-11-ignore-a-test/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "adder"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch11-writing-automated-tests/no-listing-12-shared-test-code-problem/Cargo.toml
+++ b/listings/ch11-writing-automated-tests/no-listing-12-shared-test-code-problem/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "adder"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch11-writing-automated-tests/no-listing-13-fix-shared-test-code-problem/Cargo.toml
+++ b/listings/ch11-writing-automated-tests/no-listing-13-fix-shared-test-code-problem/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "adder"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch11-writing-automated-tests/output-only-01-show-output/Cargo.toml
+++ b/listings/ch11-writing-automated-tests/output-only-01-show-output/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "silly-function"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch11-writing-automated-tests/output-only-02-single-test/Cargo.toml
+++ b/listings/ch11-writing-automated-tests/output-only-02-single-test/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "adder"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch11-writing-automated-tests/output-only-03-multiple-tests/Cargo.toml
+++ b/listings/ch11-writing-automated-tests/output-only-03-multiple-tests/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "adder"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch11-writing-automated-tests/output-only-04-running-ignored/Cargo.toml
+++ b/listings/ch11-writing-automated-tests/output-only-04-running-ignored/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "adder"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch11-writing-automated-tests/output-only-05-single-integration/Cargo.toml
+++ b/listings/ch11-writing-automated-tests/output-only-05-single-integration/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "adder"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch12-an-io-project/listing-12-01/Cargo.toml
+++ b/listings/ch12-an-io-project/listing-12-01/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "minigrep"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch12-an-io-project/listing-12-02/Cargo.toml
+++ b/listings/ch12-an-io-project/listing-12-02/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "minigrep"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch12-an-io-project/listing-12-03/Cargo.toml
+++ b/listings/ch12-an-io-project/listing-12-03/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "minigrep"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch12-an-io-project/listing-12-04/Cargo.toml
+++ b/listings/ch12-an-io-project/listing-12-04/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "minigrep"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch12-an-io-project/listing-12-05/Cargo.toml
+++ b/listings/ch12-an-io-project/listing-12-05/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "minigrep"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch12-an-io-project/listing-12-06/Cargo.toml
+++ b/listings/ch12-an-io-project/listing-12-06/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "minigrep"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch12-an-io-project/listing-12-07/Cargo.toml
+++ b/listings/ch12-an-io-project/listing-12-07/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "minigrep"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch12-an-io-project/listing-12-08/Cargo.toml
+++ b/listings/ch12-an-io-project/listing-12-08/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "minigrep"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch12-an-io-project/listing-12-09/Cargo.toml
+++ b/listings/ch12-an-io-project/listing-12-09/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "minigrep"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch12-an-io-project/listing-12-10/Cargo.toml
+++ b/listings/ch12-an-io-project/listing-12-10/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "minigrep"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch12-an-io-project/listing-12-11/Cargo.toml
+++ b/listings/ch12-an-io-project/listing-12-11/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "minigrep"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch12-an-io-project/listing-12-12/Cargo.toml
+++ b/listings/ch12-an-io-project/listing-12-12/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "minigrep"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch12-an-io-project/listing-12-13/Cargo.toml
+++ b/listings/ch12-an-io-project/listing-12-13/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "minigrep"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch12-an-io-project/listing-12-14/Cargo.toml
+++ b/listings/ch12-an-io-project/listing-12-14/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "minigrep"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch12-an-io-project/listing-12-15/Cargo.toml
+++ b/listings/ch12-an-io-project/listing-12-15/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "minigrep"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch12-an-io-project/listing-12-16/Cargo.toml
+++ b/listings/ch12-an-io-project/listing-12-16/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "minigrep"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch12-an-io-project/listing-12-17/Cargo.toml
+++ b/listings/ch12-an-io-project/listing-12-17/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "minigrep"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch12-an-io-project/listing-12-18/Cargo.toml
+++ b/listings/ch12-an-io-project/listing-12-18/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "minigrep"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch12-an-io-project/listing-12-19/Cargo.toml
+++ b/listings/ch12-an-io-project/listing-12-19/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "minigrep"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch12-an-io-project/listing-12-20/Cargo.toml
+++ b/listings/ch12-an-io-project/listing-12-20/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "minigrep"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch12-an-io-project/listing-12-21/Cargo.toml
+++ b/listings/ch12-an-io-project/listing-12-21/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "minigrep"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch12-an-io-project/listing-12-22/Cargo.toml
+++ b/listings/ch12-an-io-project/listing-12-22/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "minigrep"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch12-an-io-project/listing-12-23/Cargo.toml
+++ b/listings/ch12-an-io-project/listing-12-23/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "minigrep"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch12-an-io-project/listing-12-24/Cargo.toml
+++ b/listings/ch12-an-io-project/listing-12-24/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "minigrep"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch12-an-io-project/no-listing-01-handling-errors-in-main/Cargo.toml
+++ b/listings/ch12-an-io-project/no-listing-01-handling-errors-in-main/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "minigrep"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch12-an-io-project/no-listing-02-using-search-in-run/Cargo.toml
+++ b/listings/ch12-an-io-project/no-listing-02-using-search-in-run/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "minigrep"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch12-an-io-project/output-only-01-with-args/Cargo.toml
+++ b/listings/ch12-an-io-project/output-only-01-with-args/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "minigrep"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch12-an-io-project/output-only-02-missing-lifetimes/Cargo.toml
+++ b/listings/ch12-an-io-project/output-only-02-missing-lifetimes/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "minigrep"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch12-an-io-project/output-only-03-multiple-matches/Cargo.toml
+++ b/listings/ch12-an-io-project/output-only-03-multiple-matches/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "minigrep"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch12-an-io-project/output-only-04-no-matches/Cargo.toml
+++ b/listings/ch12-an-io-project/output-only-04-no-matches/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "minigrep"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch13-functional-features/listing-12-23-reproduced/Cargo.toml
+++ b/listings/ch13-functional-features/listing-12-23-reproduced/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "minigrep"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch13-functional-features/listing-12-24-reproduced/Cargo.toml
+++ b/listings/ch13-functional-features/listing-12-24-reproduced/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "minigrep"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch13-functional-features/listing-13-01/Cargo.toml
+++ b/listings/ch13-functional-features/listing-13-01/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "workout-app"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch13-functional-features/listing-13-02/Cargo.toml
+++ b/listings/ch13-functional-features/listing-13-02/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "workout-app"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch13-functional-features/listing-13-03/Cargo.toml
+++ b/listings/ch13-functional-features/listing-13-03/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "workout-app"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch13-functional-features/listing-13-04/Cargo.toml
+++ b/listings/ch13-functional-features/listing-13-04/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "workout-app"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch13-functional-features/listing-13-05/Cargo.toml
+++ b/listings/ch13-functional-features/listing-13-05/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "workout-app"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch13-functional-features/listing-13-06/Cargo.toml
+++ b/listings/ch13-functional-features/listing-13-06/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "workout-app"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch13-functional-features/listing-13-07/Cargo.toml
+++ b/listings/ch13-functional-features/listing-13-07/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "workout-app"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch13-functional-features/listing-13-08/Cargo.toml
+++ b/listings/ch13-functional-features/listing-13-08/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "closure-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch13-functional-features/listing-13-09/Cargo.toml
+++ b/listings/ch13-functional-features/listing-13-09/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "cacher"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch13-functional-features/listing-13-10/Cargo.toml
+++ b/listings/ch13-functional-features/listing-13-10/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "cacher"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch13-functional-features/listing-13-11/Cargo.toml
+++ b/listings/ch13-functional-features/listing-13-11/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "workout-app"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch13-functional-features/listing-13-12/Cargo.toml
+++ b/listings/ch13-functional-features/listing-13-12/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "equal-to-x"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch13-functional-features/listing-13-13/Cargo.toml
+++ b/listings/ch13-functional-features/listing-13-13/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "iterators"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch13-functional-features/listing-13-14/Cargo.toml
+++ b/listings/ch13-functional-features/listing-13-14/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "iterators"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch13-functional-features/listing-13-15/Cargo.toml
+++ b/listings/ch13-functional-features/listing-13-15/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "iterators"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch13-functional-features/listing-13-16/Cargo.toml
+++ b/listings/ch13-functional-features/listing-13-16/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "iterators"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch13-functional-features/listing-13-17/Cargo.toml
+++ b/listings/ch13-functional-features/listing-13-17/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "iterators"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch13-functional-features/listing-13-18/Cargo.toml
+++ b/listings/ch13-functional-features/listing-13-18/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "iterators"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch13-functional-features/listing-13-19/Cargo.toml
+++ b/listings/ch13-functional-features/listing-13-19/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "shoe_size"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch13-functional-features/listing-13-20/Cargo.toml
+++ b/listings/ch13-functional-features/listing-13-20/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "counter"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch13-functional-features/listing-13-21/Cargo.toml
+++ b/listings/ch13-functional-features/listing-13-21/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "counter"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch13-functional-features/listing-13-22/Cargo.toml
+++ b/listings/ch13-functional-features/listing-13-22/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "counter"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch13-functional-features/listing-13-23/Cargo.toml
+++ b/listings/ch13-functional-features/listing-13-23/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "counter"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch13-functional-features/listing-13-25/Cargo.toml
+++ b/listings/ch13-functional-features/listing-13-25/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "minigrep"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch13-functional-features/listing-13-26/Cargo.toml
+++ b/listings/ch13-functional-features/listing-13-26/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "minigrep"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch13-functional-features/listing-13-27/Cargo.toml
+++ b/listings/ch13-functional-features/listing-13-27/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "minigrep"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch13-functional-features/listing-13-29/Cargo.toml
+++ b/listings/ch13-functional-features/listing-13-29/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "minigrep"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch13-functional-features/no-listing-01-failing-cacher-test/Cargo.toml
+++ b/listings/ch13-functional-features/no-listing-01-failing-cacher-test/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "cacher"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch13-functional-features/no-listing-02-functions-cant-capture/Cargo.toml
+++ b/listings/ch13-functional-features/no-listing-02-functions-cant-capture/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "equal-to-x"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch13-functional-features/no-listing-03-move-closures/Cargo.toml
+++ b/listings/ch13-functional-features/no-listing-03-move-closures/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "equal-to-x"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch14-more-about-cargo/listing-14-01/Cargo.toml
+++ b/listings/ch14-more-about-cargo/listing-14-01/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "my_crate"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch14-more-about-cargo/listing-14-02/Cargo.toml
+++ b/listings/ch14-more-about-cargo/listing-14-02/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "my_crate"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch14-more-about-cargo/listing-14-03/Cargo.toml
+++ b/listings/ch14-more-about-cargo/listing-14-03/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "art"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch14-more-about-cargo/listing-14-04/Cargo.toml
+++ b/listings/ch14-more-about-cargo/listing-14-04/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "art"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch14-more-about-cargo/listing-14-05/Cargo.toml
+++ b/listings/ch14-more-about-cargo/listing-14-05/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "art"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch14-more-about-cargo/listing-14-06/Cargo.toml
+++ b/listings/ch14-more-about-cargo/listing-14-06/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "art"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch14-more-about-cargo/listing-14-07/add/add-one/Cargo.toml
+++ b/listings/ch14-more-about-cargo/listing-14-07/add/add-one/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "add-one"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch14-more-about-cargo/listing-14-07/add/adder/Cargo.toml
+++ b/listings/ch14-more-about-cargo/listing-14-07/add/adder/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "adder"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch14-more-about-cargo/no-listing-03-workspace-with-external-dependency/add/adder/Cargo.toml
+++ b/listings/ch14-more-about-cargo/no-listing-03-workspace-with-external-dependency/add/adder/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "adder"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch14-more-about-cargo/no-listing-04-workspace-with-tests/add/add-one/Cargo.toml
+++ b/listings/ch14-more-about-cargo/no-listing-04-workspace-with-tests/add/add-one/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "add-one"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch14-more-about-cargo/no-listing-04-workspace-with-tests/add/adder/Cargo.toml
+++ b/listings/ch14-more-about-cargo/no-listing-04-workspace-with-tests/add/adder/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "adder"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch14-more-about-cargo/output-only-02-add-one/add/add-one/Cargo.toml
+++ b/listings/ch14-more-about-cargo/output-only-02-add-one/add/add-one/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "add-one"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/listings/ch14-more-about-cargo/output-only-02-add-one/add/adder/Cargo.toml
+++ b/listings/ch14-more-about-cargo/output-only-02-add-one/add/adder/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "adder"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch14-more-about-cargo/output-only-03-use-rand/add/add-one/Cargo.toml
+++ b/listings/ch14-more-about-cargo/output-only-03-use-rand/add/add-one/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "add-one"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch14-more-about-cargo/output-only-03-use-rand/add/adder/Cargo.toml
+++ b/listings/ch14-more-about-cargo/output-only-03-use-rand/add/adder/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "adder"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch15-smart-pointers/listing-15-01/Cargo.toml
+++ b/listings/ch15-smart-pointers/listing-15-01/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "box-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch15-smart-pointers/listing-15-02/Cargo.toml
+++ b/listings/ch15-smart-pointers/listing-15-02/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "cons-list"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch15-smart-pointers/listing-15-03/Cargo.toml
+++ b/listings/ch15-smart-pointers/listing-15-03/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "cons-list"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch15-smart-pointers/listing-15-05/Cargo.toml
+++ b/listings/ch15-smart-pointers/listing-15-05/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "cons-list"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch15-smart-pointers/listing-15-06/Cargo.toml
+++ b/listings/ch15-smart-pointers/listing-15-06/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "deref-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch15-smart-pointers/listing-15-07/Cargo.toml
+++ b/listings/ch15-smart-pointers/listing-15-07/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "deref-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch15-smart-pointers/listing-15-08/Cargo.toml
+++ b/listings/ch15-smart-pointers/listing-15-08/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "deref-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch15-smart-pointers/listing-15-09/Cargo.toml
+++ b/listings/ch15-smart-pointers/listing-15-09/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "deref-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch15-smart-pointers/listing-15-10/Cargo.toml
+++ b/listings/ch15-smart-pointers/listing-15-10/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "deref-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch15-smart-pointers/listing-15-11/Cargo.toml
+++ b/listings/ch15-smart-pointers/listing-15-11/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "deref-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch15-smart-pointers/listing-15-12/Cargo.toml
+++ b/listings/ch15-smart-pointers/listing-15-12/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "deref-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch15-smart-pointers/listing-15-13/Cargo.toml
+++ b/listings/ch15-smart-pointers/listing-15-13/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "deref-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch15-smart-pointers/listing-15-14/Cargo.toml
+++ b/listings/ch15-smart-pointers/listing-15-14/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "drop-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch15-smart-pointers/listing-15-15/Cargo.toml
+++ b/listings/ch15-smart-pointers/listing-15-15/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "drop-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch15-smart-pointers/listing-15-16/Cargo.toml
+++ b/listings/ch15-smart-pointers/listing-15-16/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "drop-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch15-smart-pointers/listing-15-17/Cargo.toml
+++ b/listings/ch15-smart-pointers/listing-15-17/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "cons-list"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch15-smart-pointers/listing-15-18/Cargo.toml
+++ b/listings/ch15-smart-pointers/listing-15-18/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "cons-list"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch15-smart-pointers/listing-15-19/Cargo.toml
+++ b/listings/ch15-smart-pointers/listing-15-19/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "cons-list"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch15-smart-pointers/listing-15-20/Cargo.toml
+++ b/listings/ch15-smart-pointers/listing-15-20/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "limit-tracker"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch15-smart-pointers/listing-15-21/Cargo.toml
+++ b/listings/ch15-smart-pointers/listing-15-21/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "limit-tracker"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch15-smart-pointers/listing-15-22/Cargo.toml
+++ b/listings/ch15-smart-pointers/listing-15-22/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "limit-tracker"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch15-smart-pointers/listing-15-23/Cargo.toml
+++ b/listings/ch15-smart-pointers/listing-15-23/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "limit-tracker"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch15-smart-pointers/listing-15-24/Cargo.toml
+++ b/listings/ch15-smart-pointers/listing-15-24/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "cons-list"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch15-smart-pointers/listing-15-25/Cargo.toml
+++ b/listings/ch15-smart-pointers/listing-15-25/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "cons-list"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch15-smart-pointers/listing-15-26/Cargo.toml
+++ b/listings/ch15-smart-pointers/listing-15-26/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "cons-list"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch15-smart-pointers/listing-15-27/Cargo.toml
+++ b/listings/ch15-smart-pointers/listing-15-27/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "tree"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch15-smart-pointers/listing-15-28/Cargo.toml
+++ b/listings/ch15-smart-pointers/listing-15-28/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "tree"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch15-smart-pointers/listing-15-29/Cargo.toml
+++ b/listings/ch15-smart-pointers/listing-15-29/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "tree"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch15-smart-pointers/no-listing-01-cant-borrow-immutable-as-mutable/Cargo.toml
+++ b/listings/ch15-smart-pointers/no-listing-01-cant-borrow-immutable-as-mutable/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "borrowing"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch15-smart-pointers/output-only-01-comparing-to-reference/Cargo.toml
+++ b/listings/ch15-smart-pointers/output-only-01-comparing-to-reference/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "deref-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch16-fearless-concurrency/listing-16-01/Cargo.toml
+++ b/listings/ch16-fearless-concurrency/listing-16-01/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "threads"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch16-fearless-concurrency/listing-16-02/Cargo.toml
+++ b/listings/ch16-fearless-concurrency/listing-16-02/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "threads"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch16-fearless-concurrency/listing-16-03/Cargo.toml
+++ b/listings/ch16-fearless-concurrency/listing-16-03/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "threads"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch16-fearless-concurrency/listing-16-04/Cargo.toml
+++ b/listings/ch16-fearless-concurrency/listing-16-04/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "threads"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch16-fearless-concurrency/listing-16-05/Cargo.toml
+++ b/listings/ch16-fearless-concurrency/listing-16-05/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "threads"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch16-fearless-concurrency/listing-16-06/Cargo.toml
+++ b/listings/ch16-fearless-concurrency/listing-16-06/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "message-passing"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch16-fearless-concurrency/listing-16-07/Cargo.toml
+++ b/listings/ch16-fearless-concurrency/listing-16-07/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "message-passing"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch16-fearless-concurrency/listing-16-08/Cargo.toml
+++ b/listings/ch16-fearless-concurrency/listing-16-08/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "message-passing"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch16-fearless-concurrency/listing-16-09/Cargo.toml
+++ b/listings/ch16-fearless-concurrency/listing-16-09/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "message-passing"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch16-fearless-concurrency/listing-16-10/Cargo.toml
+++ b/listings/ch16-fearless-concurrency/listing-16-10/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "message-passing"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch16-fearless-concurrency/listing-16-11/Cargo.toml
+++ b/listings/ch16-fearless-concurrency/listing-16-11/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "message-passing"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch16-fearless-concurrency/listing-16-12/Cargo.toml
+++ b/listings/ch16-fearless-concurrency/listing-16-12/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "shared-state"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch16-fearless-concurrency/listing-16-13/Cargo.toml
+++ b/listings/ch16-fearless-concurrency/listing-16-13/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "shared-state"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch16-fearless-concurrency/listing-16-14/Cargo.toml
+++ b/listings/ch16-fearless-concurrency/listing-16-14/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "shared-state"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch16-fearless-concurrency/listing-16-15/Cargo.toml
+++ b/listings/ch16-fearless-concurrency/listing-16-15/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "shared-state"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch16-fearless-concurrency/no-listing-01-join-too-early/Cargo.toml
+++ b/listings/ch16-fearless-concurrency/no-listing-01-join-too-early/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "threads"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch16-fearless-concurrency/no-listing-02-no-loop-to-understand-error/Cargo.toml
+++ b/listings/ch16-fearless-concurrency/no-listing-02-no-loop-to-understand-error/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "shared-state"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch16-fearless-concurrency/output-only-01-move-drop/Cargo.toml
+++ b/listings/ch16-fearless-concurrency/output-only-01-move-drop/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "threads"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch17-oop/listing-17-01/Cargo.toml
+++ b/listings/ch17-oop/listing-17-01/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "averaged-collection"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch17-oop/listing-17-02/Cargo.toml
+++ b/listings/ch17-oop/listing-17-02/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "averaged-collection"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch17-oop/listing-17-03/Cargo.toml
+++ b/listings/ch17-oop/listing-17-03/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "gui"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch17-oop/listing-17-04/Cargo.toml
+++ b/listings/ch17-oop/listing-17-04/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "gui"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch17-oop/listing-17-05/Cargo.toml
+++ b/listings/ch17-oop/listing-17-05/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "gui"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch17-oop/listing-17-06/Cargo.toml
+++ b/listings/ch17-oop/listing-17-06/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "gui"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch17-oop/listing-17-07/Cargo.toml
+++ b/listings/ch17-oop/listing-17-07/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "gui"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch17-oop/listing-17-08/Cargo.toml
+++ b/listings/ch17-oop/listing-17-08/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "gui"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch17-oop/listing-17-09/Cargo.toml
+++ b/listings/ch17-oop/listing-17-09/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "gui"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch17-oop/listing-17-10/Cargo.toml
+++ b/listings/ch17-oop/listing-17-10/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "gui"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch17-oop/listing-17-11/Cargo.toml
+++ b/listings/ch17-oop/listing-17-11/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "blog"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch17-oop/listing-17-12/Cargo.toml
+++ b/listings/ch17-oop/listing-17-12/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "blog"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch17-oop/listing-17-13/Cargo.toml
+++ b/listings/ch17-oop/listing-17-13/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "blog"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch17-oop/listing-17-14/Cargo.toml
+++ b/listings/ch17-oop/listing-17-14/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "blog"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch17-oop/listing-17-15/Cargo.toml
+++ b/listings/ch17-oop/listing-17-15/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "blog"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch17-oop/listing-17-16/Cargo.toml
+++ b/listings/ch17-oop/listing-17-16/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "blog"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch17-oop/listing-17-17/Cargo.toml
+++ b/listings/ch17-oop/listing-17-17/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "blog"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch17-oop/listing-17-18/Cargo.toml
+++ b/listings/ch17-oop/listing-17-18/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "blog"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch17-oop/listing-17-19/Cargo.toml
+++ b/listings/ch17-oop/listing-17-19/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "blog"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch17-oop/listing-17-20/Cargo.toml
+++ b/listings/ch17-oop/listing-17-20/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "blog"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch17-oop/listing-17-21/Cargo.toml
+++ b/listings/ch17-oop/listing-17-21/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "blog"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch17-oop/no-listing-01-trait-object-of-clone/Cargo.toml
+++ b/listings/ch17-oop/no-listing-01-trait-object-of-clone/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "gui"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch18-patterns-and-matching/listing-18-01/Cargo.toml
+++ b/listings/ch18-patterns-and-matching/listing-18-01/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "patterns"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch18-patterns-and-matching/listing-18-02/Cargo.toml
+++ b/listings/ch18-patterns-and-matching/listing-18-02/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "patterns"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch18-patterns-and-matching/listing-18-03/Cargo.toml
+++ b/listings/ch18-patterns-and-matching/listing-18-03/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "patterns"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch18-patterns-and-matching/listing-18-04/Cargo.toml
+++ b/listings/ch18-patterns-and-matching/listing-18-04/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "patterns"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch18-patterns-and-matching/listing-18-05/Cargo.toml
+++ b/listings/ch18-patterns-and-matching/listing-18-05/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "patterns"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch18-patterns-and-matching/listing-18-06/Cargo.toml
+++ b/listings/ch18-patterns-and-matching/listing-18-06/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "patterns"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch18-patterns-and-matching/listing-18-07/Cargo.toml
+++ b/listings/ch18-patterns-and-matching/listing-18-07/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "patterns"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch18-patterns-and-matching/listing-18-08/Cargo.toml
+++ b/listings/ch18-patterns-and-matching/listing-18-08/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "patterns"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch18-patterns-and-matching/listing-18-09/Cargo.toml
+++ b/listings/ch18-patterns-and-matching/listing-18-09/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "patterns"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch18-patterns-and-matching/listing-18-10/Cargo.toml
+++ b/listings/ch18-patterns-and-matching/listing-18-10/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "patterns"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch18-patterns-and-matching/listing-18-11/Cargo.toml
+++ b/listings/ch18-patterns-and-matching/listing-18-11/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "patterns"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch18-patterns-and-matching/listing-18-12/Cargo.toml
+++ b/listings/ch18-patterns-and-matching/listing-18-12/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "patterns"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch18-patterns-and-matching/listing-18-13/Cargo.toml
+++ b/listings/ch18-patterns-and-matching/listing-18-13/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "patterns"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch18-patterns-and-matching/listing-18-14/Cargo.toml
+++ b/listings/ch18-patterns-and-matching/listing-18-14/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "patterns"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch18-patterns-and-matching/listing-18-15/Cargo.toml
+++ b/listings/ch18-patterns-and-matching/listing-18-15/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "patterns"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch18-patterns-and-matching/listing-18-16/Cargo.toml
+++ b/listings/ch18-patterns-and-matching/listing-18-16/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "patterns"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch18-patterns-and-matching/listing-18-17/Cargo.toml
+++ b/listings/ch18-patterns-and-matching/listing-18-17/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "patterns"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch18-patterns-and-matching/listing-18-18/Cargo.toml
+++ b/listings/ch18-patterns-and-matching/listing-18-18/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "patterns"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch18-patterns-and-matching/listing-18-19/Cargo.toml
+++ b/listings/ch18-patterns-and-matching/listing-18-19/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "patterns"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch18-patterns-and-matching/listing-18-20/Cargo.toml
+++ b/listings/ch18-patterns-and-matching/listing-18-20/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "patterns"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch18-patterns-and-matching/listing-18-21/Cargo.toml
+++ b/listings/ch18-patterns-and-matching/listing-18-21/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "patterns"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch18-patterns-and-matching/listing-18-22/Cargo.toml
+++ b/listings/ch18-patterns-and-matching/listing-18-22/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "patterns"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch18-patterns-and-matching/listing-18-23/Cargo.toml
+++ b/listings/ch18-patterns-and-matching/listing-18-23/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "patterns"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch18-patterns-and-matching/listing-18-24/Cargo.toml
+++ b/listings/ch18-patterns-and-matching/listing-18-24/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "patterns"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch18-patterns-and-matching/listing-18-25/Cargo.toml
+++ b/listings/ch18-patterns-and-matching/listing-18-25/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "patterns"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch18-patterns-and-matching/listing-18-26/Cargo.toml
+++ b/listings/ch18-patterns-and-matching/listing-18-26/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "patterns"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch18-patterns-and-matching/listing-18-27/Cargo.toml
+++ b/listings/ch18-patterns-and-matching/listing-18-27/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "patterns"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch18-patterns-and-matching/listing-18-28/Cargo.toml
+++ b/listings/ch18-patterns-and-matching/listing-18-28/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "patterns"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch18-patterns-and-matching/listing-18-29/Cargo.toml
+++ b/listings/ch18-patterns-and-matching/listing-18-29/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "patterns"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch18-patterns-and-matching/no-listing-01-literals/Cargo.toml
+++ b/listings/ch18-patterns-and-matching/no-listing-01-literals/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "patterns"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch18-patterns-and-matching/no-listing-02-multiple-patterns/Cargo.toml
+++ b/listings/ch18-patterns-and-matching/no-listing-02-multiple-patterns/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "patterns"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch18-patterns-and-matching/no-listing-03-ranges/Cargo.toml
+++ b/listings/ch18-patterns-and-matching/no-listing-03-ranges/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "patterns"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch18-patterns-and-matching/no-listing-04-ranges-of-char/Cargo.toml
+++ b/listings/ch18-patterns-and-matching/no-listing-04-ranges-of-char/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "patterns"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch18-patterns-and-matching/no-listing-05-destructuring-structs-and-tuples/Cargo.toml
+++ b/listings/ch18-patterns-and-matching/no-listing-05-destructuring-structs-and-tuples/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "patterns"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/listing-13-21-reproduced/Cargo.toml
+++ b/listings/ch19-advanced-features/listing-13-21-reproduced/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "counter"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/listing-19-01/Cargo.toml
+++ b/listings/ch19-advanced-features/listing-19-01/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "unsafe-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/listing-19-02/Cargo.toml
+++ b/listings/ch19-advanced-features/listing-19-02/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "unsafe-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/listing-19-03/Cargo.toml
+++ b/listings/ch19-advanced-features/listing-19-03/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "unsafe-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/listing-19-04/Cargo.toml
+++ b/listings/ch19-advanced-features/listing-19-04/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "unsafe-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/listing-19-05/Cargo.toml
+++ b/listings/ch19-advanced-features/listing-19-05/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "unsafe-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/listing-19-06/Cargo.toml
+++ b/listings/ch19-advanced-features/listing-19-06/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "unsafe-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/listing-19-07/Cargo.toml
+++ b/listings/ch19-advanced-features/listing-19-07/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "unsafe-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/listing-19-08/Cargo.toml
+++ b/listings/ch19-advanced-features/listing-19-08/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "unsafe-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/listing-19-09/Cargo.toml
+++ b/listings/ch19-advanced-features/listing-19-09/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "unsafe-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/listing-19-10/Cargo.toml
+++ b/listings/ch19-advanced-features/listing-19-10/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "unsafe-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/listing-19-11/Cargo.toml
+++ b/listings/ch19-advanced-features/listing-19-11/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "unsafe-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/listing-19-12/Cargo.toml
+++ b/listings/ch19-advanced-features/listing-19-12/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "traits-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/listing-19-13/Cargo.toml
+++ b/listings/ch19-advanced-features/listing-19-13/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "traits-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/listing-19-14/Cargo.toml
+++ b/listings/ch19-advanced-features/listing-19-14/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "traits-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/listing-19-15/Cargo.toml
+++ b/listings/ch19-advanced-features/listing-19-15/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "traits-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/listing-19-16/Cargo.toml
+++ b/listings/ch19-advanced-features/listing-19-16/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "traits-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/listing-19-17/Cargo.toml
+++ b/listings/ch19-advanced-features/listing-19-17/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "traits-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/listing-19-18/Cargo.toml
+++ b/listings/ch19-advanced-features/listing-19-18/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "traits-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/listing-19-19/Cargo.toml
+++ b/listings/ch19-advanced-features/listing-19-19/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "traits-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/listing-19-20/Cargo.toml
+++ b/listings/ch19-advanced-features/listing-19-20/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "traits-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/listing-19-21/Cargo.toml
+++ b/listings/ch19-advanced-features/listing-19-21/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "traits-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/listing-19-22/Cargo.toml
+++ b/listings/ch19-advanced-features/listing-19-22/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "traits-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/listing-19-23/Cargo.toml
+++ b/listings/ch19-advanced-features/listing-19-23/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "traits-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/listing-19-24/Cargo.toml
+++ b/listings/ch19-advanced-features/listing-19-24/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "types-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/listing-19-25/Cargo.toml
+++ b/listings/ch19-advanced-features/listing-19-25/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "types-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/listing-19-27/Cargo.toml
+++ b/listings/ch19-advanced-features/listing-19-27/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "functions-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/listing-19-28/Cargo.toml
+++ b/listings/ch19-advanced-features/listing-19-28/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "macros-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/listing-19-30/Cargo.toml
+++ b/listings/ch19-advanced-features/listing-19-30/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hello_macro"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/listing-19-33/hello_macro/Cargo.toml
+++ b/listings/ch19-advanced-features/listing-19-33/hello_macro/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hello_macro"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/listing-19-33/hello_macro/hello_macro_derive/Cargo.toml
+++ b/listings/ch19-advanced-features/listing-19-33/hello_macro/hello_macro_derive/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hello_macro_derive"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [lib]

--- a/listings/ch19-advanced-features/no-listing-01-unsafe-fn/Cargo.toml
+++ b/listings/ch19-advanced-features/no-listing-01-unsafe-fn/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "unsafe-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/no-listing-02-impl-outlineprint-for-point/Cargo.toml
+++ b/listings/ch19-advanced-features/no-listing-02-impl-outlineprint-for-point/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "traits-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/no-listing-03-impl-display-for-point/Cargo.toml
+++ b/listings/ch19-advanced-features/no-listing-03-impl-display-for-point/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "traits-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/no-listing-04-kilometers-alias/Cargo.toml
+++ b/listings/ch19-advanced-features/no-listing-04-kilometers-alias/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "types-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/no-listing-05-write-trait/Cargo.toml
+++ b/listings/ch19-advanced-features/no-listing-05-write-trait/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "traits-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/no-listing-06-result-alias/Cargo.toml
+++ b/listings/ch19-advanced-features/no-listing-06-result-alias/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "traits-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/no-listing-07-never-type/Cargo.toml
+++ b/listings/ch19-advanced-features/no-listing-07-never-type/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "traits-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/no-listing-08-match-arms-different-types/Cargo.toml
+++ b/listings/ch19-advanced-features/no-listing-08-match-arms-different-types/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "types-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/no-listing-09-unwrap-definition/Cargo.toml
+++ b/listings/ch19-advanced-features/no-listing-09-unwrap-definition/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "types-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/no-listing-10-loop-returns-never/Cargo.toml
+++ b/listings/ch19-advanced-features/no-listing-10-loop-returns-never/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "types-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/no-listing-11-cant-create-str/Cargo.toml
+++ b/listings/ch19-advanced-features/no-listing-11-cant-create-str/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "types-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/no-listing-12-generic-fn-definition/Cargo.toml
+++ b/listings/ch19-advanced-features/no-listing-12-generic-fn-definition/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "types-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/no-listing-13-generic-implicit-sized-bound/Cargo.toml
+++ b/listings/ch19-advanced-features/no-listing-13-generic-implicit-sized-bound/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "types-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/no-listing-14-generic-maybe-sized/Cargo.toml
+++ b/listings/ch19-advanced-features/no-listing-14-generic-maybe-sized/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "types-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/no-listing-15-map-closure/Cargo.toml
+++ b/listings/ch19-advanced-features/no-listing-15-map-closure/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "functions-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/no-listing-16-map-function/Cargo.toml
+++ b/listings/ch19-advanced-features/no-listing-16-map-function/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "functions-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/no-listing-17-map-initializer/Cargo.toml
+++ b/listings/ch19-advanced-features/no-listing-17-map-initializer/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "functions-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/no-listing-18-returns-closure/Cargo.toml
+++ b/listings/ch19-advanced-features/no-listing-18-returns-closure/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "functions-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/no-listing-19-returns-closure-trait-object/Cargo.toml
+++ b/listings/ch19-advanced-features/no-listing-19-returns-closure-trait-object/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "functions-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/no-listing-20-impl-hellomacro-for-pancakes/hello_macro/Cargo.toml
+++ b/listings/ch19-advanced-features/no-listing-20-impl-hellomacro-for-pancakes/hello_macro/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hello_macro"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/no-listing-20-impl-hellomacro-for-pancakes/pancakes/Cargo.toml
+++ b/listings/ch19-advanced-features/no-listing-20-impl-hellomacro-for-pancakes/pancakes/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "pancakes"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/no-listing-21-pancakes/hello_macro/Cargo.toml
+++ b/listings/ch19-advanced-features/no-listing-21-pancakes/hello_macro/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hello_macro"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch19-advanced-features/no-listing-21-pancakes/hello_macro/hello_macro_derive/Cargo.toml
+++ b/listings/ch19-advanced-features/no-listing-21-pancakes/hello_macro/hello_macro_derive/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hello_macro_derive"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [lib]

--- a/listings/ch19-advanced-features/output-only-01-missing-unsafe/Cargo.toml
+++ b/listings/ch19-advanced-features/output-only-01-missing-unsafe/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "unsafe-example"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch20-web-server/listing-20-01/Cargo.toml
+++ b/listings/ch20-web-server/listing-20-01/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hello"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch20-web-server/listing-20-02/Cargo.toml
+++ b/listings/ch20-web-server/listing-20-02/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hello"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch20-web-server/listing-20-03/Cargo.toml
+++ b/listings/ch20-web-server/listing-20-03/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hello"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch20-web-server/listing-20-04/Cargo.toml
+++ b/listings/ch20-web-server/listing-20-04/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hello"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch20-web-server/listing-20-05/Cargo.toml
+++ b/listings/ch20-web-server/listing-20-05/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hello"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch20-web-server/listing-20-06/Cargo.toml
+++ b/listings/ch20-web-server/listing-20-06/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hello"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch20-web-server/listing-20-07/Cargo.toml
+++ b/listings/ch20-web-server/listing-20-07/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hello"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch20-web-server/listing-20-08/Cargo.toml
+++ b/listings/ch20-web-server/listing-20-08/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hello"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch20-web-server/listing-20-09/Cargo.toml
+++ b/listings/ch20-web-server/listing-20-09/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hello"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch20-web-server/listing-20-10/Cargo.toml
+++ b/listings/ch20-web-server/listing-20-10/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hello"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch20-web-server/listing-20-11/Cargo.toml
+++ b/listings/ch20-web-server/listing-20-11/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hello"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch20-web-server/listing-20-12/Cargo.toml
+++ b/listings/ch20-web-server/listing-20-12/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hello"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch20-web-server/listing-20-13/Cargo.toml
+++ b/listings/ch20-web-server/listing-20-13/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hello"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch20-web-server/listing-20-14/Cargo.toml
+++ b/listings/ch20-web-server/listing-20-14/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hello"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch20-web-server/listing-20-15/Cargo.toml
+++ b/listings/ch20-web-server/listing-20-15/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hello"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch20-web-server/listing-20-16/Cargo.toml
+++ b/listings/ch20-web-server/listing-20-16/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hello"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch20-web-server/listing-20-17/Cargo.toml
+++ b/listings/ch20-web-server/listing-20-17/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hello"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch20-web-server/listing-20-18/Cargo.toml
+++ b/listings/ch20-web-server/listing-20-18/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hello"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch20-web-server/listing-20-19/Cargo.toml
+++ b/listings/ch20-web-server/listing-20-19/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hello"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch20-web-server/listing-20-20/Cargo.toml
+++ b/listings/ch20-web-server/listing-20-20/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hello"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch20-web-server/listing-20-21/Cargo.toml
+++ b/listings/ch20-web-server/listing-20-21/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hello"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch20-web-server/listing-20-22/Cargo.toml
+++ b/listings/ch20-web-server/listing-20-22/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hello"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch20-web-server/listing-20-23/Cargo.toml
+++ b/listings/ch20-web-server/listing-20-23/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hello"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch20-web-server/listing-20-24/Cargo.toml
+++ b/listings/ch20-web-server/listing-20-24/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hello"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch20-web-server/listing-20-25/Cargo.toml
+++ b/listings/ch20-web-server/listing-20-25/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hello"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch20-web-server/no-listing-01-define-threadpool-struct/Cargo.toml
+++ b/listings/ch20-web-server/no-listing-01-define-threadpool-struct/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hello"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch20-web-server/no-listing-02-impl-threadpool-new/Cargo.toml
+++ b/listings/ch20-web-server/no-listing-02-impl-threadpool-new/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hello"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch20-web-server/no-listing-03-define-execute/Cargo.toml
+++ b/listings/ch20-web-server/no-listing-03-define-execute/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hello"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch20-web-server/no-listing-04-update-worker-definition/Cargo.toml
+++ b/listings/ch20-web-server/no-listing-04-update-worker-definition/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hello"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch20-web-server/no-listing-05-fix-worker-new/Cargo.toml
+++ b/listings/ch20-web-server/no-listing-05-fix-worker-new/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hello"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch20-web-server/no-listing-06-fix-threadpool-drop/Cargo.toml
+++ b/listings/ch20-web-server/no-listing-06-fix-threadpool-drop/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hello"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch20-web-server/no-listing-07-define-message-enum/Cargo.toml
+++ b/listings/ch20-web-server/no-listing-07-define-message-enum/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hello"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]

--- a/listings/ch20-web-server/no-listing-08-final-code/Cargo.toml
+++ b/listings/ch20-web-server/no-listing-08-final-code/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hello"
 version = "0.1.0"
-authors = ["Your Name <you@example.com>"]
 edition = "2018"
 
 [dependencies]


### PR DESCRIPTION
Since RFC3052 is fully implemented in Cargo and the various Rust
websites, we can set an example by removing the authors field from all
the listings as it has been effectively soft deprecated since the last edition
of the book.

Follow on/related to #2785, which removed the references in the text.