### PR TITLE
clarify lifetimes

### DIFF
--- a/src/ch10-03-lifetime-syntax.md
+++ b/src/ch10-03-lifetime-syntax.md
@@ -193,10 +193,10 @@ lifetime.
 Now let’s examine lifetime annotations in the context of the `longest`
 function. As with generic type parameters, we need to declare generic lifetime
 parameters inside angle brackets between the function name and the parameter
-list. The constraint we want to express in this signature is that all the
-references in the parameters and the return value must have the same lifetime.
-We’ll name the lifetime `'a` and then add it to each reference, as shown in
-Listing 10-22.
+list. The constraint we want to express in this signature is that the two
+parameters passed to this function need to live at least as long as lifetime
+`'a` and so will the return value! We’ll name the lifetime `'a` and then 
+add it to each reference, as shown in Listing 10-22.
 
 <span class="filename">Filename: src/main.rs</span>
 


### PR DESCRIPTION
I found this sentence to be a bit misleading. maybe I could go as long as saying that it is wrong! 😱

> in this signature is that all the references in the parameters and the return value **must have the same lifetime**

given the following code:

```rust
fn longest<'a>(x: &'a str, y: &'a str) -> &'a str {
    if x.len() > y.len() {
        x
    } else {
        y
    }
}

fn main() {
    let foo = String::from("Foo");
    {
        let bar = String::from("Bar");
        let longest_string = longest(&foo, &bar);
        println!("longest is {}", longest_string);
    }
}
```

you can see that the lifetime of `foo` and `bar` is **not** the same though the text in The Book says that it should be, so I thought to address that with this PR.

thank you