### PR TITLE
Remove the Hebrew translation link, it's a 404

### DIFF
--- a/src/appendix-06-translation.md
+++ b/src/appendix-06-translation.md
@@ -17,7 +17,6 @@ For resources in languages other than English. Most are still in progress; see
 - [日本語](https://github.com/rust-lang-ja/book-ja)
 - [Français](https://github.com/Jimskapt/rust-book-fr)
 - [Polski](https://github.com/paytchoo/book-pl)
-- [עברית](https://github.com/idanmel/rust-book-heb)
 - [Cebuano](https://github.com/agentzero1/book)
 - [Tagalog](https://github.com/josephace135/book)
 - [Esperanto](https://github.com/psychoslave/Rust-libro)


### PR DESCRIPTION
Link is a 404. Checked the author's other repos and I don't see a reference to it.
Googled for an alternative and while there is a [repo here](https://github.com/GilRtr/rustbook-heb/), only the introduction is translated. 