### PR TITLE
Fixed error in ch19.6 example to show [lib] line

### DIFF
--- a/src/ch19-06-macros.md
+++ b/src/ch19-06-macros.md
@@ -280,7 +280,7 @@ in a moment, so we need to add them as dependencies. Add the following to the
 <span class="filename">Filename: hello_macro_derive/Cargo.toml</span>
 
 ```toml
-{{#include ../listings/ch19-advanced-features/listing-19-31/hello_macro/hello_macro_derive/Cargo.toml:7:12}}
+{{#include ../listings/ch19-advanced-features/listing-19-31/hello_macro/hello_macro_derive/Cargo.toml:6:12}}
 ```
 
 To start defining the procedural macro, place the code in Listing 19-31 into


### PR DESCRIPTION
I ran in to the issue described in this issue report [here](https://github.com/rust-lang/book/issues/2579) today when reading Chapter 19 section 6 in the book. The `[lib]` line in the example was not present, and was producing an error when I attempted to edit my `hello_macro_derive/Cargo.toml` file following the book's instruction. 

I've adjusted the example in Chapter 19.6 to show the `[lib]` tag on line `6` in the `Cargo.toml` file. 

Love the book, and I hope this helps. :)