### PR TITLE
Update book repo links for default branch rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ $ mdbook test
 We'd love your help! Please see [CONTRIBUTING.md][contrib] to learn about the
 kinds of contributions we're looking for.
 
-[contrib]: https://github.com/rust-lang/book/blob/master/CONTRIBUTING.md
+[contrib]: https://github.com/rust-lang/book/blob/main/CONTRIBUTING.md
 
 Because the book is [printed](https://nostarch.com/rust), and because we want
 to keep the online version of the book close to the print version when

--- a/src/ch00-00-introduction.md
+++ b/src/ch00-00-introduction.md
@@ -187,4 +187,4 @@ doesn’t compile.
 The source files from which this book is generated can be found on
 [GitHub][book].
 
-[book]: https://github.com/rust-lang/book/tree/master/src
+[book]: https://github.com/rust-lang/book/tree/main/src


### PR DESCRIPTION
Since the rust-lang/book repo has had its default branch name renamed from master to main, the links to the repo can be updated so that users clicking the links will not need to see the rename notification banner.