### PR TITLE
Mention `cargo test -- --include-ignored` in test chapter

### DIFF
--- a/nostarch/chapter11.md
+++ b/nostarch/chapter11.md
@@ -1174,6 +1174,8 @@ will be fast. When you’re at a point where it makes sense to check the results
 of the `ignored` tests and you have time to wait for the results, you can run
 `cargo test -- --ignored` instead.
 
+If you want to run all test, not just the `ignored` tests, you can run `cargo test -- --include-ignored`.
+
 ## Test Organization
 
 As mentioned at the start of the chapter, testing is a complex discipline, and


### PR DESCRIPTION
I'm working through Excercism's rust track.

By default, all but the first test is `ignored`.

I was disappointed that the book didn't mention a way to run `all` tests, not just the `ignored`.

It turns out a flag exists to run all tests, including the ignored: `--include-ignored`

I added it to the book in this PR.