### PR TITLE
Shrink and move ferris when possible

### DIFF
--- a/ferris.css
+++ b/ferris.css
@@ -19,13 +19,24 @@ body.ayu .not_desired_behavior {
   background: #501f21;
 }
 
-.ferris {
+.ferris-container {
   position: absolute;
   z-index: 99;
   right: 5px;
   top: 30px;
-	width: 10%;
-	height: auto;
+}
+
+.ferris {
+  vertical-align: top;
+  margin-left: 0.5em;
+}
+
+.ferris-large {
+  width: 4.5em;
+}
+
+.ferris-small {
+  width: 3em;
 }
 
 .ferris-explain {

--- a/ferris.css
+++ b/ferris.css
@@ -29,6 +29,7 @@ body.ayu .not_desired_behavior {
 .ferris {
   vertical-align: top;
   margin-left: 0.5em;
+  height: auto;
 }
 
 .ferris-large {

--- a/ferris.js
+++ b/ferris.js
@@ -19,19 +19,36 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 })
 
-function attachFerrises (type) {
+function attachFerrises(type) {
   var elements = document.getElementsByClassName(type.attr)
 
   for (var codeBlock of elements) {
-    var lines = codeBlock.textContent.split(/\r|\r\n|\n/).length - 1;
-
-    if (lines >= 4) {
-      attachFerris(codeBlock, type)
+    var lines = codeBlock.innerText.replace(/\n$/, '').split(/\n/).length
+    var size = 'large'
+    if (lines < 4) {
+      size = 'small'
     }
+
+    var container = prepareFerrisContainer(codeBlock, size == 'small')
+    container.appendChild(createFerris(type, size))
   }
 }
 
-function attachFerris (element, type) {
+function prepareFerrisContainer(element, useButtons) {
+  var foundButtons = element.parentElement.querySelector('.buttons')
+  if (useButtons && foundButtons) {
+    return foundButtons
+  }
+
+  var div = document.createElement('div')
+  div.classList.add('ferris-container')
+
+  element.parentElement.insertBefore(div, element)
+
+  return div
+}
+
+function createFerris(type, size) {
   var a = document.createElement('a')
   a.setAttribute('href', 'ch00-00-introduction.html#ferris')
   a.setAttribute('target', '_blank')
@@ -39,9 +56,10 @@ function attachFerris (element, type) {
   var img = document.createElement('img')
   img.setAttribute('src', 'img/ferris/' + type.attr + '.svg')
   img.setAttribute('title', type.title)
-  img.className = 'ferris'
+  img.classList.add('ferris')
+  img.classList.add('ferris-' + size)
 
   a.appendChild(img)
 
-  element.parentElement.insertBefore(a, element)
+  return a
 }


### PR DESCRIPTION
Resolves #2810 

# Solution

1. Use `innerText` instead of `textContent` to ignore `.boring`.
2. When possible, shrink ferris to a smaller size.
3. If there are mdBook buttons in the code block, place ferris in the right of the buttons box.

# Other improvements

- Switch from 10% width to `em`s to preserve size of ferris on smaller screens.

# Drawbacks

- Decreases Firefox compatibility from >12 to >44
  - Firefox 44 was released in 2016

# Screenshots

![image](https://user-images.githubusercontent.com/1705906/129470630-a45d0232-6e36-475d-942a-aa3c579268aa.png)
![image](https://user-images.githubusercontent.com/1705906/129470646-5d884df1-8be8-4dee-bcdb-3d3762223c2d.png)
![image](https://user-images.githubusercontent.com/1705906/129471009-ab01d3ba-3d05-442c-bd22-8e6919daba14.png)
