### PR TITLE
Make need to open new shell post-install clearer

### DIFF
--- a/src/ch01-01-installation.md
+++ b/src/ch01-01-installation.md
@@ -91,15 +91,13 @@ $ rustup self uninstall
 
 ### Troubleshooting
 
-To check whether you have Rust installed correctly, open a new shell that is not the one you ran the installer in and enter this
-line:
+To check whether you have Rust installed correctly, open a new shell that is not the one you ran the installer in and enter thisline:
 
 ```console
 $ rustc --version
 ```
 
-You should see the version number, commit hash, and commit date for the latest
-stable version that has been released in the following format:
+You should see the version number, commit hash, and commit date for the lateststable version that has been released in the following format:
 
 ```text
 rustc x.y.z (abcabcabc yyyy-mm-dd)

--- a/src/ch01-01-installation.md
+++ b/src/ch01-01-installation.md
@@ -91,7 +91,7 @@ $ rustup self uninstall
 
 ### Troubleshooting
 
-To check whether you have Rust installed correctly, open a shell and enter this
+To check whether you have Rust installed correctly, open a new shell that is not the one you ran the installer in and enter this
 line:
 
 ```console
@@ -105,10 +105,11 @@ stable version that has been released in the following format:
 rustc x.y.z (abcabcabc yyyy-mm-dd)
 ```
 
-If you see this information, you have installed Rust successfully! If you don’t
-see this information and you’re on Windows, check that Rust is in your `%PATH%`
-system variable. If that’s all correct and Rust still isn’t working, there are
-a number of places you can get help. The easiest is the #beginners channel on
+If you see this information, you have installed Rust successfully! If you don't
+see this information, make sure you opened a new shell before running the command.
+If it's still not working and you’re on Windows, check that Rust is in your
+`%PATH%` system variable. If that’s all correct and Rust still isn’t working, there
+are a number of places you can get help. The easiest is the #beginners channel on
 [the official Rust Discord][discord]. There, you can chat with other Rustaceans
 (a silly nickname we call ourselves) who can help you out. Other great
 resources include [the Users forum][users] and [Stack Overflow][stackoverflow].


### PR DESCRIPTION
The current text makes it easy to miss the fact that you need to open a new shell after the install for the new path variables to be usable. To make it clearer, add a discrete statement to open a new shell separate from the session you ran the install in. Then, when it runs through a list of troubleshooting steps, reiterate this fact so that the user has little chance of missing it. This will prevent vain troubleshooting from users who missed the "new shell" part and prevent unneeded forum posts.