### PR TITLE
Chapter 12.4: fix grammar of parenthetical

### DIFF
--- a/src/ch12-04-testing-the-librarys-functionality.md
+++ b/src/ch12-04-testing-the-librarys-functionality.md
@@ -48,9 +48,9 @@ yet.
 function we wish we had</span>
 
 This test searches for the string `"duct"`. The text we’re searching is three
-lines, only one of which contains `"duct"` (Note that the backslash after the
+lines, only one of which contains `"duct"`. (Note that the backslash after the
 opening double quote tells Rust not to put a newline character at the beginning
-of the contents of this string literal). We assert that the value returned from
+of the contents of this string literal.) We assert that the value returned from
 the `search` function contains only the line we expect.
 
 We aren’t able to run this test and watch it fail because the test doesn’t even


### PR DESCRIPTION
This parenthetical is partially set up as its own sentence (initial caps) and partially set up as part of a sentence (placement of periods). I think it works better as a separate sentence.﻿
