### PR TITLE
fix description of return value's lifetime

### DIFF
--- a/src/ch10-03-lifetime-syntax.md
+++ b/src/ch10-03-lifetime-syntax.md
@@ -214,7 +214,7 @@ This code should compile and produce the result we want when we use it with the
 The function signature now tells Rust that for some lifetime `'a`, the function
 takes two parameters, both of which are string slices that live at least as
 long as lifetime `'a`. The function signature also tells Rust that the string
-slice returned from the function will live at least as long as lifetime `'a`.
+slice returned from the function will live at most as long as lifetime `'a`.
 In practice, it means that the lifetime of the reference returned by the
 `longest` function is the same as the smaller of the lifetimes of the
 references passed in. These constraints are what we want Rust to enforce.


### PR DESCRIPTION
The example in this section shows that the lifetime of the return value needs to be at **most** (not at *least*) `a. So I'm fixing this line.