### PR TITLE
Clean up a complex phrase

### DIFF
--- a/src/ch15-06-reference-cycles.md
+++ b/src/ch15-06-reference-cycles.md
@@ -2,12 +2,12 @@
 
 Rust’s memory safety guarantees make it difficult, but not impossible, to
 accidentally create memory that is never cleaned up (known as a *memory leak*).
-Preventing memory leaks entirely is not one of Rust’s guarantees in the same
-way that disallowing data races at compile time is, meaning memory leaks are
-memory safe in Rust. We can see that Rust allows memory leaks by using `Rc<T>`
-and `RefCell<T>`: it’s possible to create references where items refer to each
-other in a cycle. This creates memory leaks because the reference count of each
-item in the cycle will never reach 0, and the values will never be dropped.
+Preventing memory leaks entirely is not one of Rust’s guarantees, meaning
+[memory leaks][memleaks] are memory safe in Rust. We can see that Rust allows
+memory leaks by using `Rc<T>` and `RefCell<T>`: it’s possible to create references
+where items refer to each other in a cycle. This creates memory leaks because
+the reference count of each item in the cycle will never reach 0, and the values
+will never be dropped.
 
 ### Creating a Reference Cycle
 
@@ -316,3 +316,4 @@ Next, we’ll talk about concurrency in Rust. You’ll even learn about a few ne
 smart pointers.
 
 [nomicon]: ../nomicon/index.html
+[memleaks]: https://en.wikipedia.org/wiki/Memory_leak


### PR DESCRIPTION
While it is semantically correct English, it makes non-english speakers brains boil out and also has some logical issues (being able to prevent data races does not logically imply memory safety of leaks). I've just removed this redundant comparison, simplifying the phrase.

Please, native English speakers chime in - it should be possible to further make this phrase better.