### PR TITLE
Fix Out of Order `Generating Random Number` Code Sample Imports in Chapter 2

### DIFF
--- a/listings/ch02-guessing-game-tutorial/listing-02-03/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/listing-02-03/src/main.rs
@@ -1,7 +1,7 @@
-// ANCHOR: all
-use std::io;
 // ANCHOR: ch07-04
 use rand::Rng;
+// ANCHOR: all
+use std::io;
 
 fn main() {
     // ANCHOR_END: ch07-04

--- a/listings/ch02-guessing-game-tutorial/listing-02-03/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/listing-02-03/src/main.rs
@@ -24,5 +24,5 @@ fn main() {
     println!("You guessed: {guess}");
     // ANCHOR: ch07-04
 }
-// ANCHOR_END: ch07-04
 // ANCHOR_END: all
+// ANCHOR_END: ch07-04


### PR DESCRIPTION
Fixes #3121

Currently, imported crates are out of order in the code samples of the [Generating a Random Number](https://doc.rust-lang.org/book/ch02-00-guessing-game-tutorial.html#generating-a-random-number) section of Chapter 02:

```rust
use std::io;
use rand::Rng;
```

Suggested fix:
Update the relevant imports to display the following:

```rust
use rand::Rng;
use std::io;
```