### PR TITLE
Chapter 3, section 2 - Add explicit type annotation to example of scalar type char.

### DIFF
--- a/listings/ch03-common-programming-concepts/no-listing-09-char/src/main.rs
+++ b/listings/ch03-common-programming-concepts/no-listing-09-char/src/main.rs
@@ -1,5 +1,5 @@
 fn main() {
     let c = 'z';
-    let z = 'ℤ';
+    let z: char = 'ℤ'; // with explicit type annotation
     let heart_eyed_cat = '😻';
 }


### PR DESCRIPTION
See issue rust-lang/book#2941.