### PR TITLE
Change "semantics" to "mechanics"; when referring to compiler behavior, rather than syntax.

### DIFF
--- a/nostarch/chapter04.md
+++ b/nostarch/chapter04.md
@@ -456,7 +456,7 @@ implement `Copy`:
 
 ### Ownership and Functions
 
-The semantics for passing a value to a function are similar to those for
+The mechanics of passing a value to a function are similar to those when
 assigning a value to a variable. Passing a variable to a function will move or
 copy, just as assignment does. Listing 4-3 has an example with some annotations
 showing where variables go into and out of scope.

--- a/src/ch04-01-what-is-ownership.md
+++ b/src/ch04-01-what-is-ownership.md
@@ -404,7 +404,7 @@ implement `Copy`:
 
 ### Ownership and Functions
 
-The semantics for passing a value to a function are similar to those for
+The mechanics of passing a value to a function are similar to those when
 assigning a value to a variable. Passing a variable to a function will move or
 copy, just as assignment does. Listing 4-3 has an example with some annotations
 showing where variables go into and out of scope.


### PR DESCRIPTION
Changes "semantics" to "mechanics"; when referring to compiler behavior, rather than syntax.

I'm not certain that "mechanics" is the ideal word, here. But, if understand what this sentence is meant to mean correctly, it is not referring to semantics/syntax.