### PR TITLE
Extra-clarity qualification

### DIFF
--- a/listings/ch08-common-collections/listing-08-05/src/main.rs
+++ b/listings/ch08-common-collections/listing-08-05/src/main.rs
@@ -6,7 +6,7 @@ fn main() {
     println!("The third element is {}", third);
 
     match v.get(2) {
-        Some(third) => println!("The third element is {}", third),
+        Some(third @&i32) => println!("The third element is {}", third),
         None => println!("There is no third element."),
     }
     // ANCHOR_END: here


### PR DESCRIPTION
Regard the preceding wording “_we’ve annotated the types of the values that are returned from these functions for extra clarity._” in [**_rust-lang-book/src/ch08-01-vectors.md_**](https://doc.rust-lang.org/book/ch08-01-vectors.html#reading-elements-of-vectors) while only the indexing function is annotated.