### PR TITLE
Added missing example for a value that can be present or absent in chapter 6

### DIFF
--- a/src/ch06-01-defining-an-enum.md
+++ b/src/ch06-01-defining-an-enum.md
@@ -217,6 +217,14 @@ property is pervasive, it’s extremely easy to make this kind of error.
 However, the concept that null is trying to express is still a useful one: a
 null is a value that is currently invalid or absent for some reason.
 
+> ### Examples for absent values
+> It is not simple to grasp the concept of an absent value but a good
+> example of that will be the one for environment variables.  Let's say
+> you want to get the environment variable called ENV_VAR, this environment
+> variable can be either present or it can be undefined as the variable was
+> not set.  This is an example for a value that a function could return
+> or that it can be absent and in this case return `None`.
+
 The problem isn’t really with the concept but with the particular
 implementation. As such, Rust does not have nulls, but it does have an enum
 that can encode the concept of a value being present or absent. This enum is


### PR DESCRIPTION
In my opinion, as a C developer it was hard to come up and think about examples for a value that can be present or absent.  With my friend I came up with 3 different examples I think can really give a good example for the Option enum.

The 3 are:
1. The C library function strstr which searches for a string inside another string - it can either find one or not (and it's not an error).
2. A recv from a socket which is none blocking, it may get data back or it may not.
3. Read an environment variable - it may have been defined or it may have not

I think the best one is the third one but I'm open to hear your opinions.