### PR TITLE
Minor grammatical correction in "Rust - getting started" documentation

### DIFF
--- a/src/ch01-03-hello-cargo.md
+++ b/src/ch01-03-hello-cargo.md
@@ -3,8 +3,7 @@
 Cargo is Rust’s build system and package manager. Most Rustaceans use this tool
 to manage their Rust projects because Cargo handles a lot of tasks for you,
 such as building your code, downloading the libraries your code depends on, and
-building those libraries. (We call the libraries that your code needs
-*dependencies*.)
+building those libraries. (We call the libraries that your code needs as *dependencies*.)
 
 The simplest Rust programs, like the one we’ve written so far, don’t have any
 dependencies. So if we had built the “Hello, world!” project with Cargo, it


### PR DESCRIPTION
When I was going through the documentation, I saw a grammatical error which I felt requires a correction,  "as" was missing in a sentence "We call the libraries that your code needs as *dependencies*.".