### PR TITLE
Fix ch03-02-data-types: rounding of integer division

### DIFF
--- a/src/ch03-02-data-types.md
+++ b/src/ch03-02-data-types.md
@@ -149,7 +149,7 @@ Floating-point numbers are represented according to the IEEE-754 standard. The
 
 Rust supports the basic mathematical operations you’d expect for all of the
 number types: addition, subtraction, multiplication, division, and remainder.
-Integer division rounds down to the nearest integer. The following code shows
+Integer division rounds towards zero. The following code shows
 how you’d use each numeric operation in a `let` statement:
 
 <span class="filename">Filename: src/main.rs</span>


### PR DESCRIPTION
Example:

```rust
let x = -5 / 2;
// x == -2
```

If it is "rounding down", then `x == -3`. But for `-2` I think "rounding towards zero" is much more precise.