### PR TITLE
Updated `horse_ebooks` tweet content

### DIFF
--- a/listings/ch10-generic-types-traits-and-lifetimes/no-listing-01-calling-trait-method/src/main.rs
+++ b/listings/ch10-generic-types-traits-and-lifetimes/no-listing-01-calling-trait-method/src/main.rs
@@ -4,7 +4,7 @@ fn main() {
     let tweet = Tweet {
         username: String::from("horse_ebooks"),
         content: String::from(
-            "of course, as you probably already know, people",
+            "unfortunately, as you probably already know, people",
         ),
         reply: false,
         retweet: false,

--- a/src/ch10-02-traits.md
+++ b/src/ch10-02-traits.md
@@ -90,7 +90,7 @@ library crate:
 {{#rustdoc_include ../listings/ch10-generic-types-traits-and-lifetimes/no-listing-01-calling-trait-method/src/main.rs}}
 ```
 
-This code prints `1 new tweet: horse_ebooks: of course, as you probably already
+This code prints `1 new tweet: horse_ebooks: unfortunately, as you probably already
 know, people`.
 
 Other crates that depend on the `aggregator` crate can also bring the `Summary`


### PR DESCRIPTION
Changed `of course, as you probably already know, people` to  `unfortunatley, as you probably already know, people` which was the [actual tweet](https://twitter.com/horse_ebooks/status/228032106859749377?lang=en)