### PR TITLE
Update src/ch04-01-what-is-ownership.md

### DIFF
--- a/src/ch04-01-what-is-ownership.md
+++ b/src/ch04-01-what-is-ownership.md
@@ -44,8 +44,8 @@ strings.
 > certain amount of space. The memory allocator finds an empty spot in the heap
 > that is big enough, marks it as being in use, and returns a *pointer*, which
 > is the address of that location. This process is called *allocating on the
-> heap* and is sometimes abbreviated as just *allocating*. Pushing values onto
-> the stack is not considered allocating. Because the pointer to the heap is a
+> heap* and is sometimes abbreviated as just *allocating* (pushing values onto 
+> the stack is not considered allocating). Because the pointer to the heap is a
 > known, fixed size, you can store the pointer on the stack, but when you want
 > the actual data, you must follow the pointer. Think of being seated at a
 > restaurant. When you enter, you state the number of people in your group, and


### PR DESCRIPTION
Small change removing punctuation to enhance the sentence flow.

This commit changes this:

> This process is called allocating on the heap and is sometimes abbreviated as just allocating. Pushing values onto the stack is not considered allocating. Because the pointer to the heap is a known, fixed size, you can store the pointer on the stack, but when you want the actual data, you must follow the pointer. 

to

> This process is called allocating on the heap and is sometimes abbreviated as just allocating (pushing values onto the stack is not considered allocating). Because the pointer to the heap is a known, fixed size, you can store the pointer on the stack, but when you want the actual data, you must follow the pointer. Think of being seated at a restaurant.

The parenthesis for references to the stack on the heap section is used below, and I would say it provides a better mental model while reading the stack (the previous paragraph/section) and heap comparison. It's slightly better than the punctuation.