### PR TITLE
Attempt to fix grammatically confusing sentence in this paragraph.

### DIFF
--- a/src/ch16-03-shared-state.md
+++ b/src/ch16-03-shared-state.md
@@ -71,8 +71,8 @@ that case, no one would ever be able to get the lock, so we’ve chosen to
 
 After we’ve acquired the lock, we can treat the return value, named `num` in
 this case, as a mutable reference to the data inside. The type system ensures
-that we acquire a lock before using the value in `m`: `Mutex<i32>` is not an
-`i32`, so we *must* acquire the lock to be able to use the `i32` value. We
+that the lock we acquire before using the value in `m`: `Mutex<i32>` is not
+an `i32`, so we *must* acquire the lock to be able to use the `i32` value. We
 can’t forget; the type system won’t let us access the inner `i32` otherwise.
 
 As you might suspect, `Mutex<T>` is a smart pointer. More accurately, the call

--- a/src/ch16-03-shared-state.md
+++ b/src/ch16-03-shared-state.md
@@ -71,8 +71,8 @@ that case, no one would ever be able to get the lock, so we’ve chosen to
 
 After we’ve acquired the lock, we can treat the return value, named `num` in
 this case, as a mutable reference to the data inside. The type system ensures
-that the lock we acquire before using the value in `m`: `Mutex<i32>` is not
-an `i32`, so we *must* acquire the lock to be able to use the `i32` value. We
+that we acquire a lock before using the value in `m`: `Mutex<i32>`, because `m`
+is not an `i32`, so we *must* acquire the lock to be able to use the `i32` value. We
 can’t forget; the type system won’t let us access the inner `i32` otherwise.
 
 As you might suspect, `Mutex<T>` is a smart pointer. More accurately, the call


### PR DESCRIPTION
It is unclear to me what the original author was TRYING to say here, but this is my best guess.

It seems like they were trying to say "you can only access the `i32` via `.lock()`, but the actual result of `.lock()` won't be an `i32` value so Rust's type system ensures you actually acquire a lock before using the `i32` value?

But I'm not actually sure.