### PR TITLE
Return Output from add

### DIFF
--- a/listings/ch19-advanced-features/listing-19-14/src/main.rs
+++ b/listings/ch19-advanced-features/listing-19-14/src/main.rs
@@ -9,7 +9,7 @@ struct Point {
 impl Add for Point {
     type Output = Point;
 
-    fn add(self, other: Point) -> Output {
+    fn add(self, other: Point) -> Self::Output {
         Point {
             x: self.x + other.x,
             y: self.y + other.y,

--- a/listings/ch19-advanced-features/listing-19-14/src/main.rs
+++ b/listings/ch19-advanced-features/listing-19-14/src/main.rs
@@ -9,7 +9,7 @@ struct Point {
 impl Add for Point {
     type Output = Point;
 
-    fn add(self, other: Point) -> Point {
+    fn add(self, other: Point) -> Output {
         Point {
             x: self.x + other.x,
             y: self.y + other.y,


### PR DESCRIPTION
Hi, I'm confused by this documentation since `Output` is never used, shouldn't it be the return type of `add`?

> The add method adds the x values of two Point instances and the y values of two Point instances to create a new Point. The Add trait has an associated type named Output that determines the type returned from the add method.