### PR TITLE
fix divided by 0 when removing last item

### DIFF
--- a/listings/ch17-oop/listing-17-02/src/lib.rs
+++ b/listings/ch17-oop/listing-17-02/src/lib.rs
@@ -14,7 +14,9 @@ impl AveragedCollection {
         let result = self.list.pop();
         match result {
             Some(value) => {
-                self.update_average();
+                if self.list.len() > 0 {
+                    self.update_average();
+                }
                 Some(value)
             }
             None => None,
@@ -22,7 +24,12 @@ impl AveragedCollection {
     }
 
     pub fn average(&self) -> f64 {
-        self.average
+        if self.list.len() > 0 {
+            self.average
+        }
+        else {
+            panic!("Collection is empty, no average available !");
+        }
     }
 
     fn update_average(&mut self) {


### PR DESCRIPTION
When `remove` is called on a one element AverageCollection, the last element is removed, result matches `Some(value)`  so `self.update.average` is called.
And `update_average` executes total (which is `list.iter.sum()` but list is empty) divided by `list.len` which is zero => big trouble here I guess.
Furhermore, calling `average` on an empty list should not be allowed, average having no signification then ...