### PR TITLE
Fix #3002 ch11.3 use noplayground with common.rs

### DIFF
--- a/src/ch11-03-test-organization.md
+++ b/src/ch11-03-test-organization.md
@@ -162,7 +162,7 @@ we want to call from multiple test functions in multiple test files:
 
 <span class="filename">Filename: tests/common.rs</span>
 
-```rust
+```rust,noplayground
 {{#rustdoc_include ../listings/ch11-writing-automated-tests/no-listing-12-shared-test-code-problem/tests/common.rs}}
 ```
 


### PR DESCRIPTION
Hi, this is a fix for #3002 . The inclusion of `common.rs` should be marked as `noplayground` to avoid generating a `main()`.