### PR TITLE
Add `cargo new` learning to recap in ch01-03-hello-cargo.md

### DIFF
--- a/src/ch01-03-hello-cargo.md
+++ b/src/ch01-03-hello-cargo.md
@@ -184,6 +184,7 @@ build` when they’re ready to use the executable.
 
 Let’s recap what we’ve learned so far about Cargo:
 
+* We can create a project using `cargo new`.
 * We can build a project using `cargo build`.
 * We can build and run a project in one step using `cargo run`.
 * We can build a project without producing a binary to check for errors using


### PR DESCRIPTION
Although `cargo new` was explained in the previous subsection, it is altogether a very detailed section and it is good to include this for completeness and to remind the reader how to create a project, without them having to go back.