### PR TITLE
Don‘t make side effect in match scrutinee

### DIFF
--- a/listings/ch09-error-handling/listing-09-05/src/main.rs
+++ b/listings/ch09-error-handling/listing-09-05/src/main.rs
@@ -7,9 +7,13 @@ fn main() {
     let f = match f {
         Ok(file) => file,
         Err(error) => match error.kind() {
-            ErrorKind::NotFound => match File::create("hello.txt") {
-                Ok(fc) => fc,
-                Err(e) => panic!("Problem creating the file: {:?}", e),
+            ErrorKind::NotFound => {
+                let f2 = File::create("hello.txt");
+
+                match f2 {
+                    Ok(fc) => fc,
+                    Err(e) => panic!("Problem creating the file: {:?}", e),
+                }
             },
             other_error => {
                 panic!("Problem opening the file: {:?}", other_error)


### PR DESCRIPTION
This PR proposes to make the code more consistent by moving the file creation call out of the `match` scrutinee into a separate variable assignment like the previous file creation call.

Alternatively, the previous file open call could be moved into the `match` scrutinee.

```rust
let f = match File::open("hello.txt") {
     // …
}
```