### PR TITLE
Ch20: Move hardcoded string into status_line to be consistent in both 200 and 404 response

### DIFF
--- a/listings/ch20-web-server/listing-20-05/src/main.rs
+++ b/listings/ch20-web-server/listing-20-05/src/main.rs
@@ -22,10 +22,12 @@ fn handle_connection(mut stream: TcpStream) {
     let mut buffer = [0; 1024];
     stream.read(&mut buffer).unwrap();
 
+    let status_line = "HTTP/1.1 200 OK";
     let contents = fs::read_to_string("hello.html").unwrap();
 
     let response = format!(
-        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}",
+        "{}\r\nContent-Length: {}\r\n\r\n{}",
+        status_line,
         contents.len(),
         contents
     );

--- a/listings/ch20-web-server/listing-20-06/src/main.rs
+++ b/listings/ch20-web-server/listing-20-06/src/main.rs
@@ -23,10 +23,12 @@ fn handle_connection(mut stream: TcpStream) {
     let get = b"GET / HTTP/1.1\r\n";
 
     if buffer.starts_with(get) {
+        let status_line = "HTTP/1.1 200 OK";
         let contents = fs::read_to_string("hello.html").unwrap();
 
         let response = format!(
-            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}",
+            "{}\r\nContent-Length: {}\r\n\r\n{}",
+            status_line,
             contents.len(),
             contents
         );

--- a/listings/ch20-web-server/listing-20-07/src/main.rs
+++ b/listings/ch20-web-server/listing-20-07/src/main.rs
@@ -20,10 +20,12 @@ fn handle_connection(mut stream: TcpStream) {
     let get = b"GET / HTTP/1.1\r\n";
 
     if buffer.starts_with(get) {
+        let status_line = "HTTP/1.1 200 OK";
         let contents = fs::read_to_string("hello.html").unwrap();
 
         let response = format!(
-            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}",
+            "{}\r\nContent-Length: {}\r\n\r\n{}",
+            status_line,
             contents.len(),
             contents
         );


### PR DESCRIPTION
Hey folks, 

in [Chapter 20.1](https://doc.rust-lang.org/book/ch20-01-single-threaded.html) we do a refactoring by using a tuple to get `status_line` and `filename`.

Currently, the 200-response has its status line hardcoded in the response, but the 404-response uses a `status_line`.

```
let response = format!(
    "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}",
    contents.len(),
    contents
);
```

```
let status_line = "HTTP/1.1 404 NOT FOUND";
//...
let response = format!(
    "{}\r\nContent-Length: {}\r\n\r\n{}",
    status_line,
    contents.len(),
    contents
);
```

By using my small improvement, we would have a consistent use of `status_line`.
This would decrease the complexity to understand the refactoring, because both the `if` and the `else` would have the exact same outlining afterwards. ([expand view after loading](https://github.com/miku86/book/commit/d6bceb46145beb23c779cd58270b63eaca34227c#diff-57fa1a1bcf92055a35c3e42df4fb6f97bdf225a7e93fe32810c23a87cf4a4159))

Greetings
Michael