### PR TITLE
Use v1.58 captured ident formatting in examples

### DIFF
--- a/listings/ch04-understanding-ownership/listing-04-05/src/main.rs
+++ b/listings/ch04-understanding-ownership/listing-04-05/src/main.rs
@@ -3,7 +3,7 @@ fn main() {
 
     let (s2, len) = calculate_length(s1);
 
-    println!("The length of '{}' is {}.", s2, len);
+    println!("The length of '{s2}' is {len}.");
 }
 
 fn calculate_length(s: String) -> (String, usize) {

--- a/listings/ch04-understanding-ownership/no-listing-05-clone/src/main.rs
+++ b/listings/ch04-understanding-ownership/no-listing-05-clone/src/main.rs
@@ -3,6 +3,6 @@ fn main() {
     let s1 = String::from("hello");
     let s2 = s1.clone();
 
-    println!("s1 = {}, s2 = {}", s1, s2);
+    println!("s1 = {s1}, s2 = {s2}");
     // ANCHOR_END: here
 }

--- a/listings/ch04-understanding-ownership/no-listing-06-copy/src/main.rs
+++ b/listings/ch04-understanding-ownership/no-listing-06-copy/src/main.rs
@@ -3,6 +3,6 @@ fn main() {
     let x = 5;
     let y = x;
 
-    println!("x = {}, y = {}", x, y);
+    println!("x = {x}, y = {y}");
     // ANCHOR_END: here
 }

--- a/listings/ch04-understanding-ownership/no-listing-07-reference/src/main.rs
+++ b/listings/ch04-understanding-ownership/no-listing-07-reference/src/main.rs
@@ -6,7 +6,7 @@ fn main() {
     let len = calculate_length(&s1);
     // ANCHOR_END: here
 
-    println!("The length of '{}' is {}.", s1, len);
+    println!("The length of '{s1}' is {len}.");
 }
 
 fn calculate_length(s: &String) -> usize {

--- a/listings/ch04-understanding-ownership/no-listing-08-reference-with-annotations/src/main.rs
+++ b/listings/ch04-understanding-ownership/no-listing-08-reference-with-annotations/src/main.rs
@@ -3,7 +3,7 @@ fn main() {
 
     let len = calculate_length(&s1);
 
-    println!("The length of '{}' is {}.", s1, len);
+    println!("The length of '{s1}' is {len}.");
 }
 
 // ANCHOR: here

--- a/listings/ch06-enums-and-pattern-matching/no-listing-09-variable-in-pattern/src/main.rs
+++ b/listings/ch06-enums-and-pattern-matching/no-listing-09-variable-in-pattern/src/main.rs
@@ -19,7 +19,7 @@ fn value_in_cents(coin: Coin) -> u8 {
         Coin::Nickel => 5,
         Coin::Dime => 10,
         Coin::Quarter(state) => {
-            println!("State quarter from {:?}!", state);
+            println!("State quarter from {state:?}!");
             25
         }
     }

--- a/listings/ch06-enums-and-pattern-matching/no-listing-13-count-and-announce-match/src/main.rs
+++ b/listings/ch06-enums-and-pattern-matching/no-listing-13-count-and-announce-match/src/main.rs
@@ -17,7 +17,7 @@ fn main() {
     // ANCHOR: here
     let mut count = 0;
     match coin {
-        Coin::Quarter(state) => println!("State quarter from {:?}!", state),
+        Coin::Quarter(state) => println!("State quarter from {state:?}!"),
         _ => count += 1,
     }
     // ANCHOR_END: here

--- a/listings/ch06-enums-and-pattern-matching/no-listing-14-count-and-announce-if-let-else/src/main.rs
+++ b/listings/ch06-enums-and-pattern-matching/no-listing-14-count-and-announce-if-let-else/src/main.rs
@@ -17,7 +17,7 @@ fn main() {
     // ANCHOR: here
     let mut count = 0;
     if let Coin::Quarter(state) = coin {
-        println!("State quarter from {:?}!", state);
+        println!("State quarter from {state:?}!");
     } else {
         count += 1;
     }

--- a/listings/ch11-writing-automated-tests/no-listing-05-greeter/src/lib.rs
+++ b/listings/ch11-writing-automated-tests/no-listing-05-greeter/src/lib.rs
@@ -1,5 +1,5 @@
 pub fn greeting(name: &str) -> String {
-    format!("Hello {}!", name)
+    format!("Hello {name}!")
 }
 
 #[cfg(test)]

--- a/listings/ch16-fearless-concurrency/listing-16-01/src/main.rs
+++ b/listings/ch16-fearless-concurrency/listing-16-01/src/main.rs
@@ -4,13 +4,13 @@ use std::time::Duration;
 fn main() {
     thread::spawn(|| {
         for i in 1..10 {
-            println!("hi number {} from the spawned thread!", i);
+            println!("hi number {i} from the spawned thread!");
             thread::sleep(Duration::from_millis(1));
         }
     });
 
     for i in 1..5 {
-        println!("hi number {} from the main thread!", i);
+        println!("hi number {i} from the main thread!");
         thread::sleep(Duration::from_millis(1));
     }
 }

--- a/listings/ch16-fearless-concurrency/listing-16-02/src/main.rs
+++ b/listings/ch16-fearless-concurrency/listing-16-02/src/main.rs
@@ -4,13 +4,13 @@ use std::time::Duration;
 fn main() {
     let handle = thread::spawn(|| {
         for i in 1..10 {
-            println!("hi number {} from the spawned thread!", i);
+            println!("hi number {i} from the spawned thread!");
             thread::sleep(Duration::from_millis(1));
         }
     });
 
     for i in 1..5 {
-        println!("hi number {} from the main thread!", i);
+        println!("hi number {i} from the main thread!");
         thread::sleep(Duration::from_millis(1));
     }
 

--- a/listings/ch16-fearless-concurrency/no-listing-01-join-too-early/src/main.rs
+++ b/listings/ch16-fearless-concurrency/no-listing-01-join-too-early/src/main.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 fn main() {
     let handle = thread::spawn(|| {
         for i in 1..10 {
-            println!("hi number {} from the spawned thread!", i);
+            println!("hi number {i} from the spawned thread!");
             thread::sleep(Duration::from_millis(1));
         }
     });
@@ -12,7 +12,7 @@ fn main() {
     handle.join().unwrap();
 
     for i in 1..5 {
-        println!("hi number {} from the main thread!", i);
+        println!("hi number {i} from the main thread!");
         thread::sleep(Duration::from_millis(1));
     }
 }

--- a/listings/ch18-patterns-and-matching/listing-18-11/src/main.rs
+++ b/listings/ch18-patterns-and-matching/listing-18-11/src/main.rs
@@ -6,9 +6,9 @@ fn main() {
     match x {
         Some(50) => println!("Got 50"),
         Some(y) => println!("Matched, y = {y}"),
-        _ => println!("Default case, x = {:?}", x),
+        _ => println!("Default case, x = {x:?}"),
     }
 
-    println!("at the end: x = {:?}, y = {y}", x);
+    println!("at the end: x = {x:?}, y = {y}");
     // ANCHOR_END: here
 }

--- a/listings/ch18-patterns-and-matching/listing-18-27/src/main.rs
+++ b/listings/ch18-patterns-and-matching/listing-18-27/src/main.rs
@@ -5,7 +5,7 @@ fn main() {
     match x {
         Some(50) => println!("Got 50"),
         Some(n) if n == y => println!("Matched, n = {n}"),
-        _ => println!("Default case, x = {:?}", x),
+        _ => println!("Default case, x = {x:?}"),
     }
 
     println!("at the end: x = {:?}, y = {y}", x);

--- a/redirects/loops.md
+++ b/redirects/loops.md
@@ -14,13 +14,13 @@ loop {
 
 let mut number = 3;
 while number != 0 {
-    println!("{}!", number);
+    println!("{number}!");
     number = number - 1;
 }
 
 let a = [10, 20, 30, 40, 50];
 for element in a.iter() {
-    println!("the value is: {}", element);
+    println!("the value is: {element}");
 }
 ```
 


### PR DESCRIPTION
Per https://github.com/rust-lang/book/issues/3047, use captured identifiers instead of the positional ones for some examples, e.g.

```diff
-  println!("Worker {} got a job; executing.", id);
+  println!("Worker {id} got a job; executing.");
```