### PR TITLE
Fix unidiomatic new functions in chapter 15

### DIFF
--- a/listings/ch15-smart-pointers/listing-15-20/src/lib.rs
+++ b/listings/ch15-smart-pointers/listing-15-20/src/lib.rs
@@ -12,7 +12,7 @@ impl<'a, T> LimitTracker<'a, T>
 where
     T: Messenger,
 {
-    pub fn new(messenger: &T, max: usize) -> LimitTracker<T> {
+    pub fn new(messenger: &'a T, max: usize) -> LimitTracker<'a, T> {
         LimitTracker {
             messenger,
             value: 0,

--- a/listings/ch15-smart-pointers/listing-15-21/src/lib.rs
+++ b/listings/ch15-smart-pointers/listing-15-21/src/lib.rs
@@ -12,7 +12,7 @@ impl<'a, T> LimitTracker<'a, T>
 where
     T: Messenger,
 {
-    pub fn new(messenger: &T, max: usize) -> LimitTracker<T> {
+    pub fn new(messenger: &'a T, max: usize) -> LimitTracker<'a, T> {
         LimitTracker {
             messenger,
             value: 0,

--- a/listings/ch15-smart-pointers/listing-15-22/src/lib.rs
+++ b/listings/ch15-smart-pointers/listing-15-22/src/lib.rs
@@ -12,7 +12,7 @@ impl<'a, T> LimitTracker<'a, T>
 where
     T: Messenger,
 {
-    pub fn new(messenger: &T, max: usize) -> LimitTracker<T> {
+    pub fn new(messenger: &'a T, max: usize) -> LimitTracker<'a, T> {
         LimitTracker {
             messenger,
             value: 0,

--- a/listings/ch15-smart-pointers/listing-15-23/src/lib.rs
+++ b/listings/ch15-smart-pointers/listing-15-23/src/lib.rs
@@ -12,7 +12,7 @@ impl<'a, T> LimitTracker<'a, T>
 where
     T: Messenger,
 {
-    pub fn new(messenger: &T, max: usize) -> LimitTracker<T> {
+    pub fn new(messenger: &'a T, max: usize) -> LimitTracker<'a, T> {
         LimitTracker {
             messenger,
             value: 0,


### PR DESCRIPTION
Some questions came up on the discord today that where rooted in the example code for chapter 15 having a unidiomatic new function. `new` should return the same type as `Self`, which was not the case here. 😄 

I was also wondering if I should make all those return types `Self` directly, as that would be even better, but I'm not sure if that distracts too much from the topic.