### PR TITLE
Show Ferris even for short examples by removing the count lines check

### DIFF
--- a/ferris.css
+++ b/ferris.css
@@ -22,8 +22,8 @@ body.ayu .not_desired_behavior {
 .ferris {
   position: absolute;
   z-index: 99;
-  right: 5px;
-  top: 30px;
+  right: 60px;
+  top: 5px;
 	width: 10%;
 	height: auto;
 }

--- a/ferris.js
+++ b/ferris.js
@@ -23,15 +23,23 @@ function attachFerrises (type) {
   var elements = document.getElementsByClassName(type.attr)
 
   for (var codeBlock of elements) {
-    var lines = codeBlock.textContent.split(/\r|\r\n|\n/).length - 1;
+    var lines = 0;
+    for (var child of codeBlock.childNodes) {
+      if(child.nodeType ===  Node.ELEMENT_NODE && child.classList.contains('boring')) {
+        continue;
+      }
 
-    if (lines >= 4) {
-      attachFerris(codeBlock, type)
+      var text = child.textContent;
+      if(/\r|\r\n|\n/.exec(text)) {
+        lines += text.split(/\r|\r\n|\n/).length -1;
+      }
     }
+
+    attachFerris(codeBlock, type, lines)
   }
 }
 
-function attachFerris (element, type) {
+function attachFerris (element, type, lines) {
   var a = document.createElement('a')
   a.setAttribute('href', 'ch00-00-introduction.html#ferris')
   a.setAttribute('target', '_blank')
@@ -40,6 +48,11 @@ function attachFerris (element, type) {
   img.setAttribute('src', 'img/ferris/' + type.attr + '.svg')
   img.setAttribute('title', type.title)
   img.className = 'ferris'
+
+  if(lines < 4) {
+    img.style.width = "30px"
+    img.style.height = "30px"
+  }
 
   a.appendChild(img)
 


### PR DESCRIPTION
I tried solving your recent issue #2810 by removing the count lines check.

**Task 1**  Excluding text content of the spans that have the class boring before counting the number of lines in an example_

I achieve this by iterating over all child nodes of a code block and then ignoring the ones with boring class. Then I get the child textContent and check if the text contains line break. If it does I count the number of lines and add it to the total lines.

    var lines = 0;
    for (var child of codeBlock.childNodes) {
      if(child.nodeType ===  Node.ELEMENT_NODE && child.classList.contains('boring')) {
        continue;
      }

      var text = child.textContent;
      if(/\r|\r\n|\n/.exec(text)) {
        lines += text.split(/\r|\r\n|\n/).length -1;
      }
    }


**Task 2** Giving the Ferris image different CSS based on whether the number of lines is 1, 2, 3, or 4 or more. 4 or more

I did this by only changing the size of ferris image if the number of visible lines are less than 4. However, another change that I made is that I moved the ferris on the left side regardless of the number of the lines. Not sure if you want it for lines > 4, but if not feel free to reject this.

Ferris when visible lines are less than 4
![Screenshot_2021-08-15_11-58-58](https://user-images.githubusercontent.com/6375481/129470029-4d5d9a25-5daa-44fc-9cc3-0d0f7c57029e.png)

Ferris when visible lines are greater than 4.
![Screenshot_2021-08-15_11-56-51](https://user-images.githubusercontent.com/6375481/129470003-8637e3eb-2f64-4ff4-8c72-d7e79af23ce4.png)