### PR TITLE
Compiler error when using 7-17 code

### DIFF
--- a/src/ch07-05-separating-modules-into-different-files.md
+++ b/src/ch07-05-separating-modules-into-different-files.md
@@ -5,10 +5,11 @@ When modules get large, you might want to move their definitions to a separate
 file to make the code easier to navigate.
 
 For example, let’s start from the code in Listing 7-17 and move the
-`front_of_house` module to its own file *src/front_of_house.rs* by changing the
-crate root file so it contains the code shown in Listing 7-21. In this case,
-the crate root file is *src/lib.rs*, but this procedure also works with binary
-crates whose crate root file is *src/main.rs*.
+`front_of_house` module to its own file *src/front_of_house.rs*. Once moved
+we can remove the redundant outer `mod front_of_house` scope. Now change the
+crate root file *src/lib.rs* so it contains the code shown in Listing 7-21.
+This procedure also works with binary crates whose crate root file is 
+src/main.rs.
 
 <span class="filename">Filename: src/lib.rs</span>
 


### PR DESCRIPTION
When moving the code over from the current 7-17 example and finishing the paragraph you're stuck with a compiling error from lib.rs due to the redundant outer front_of_house module in front_of_house.rs

---------------------------------
src/front_of_house.rs
unresolved import `crate::front_of_house::hosting`

no `hosting` in `front_of_house`rustc(E0432)
lib.rs(3, 9): no `hosting` in `front_of_house`