### PR TITLE
listing-08-05: Extra-clarity qualification

### DIFF
--- a/listings/ch08-common-collections/listing-08-05/src/main.rs
+++ b/listings/ch08-common-collections/listing-08-05/src/main.rs
@@ -5,7 +5,8 @@ fn main() {
     let third: &i32 = &v[2];
     println!("The third element is {}", third);
 
-    match v.get(2) {
+    let third: Option<&i32> = v.get(2);
+    match third  {
         Some(third) => println!("The third element is {}", third),
         None => println!("There is no third element."),
     }


### PR DESCRIPTION
Regard the preceding wording “_we’ve annotated the types of the values that are returned from these functions for extra clarity._” in [**_rust-lang-book/src/ch08-01-vectors.md_**](https://doc.rust-lang.org/book/ch08-01-vectors.html#reading-elements-of-vectors) while only the indexing function is annotated.