### PR TITLE
Emphasize return type is mandatory

### DIFF
--- a/src/ch03-03-how-functions-work.md
+++ b/src/ch03-03-how-functions-work.md
@@ -179,7 +179,7 @@ Keep this in mind as you explore function return values and expressions next.
 ### Functions with Return Values
 
 Functions can return values to the code that calls them. We don’t name return
-values, but we do declare their type after an arrow (`->`). In Rust, the return
+values, but we must declare their type after an arrow (`->`). In Rust, the return
 value of the function is synonymous with the value of the final expression in
 the block of the body of a function. You can return early from a function by
 using the `return` keyword and specifying a value, but most functions return


### PR DESCRIPTION
After being introduced to rust's type inference capabilities, I wrongly expected it to also infer return types. As this is the first point of introduction to function return types, we could further emphasize that the return type **must** be specified.