### PR TITLE
Ferris moved left side to the buttons and height update

### DIFF
--- a/ferris.css
+++ b/ferris.css
@@ -22,10 +22,9 @@ body.ayu .not_desired_behavior {
 .ferris {
   position: absolute;
   z-index: 99;
-  right: 5px;
-  top: 30px;
-	width: 10%;
-	height: auto;
+  right: 85px;
+	height: 100%;
+  max-height: 50px;
 }
 
 .ferris-explain {

--- a/ferris.js
+++ b/ferris.js
@@ -23,11 +23,7 @@ function attachFerrises (type) {
   var elements = document.getElementsByClassName(type.attr)
 
   for (var codeBlock of elements) {
-    var lines = codeBlock.textContent.split(/\r|\r\n|\n/).length - 1;
-
-    if (lines >= 4) {
-      attachFerris(codeBlock, type)
-    }
+    attachFerris(codeBlock, type)
   }
 }
 


### PR DESCRIPTION
Ferris moved left side to the buttons and height set based on code block size.  It will fix #2810
1. Removed no of line check
2. Set the Ferris height based on code block height
3. Ferris height will grow up to 50px. (50px took from current height setting)
4. Moved Ferris to left side to the buttons