### PR TITLE
Explicitly mention UpperCamelCase

### DIFF
--- a/src/ch10-01-syntax.md
+++ b/src/ch10-01-syntax.md
@@ -33,8 +33,8 @@ To parameterize the types in the new function we’ll define, we need to name th
 type parameter, just as we do for the value parameters to a function. You can
 use any identifier as a type parameter name. But we’ll use `T` because, by
 convention, parameter names in Rust are short, often just a letter, and Rust’s
-type-naming convention is CamelCase. Short for “type,” `T` is the default
-choice of most Rust programmers.
+type-naming convention is UpperCamelCase (otherwise known as PascalCase). Short
+for “type,” `T` is the default choice of most Rust programmers.
 
 When we use a parameter in the body of the function, we have to declare the
 parameter name in the signature so the compiler knows what that name means.


### PR DESCRIPTION
According to the [Rust guidelines for naming](https://rust-lang.github.io/api-guidelines/naming.html), the type naming convention for Rust is UpperCamelCase. This updates the book to explicitly mention that (and offer an alternate name, PascalCase).