### PR TITLE
Tweak a snippet of ch19-03

### DIFF
--- a/src/ch19-03-advanced-traits.md
+++ b/src/ch19-03-advanced-traits.md
@@ -65,7 +65,7 @@ This syntax seems comparable to that of generics. So why not just define the
 
 The difference is that when using generics, as in Listing 19-13, we must
 annotate the types in each implementation; because we can also implement
-`Iterator<String> for Counter` or any other type, we could have multiple
+`impl Iterator<String> for Counter` or any other type, we could have multiple
 implementations of `Iterator` for `Counter`. In other words, when a trait has a
 generic parameter, it can be implemented for a type multiple times, changing
 the concrete types of the generic type parameters each time. When we use the


### PR DESCRIPTION
It seems to help understanding with the addition of `impl`, as in the text below.

```markdown
because there can only be one `impl Iterator for Counter`.
```

The above is a quote from other text in ch19-03 and this patch makes the contrast with this snippet clearer.

Target page: https://doc.rust-lang.org/book/ch19-03-advanced-traits.html#specifying-placeholder-types-in-trait-definitions-with-associated-types