### PR TITLE
fix: Listing number from 1-1 to 1-2 in ch01-03

### DIFF
--- a/src/ch01-03-hello-cargo.md
+++ b/src/ch01-03-hello-cargo.md
@@ -99,7 +99,7 @@ fn main() {
 ```
 
 Cargo has generated a “Hello, world!” program for you, just like the one we
-wrote in Listing 1-1! So far, the differences between our previous project and
+wrote in Listing 1-2! So far, the differences between our previous project and
 the project Cargo generated are that Cargo placed the code in the *src*
 directory, and we have a *Cargo.toml* configuration file in the top directory.
 


### PR DESCRIPTION
Hello ! 

I think there is a little mistake in chapter 01-03 when it talks about the 1-1 list instead of 1-2?

It is mentioned that the hello world code was written in the chapter 1-1 when it is rather in the 1-2.