### PR TITLE
Update ch10-03-lifetime-syntax.md

### DIFF
--- a/src/ch10-03-lifetime-syntax.md
+++ b/src/ch10-03-lifetime-syntax.md
@@ -52,7 +52,7 @@ try to use it. Here is the error message:
 ```
 
 The variable `x` doesn’t “live long enough.” The reason is that `x` will be out
-of scope when the inner scope ends on line 7. But `r` is still valid for the
+of scope when the inner scope ends on line 8. But `r` is still valid for the
 outer scope; because its scope is larger, we say that it “lives longer.” If
 Rust allowed this code to work, `r` would be referencing memory that was
 deallocated when `x` went out of scope, and anything we tried to do with `r`


### PR DESCRIPTION
adjust explanation text per output from compiler. The scope ends on line 8 of actual code, not 7. Can be confusing since line 7 is assignment.