### PR TITLE
Fix #3102 - CH10.2 // 'use aggretaror::' instead of 'use chapter10::'.

### DIFF
--- a/listings/ch10-generic-types-traits-and-lifetimes/no-listing-02-calling-default-impl/src/main.rs
+++ b/listings/ch10-generic-types-traits-and-lifetimes/no-listing-02-calling-default-impl/src/main.rs
@@ -1,4 +1,4 @@
-use chapter10::{self, NewsArticle, Summary};
+use aggregator::{self, NewsArticle, Summary};
 
 fn main() {
     // ANCHOR: here

--- a/listings/ch10-generic-types-traits-and-lifetimes/no-listing-03-default-impl-calls-other-methods/src/main.rs
+++ b/listings/ch10-generic-types-traits-and-lifetimes/no-listing-03-default-impl-calls-other-methods/src/main.rs
@@ -1,4 +1,4 @@
-use chapter10::{self, Summary, Tweet};
+use aggregator::{self, Summary, Tweet};
 
 fn main() {
     // ANCHOR: here


### PR DESCRIPTION
This PR to replace wrong `chapter10` in examples with `aggregator`, as indicated in documentation.

See #3102 for details.

