### PR TITLE
Added a mention to the translations appendix

### DIFF
--- a/src/title-page.md
+++ b/src/title-page.md
@@ -11,9 +11,12 @@ The HTML format is available online at
 and offline with installations of Rust made with `rustup`; run `rustup docs
 --book` to open.
 
+Several other [translations] are also available.
+
 This text is available in [paperback and ebook format from No Starch
 Press][nsprust].
 
 [install]: ch01-01-installation.html
 [editions]: appendix-05-editions.html
 [nsprust]: https://nostarch.com/rust
+[translations]: appendix-06-translation.html


### PR DESCRIPTION
Currently, it's difficult to find a mention of the translations appendix anywhere - one has to scroll all the way to the bottom of the chapter list to see it. This is a problem because it's caused some people to discard reading the book entirely, as they thought no translation is available and they found the English version too hard to understand.

This PR aims to bring more visibility to that fact and should hopefully fix the problem.

I don't know if this should be merged now, because I'd like to get input on where exactly the paragraph should be put - maybe the title page isn't the correct spot.