### PR TITLE
& is not valid inside image alt text

### DIFF
--- a/src/ch04-02-references-and-borrowing.md
+++ b/src/ch04-02-references-and-borrowing.md
@@ -25,7 +25,7 @@ function return value is gone. Second, note that we pass `&s1` into
 `String`. These ampersands represent *references*, and they allow you to refer
 to some value without taking ownership of it. Figure 4-5 depicts this concept.
 
-<img alt="&String s pointing at String s1" src="img/trpl04-05.svg" class="center" />
+<img alt="&#59;String s pointing at String s1" src="img/trpl04-05.svg" class="center" />
 
 <span class="caption">Figure 4-5: A diagram of `&String s` pointing at `String
 s1`</span>


### PR DESCRIPTION
Ampersand characters should be HTML escaped in alt text.
This was causing validation errors downstream when checking a generated EPUB.