### PR TITLE
fix: ch04-understanding-ownership-listing-04-06

### DIFF
--- a/listings/ch04-understanding-ownership/listing-04-06/src/main.rs
+++ b/listings/ch04-understanding-ownership/listing-04-06/src/main.rs
@@ -1,5 +1,5 @@
 fn main() {
-    let s = String::from("hello");
+    let mut s = String::from("hello");
 
     change(&s);
 }


### PR DESCRIPTION
Variable s must be declared as mutable. We can not have a mutable reference from an immutable variable. When I initially saw this example I thought that I could declare an immutable variable and then mutate it via a mutable reference.

Note: The reason I believed the above is because in the next listing [no-listing-09-fixes-listing-04-06](https://github.com/rust-lang/book/blob/main/listings/ch04-understanding-ownership/no-listing-09-fixes-listing-04-06/src/main.rs), the variable appears as mutable during the variable's declaration and also in the mutating function