### PR TITLE
Tweak a snippet of ch18-03

### DIFF
--- a/src/ch18-03-pattern-syntax.md
+++ b/src/ch18-03-pattern-syntax.md
@@ -107,7 +107,7 @@ Here is an example using ranges of `char` values:
 {{#rustdoc_include ../listings/ch18-patterns-and-matching/no-listing-04-ranges-of-char/src/main.rs:here}}
 ```
 
-Rust can tell that `c` is within the first pattern’s range and prints `early
+Rust can tell that `'c'` is within the first pattern’s range and prints `early
 ASCII letter`.
 
 ### Destructuring to Break Apart Values


### PR DESCRIPTION
By enclosing `c` in quotes, the following `c` will be clarified as a literal rather than a variable.

```rust
let x = 'c';
```

https://doc.rust-lang.org/book/ch18-03-pattern-syntax.html#matching-ranges-of-values-with-