### PR TITLE
unsafe: add assume and safety to describe invariants and reasoning

### DIFF
--- a/listings/ch19-advanced-features/listing-19-03/src/main.rs
+++ b/listings/ch19-advanced-features/listing-19-03/src/main.rs
@@ -5,6 +5,7 @@ fn main() {
     let r1 = &num as *const i32;
     let r2 = &mut num as *mut i32;
 
+    // safety: r1 and r2 point to the same i32 variable on the stack
     unsafe {
         println!("r1 is: {}", *r1);
         println!("r2 is: {}", *r2);

--- a/listings/ch19-advanced-features/listing-19-06/src/main.rs
+++ b/listings/ch19-advanced-features/listing-19-06/src/main.rs
@@ -5,8 +5,10 @@ fn split_at_mut(slice: &mut [i32], mid: usize) -> (&mut [i32], &mut [i32]) {
     let len = slice.len();
     let ptr = slice.as_mut_ptr();
 
-    assert!(mid <= len);
+    assert!(mid < len);
 
+    // safety: 0 <= mid < len and slice is continous memory
+    // => pointer access valid and 2 distinct slices are created
     unsafe {
         (
             slice::from_raw_parts_mut(ptr, mid),

--- a/listings/ch19-advanced-features/listing-19-07/src/main.rs
+++ b/listings/ch19-advanced-features/listing-19-07/src/main.rs
@@ -5,6 +5,7 @@ fn main() {
     let address = 0x01234usize;
     let r = address as *mut i32;
 
+    // pointer does not point to valid object, so access crashes program
     let slice: &[i32] = unsafe { slice::from_raw_parts_mut(r, 10000) };
     // ANCHOR_END: here
 }

--- a/listings/ch19-advanced-features/listing-19-08/src/main.rs
+++ b/listings/ch19-advanced-features/listing-19-08/src/main.rs
@@ -3,6 +3,7 @@ extern "C" {
 }
 
 fn main() {
+    // safety: function abs is defined for all inputs
     unsafe {
         println!("Absolute value of -3 according to C: {}", abs(-3));
     }

--- a/listings/ch19-advanced-features/listing-19-10/src/main.rs
+++ b/listings/ch19-advanced-features/listing-19-10/src/main.rs
@@ -1,6 +1,7 @@
 static mut COUNTER: u32 = 0;
 
 fn add_to_count(inc: u32) {
+    // safety: only 1 thread can increment COUNTER (assumes no _start hackery)
     unsafe {
         COUNTER += inc;
     }
@@ -9,6 +10,7 @@ fn add_to_count(inc: u32) {
 fn main() {
     add_to_count(3);
 
+    // safety: only 1 thread accesses COUNTER (assumes no _start hackery)
     unsafe {
         println!("COUNTER: {}", COUNTER);
     }

--- a/listings/ch19-advanced-features/listing-19-11/src/main.rs
+++ b/listings/ch19-advanced-features/listing-19-11/src/main.rs
@@ -1,7 +1,9 @@
+//assume: description of invariants goes here
 unsafe trait Foo {
     // methods go here
 }
 
+//assume: description of invariants goes here
 unsafe impl Foo for i32 {
     // method implementations go here
 }

--- a/listings/ch19-advanced-features/no-listing-01-unsafe-fn/src/main.rs
+++ b/listings/ch19-advanced-features/no-listing-01-unsafe-fn/src/main.rs
@@ -1,7 +1,9 @@
 fn main() {
     // ANCHOR: here
+    // assume: This function has to be called from main()
     unsafe fn dangerous() {}
 
+    // safety: function dangerous() is called from main()
     unsafe {
         dangerous();
     }

--- a/src/ch19-01-unsafe-rust.md
+++ b/src/ch19-01-unsafe-rust.md
@@ -125,6 +125,9 @@ Recall that we can create raw pointers in safe code, but we can’t *dereference
 raw pointers and read the data being pointed to. In Listing 19-3, we use the
 dereference operator `*` on a raw pointer that requires an `unsafe` block.
 
+The convention for `unsafe` is to describe why the unsafe block is safe for
+reviewers in a comment prefixed with `safety:`.
+
 ```rust
 {{#rustdoc_include ../listings/ch19-advanced-features/listing-19-03/src/main.rs:here}}
 ```
@@ -162,6 +165,11 @@ need to uphold when we call this function, because Rust can’t guarantee we’v
 met these requirements. By calling an unsafe function within an `unsafe` block,
 we’re saying that we’ve read this function’s documentation and take
 responsibility for upholding the function’s contracts.
+
+The convention for `unsafe fn` is to describe the necessary invariants for the
+safety of the function in a comment prefixed with `assume:`. Correspondingly
+usage in unsafe blocks is annotated with `safety:` followed by a reasoning for
+reviewers.
 
 Here is an unsafe function named `dangerous` that doesn’t do anything in its
 body:


### PR DESCRIPTION
As of now I found no best practice what to grep for or lint
for the different usages of unsafe:
1. unsafe blocks should be explained to convince reviewers that code
   is safe by explaining that domain-specific assumptions are uphold.
   This usually means:
   - upholding aliasing rules
   - memory is valid during access
   - global data absence of racy variable access
2. unsafe trait/fn/macro should define what assumptions they make on
   their execution.

Additional reasons:
1. Linting, but conventions must be established beforehand.
2. reviewing becomes much easier.
3. verification (finding invariants) of code becomes much easier.
4. bug fixing: check assumption of function against the descriptions

Please let me know, how I can make things shorter and what you think.