### PR TITLE
Fix #3152 - Wrong character used

### DIFF
--- a/src/ch04-02-references-and-borrowing.md
+++ b/src/ch04-02-references-and-borrowing.md
@@ -25,7 +25,7 @@ function return value is gone. Second, note that we pass `&s1` into
 `String`. These ampersands represent *references*, and they allow you to refer
 to some value without taking ownership of it. Figure 4-5 depicts this concept.
 
-<img alt="&#59;String s pointing at String s1" src="img/trpl04-05.svg" class="center" />
+<img alt="&amp;String s pointing at String s1" src="img/trpl04-05.svg" class="center" />
 
 <span class="caption">Figure 4-5: A diagram of `&String s` pointing at `String
 s1`</span>


### PR DESCRIPTION
PR #3152 fixed the invalid alt text (so it correctly validates), but was the wrong character.
&amp; is the correct ampersand, &#59; was a semicolon