### PR TITLE
Fix incorrectly ordered print statements

### DIFF
--- a/src/ch08-03-hash-maps.md
+++ b/src/ch08-03-hash-maps.md
@@ -119,8 +119,8 @@ do with vectors, using a `for` loop:
 This code will print each pair in an arbitrary order:
 
 ```text
-Yellow: 50
 Blue: 10
+Yellow: 50
 ```
 
 ### Updating a Hash Map


### PR DESCRIPTION
The preceding code block prints as
```
Blue: 10
Yellow: 50
```
However, the following text reports it as
```
Yellow: 50
Blue: 10
```
This change fixes the reference output's incorrect order.
[Here](https://github.com/rust-lang/book/blob/main/listings/ch08-common-collections/no-listing-03-iterate-over-hashmap/src/main.rs) is the code-block for reference:
```rs
    use std::collections::HashMap;

    let mut scores = HashMap::new();

    scores.insert(String::from("Blue"), 10);
    scores.insert(String::from("Yellow"), 50);

    for (key, value) in &scores {
        println!("{}: {}", key, value);
    }
```