### PR TITLE
Update ch10-03-lifetime-syntax.md

### DIFF
--- a/src/ch10-03-lifetime-syntax.md
+++ b/src/ch10-03-lifetime-syntax.md
@@ -218,9 +218,9 @@ takes two parameters, both of which are string slices that live at least as
 long as lifetime `'a`. The function signature also tells Rust that the string
 slice returned from the function will live at least as long as lifetime `'a`.
 In practice, it means that the lifetime of the reference returned by the
-`longest` function is the same as the smaller of the lifetimes of the
-references passed in. These relationships are what we want Rust to use when
-analyzing this code.
+`longest` function is the same as the smaller of the lifetimes of the values
+to which the references are passed in as function arguments. These relationships
+are what we want Rust to use when analyzing this code.
 
 Remember, when we specify the lifetime parameters in this function signature,
 we’re not changing the lifetimes of any values passed in or returned. Rather,


### PR DESCRIPTION
Lifetime parameters refer to the borrowed (referenced) values not to the function parameters (which are the references). 