### PR TITLE
Correct the naming convention used for typenames.

### DIFF
--- a/src/ch10-01-syntax.md
+++ b/src/ch10-01-syntax.md
@@ -33,7 +33,7 @@ To parameterize the types in the new function we’ll define, we need to name th
 type parameter, just as we do for the value parameters to a function. You can
 use any identifier as a type parameter name. But we’ll use `T` because, by
 convention, parameter names in Rust are short, often just a letter, and Rust’s
-type-naming convention is CamelCase. Short for “type,” `T` is the default
+type-naming convention is PascalCase. Short for “type,” `T` is the default
 choice of most Rust programmers.
 
 When we use a parameter in the body of the function, we have to declare the


### PR DESCRIPTION
It is called PascalCase, not camelCase. The only difference between the two conventions is that PascalCase requires the first letter to be capitalized.