### PR TITLE
Use a 3 bytes for the color example instead of 12 bytes

### DIFF
--- a/listings/ch05-using-structs-to-structure-related-data/no-listing-01-tuple-structs/src/main.rs
+++ b/listings/ch05-using-structs-to-structure-related-data/no-listing-01-tuple-structs/src/main.rs
@@ -1,5 +1,5 @@
-struct Color(i32, i32, i32);
-struct Point(i32, i32, i32);
+struct Color(u8, u8, u8);
+struct Point(u8, u8, u8);
 
 fn main() {
     let black = Color(0, 0, 0);


### PR DESCRIPTION
A color is composed of 3 bytes of u8, it would be more adequate to replace the i32 with u8 in both the explanation and the code.