### PR TITLE
Fix error message typo

### DIFF
--- a/src/appendix-04-useful-development-tools.md
+++ b/src/appendix-04-useful-development-tools.md
@@ -56,7 +56,7 @@ $ cargo build
 warning: unused variable: `i`
  --> src/main.rs:4:9
   |
-4 |     for i in 1..100 {
+4 |     for i in 0..100 {
   |         ^ help: consider using `_i` instead
   |
   = note: #[warn(unused_variables)] on by default


### PR DESCRIPTION
Fixes a typo in an error message so that it matches its corresponding code snippet (`1..100` -> `0..100`)