### PR TITLE
ch10-03: Fix wording about lifetime annotations

### DIFF
--- a/src/ch10-03-lifetime-syntax.md
+++ b/src/ch10-03-lifetime-syntax.md
@@ -216,7 +216,7 @@ This code should compile and produce the result we want when we use it with the
 The function signature now tells Rust that for some lifetime `'a`, the function
 takes two parameters, both of which are string slices that live at least as
 long as lifetime `'a`. The function signature also tells Rust that the string
-slice returned from the function will live at least as long as lifetime `'a`.
+slice returned from the function will live at most as long as lifetime `'a`.
 In practice, it means that the lifetime of the reference returned by the
 `longest` function is the same as the smaller of the lifetimes of the
 references passed in. These relationships are what we want Rust to use when


### PR DESCRIPTION
The borrow checker must check that the returned reference doesn't
outlive any of the parameters (with the same lifetime annotation), so
reword to "will live at most as long".