### PR TITLE
interchanged position of `binary` and `library`

### DIFF
--- a/src/ch07-01-packages-and-crates.md
+++ b/src/ch07-01-packages-and-crates.md
@@ -37,7 +37,7 @@ or binary.
 
 Here, we have a package that only contains *src/main.rs*, meaning it only
 contains a binary crate named `my-project`. If a package contains *src/main.rs*
-and *src/lib.rs*, it has two crates: a library and a binary, both with the same
+and *src/lib.rs*, it has two crates: a binary and a library, both with the same
 name as the package. A package can have multiple binary crates by placing files
 in the *src/bin* directory: each file will be a separate binary crate.
 


### PR DESCRIPTION
As per the sentence , I think `binary` should come first because we have mentioned `src/main.rs` before then `library` for `src/lib.rs` . 

I may be wrong , my English is not too good with best of my knowlege I am proposing this changes . Sorry if I made a mistake