### PR TITLE
Fix line numbers Cargo.toml in cargo-workspaces

### DIFF
--- a/src/ch14-03-cargo-workspaces.md
+++ b/src/ch14-03-cargo-workspaces.md
@@ -134,7 +134,7 @@ library. First, we’ll need to add a path dependency on `add-one` to
 <span class="filename">Filename: adder/Cargo.toml</span>
 
 ```toml
-{{#include ../listings/ch14-more-about-cargo/no-listing-02-workspace-with-two-crates/add/adder/Cargo.toml:7:9}}
+{{#include ../listings/ch14-more-about-cargo/no-listing-02-workspace-with-two-crates/add/adder/Cargo.toml:6:8}}
 ```
 
 Cargo doesn’t assume that crates in a workspace will depend on each other, so


### PR DESCRIPTION
Updated ch14-03-cargo-workspaces

Seems like the file was updated and the line `[dependencies]` is lost.
![image](https://user-images.githubusercontent.com/2585816/138104960-52fac290-fcb0-4f31-94d0-31e07c776dbb.png)

I think this should fix it 👍🏻 