### PR TITLE
ch04-02-fix-meaning

### DIFF
--- a/src/ch04-02-references-and-borrowing.md
+++ b/src/ch04-02-references-and-borrowing.md
@@ -1,7 +1,7 @@
 ## References and Borrowing
 
 The issue with the tuple code in Listing 4-5 is that we have to return the
-`String` to the calling function so we can still use the `String` after the
+`String` to the calling function so we can't still use the `String` after the
 call to `calculate_length`, because the `String` was moved into
 `calculate_length`. Instead, we can provide a reference to the `String` value.
 A *reference* is like a pointer in that it’s an address we can follow to access


### PR DESCRIPTION
Fixes #3183

URL to the section(s) of the book with this problem:
https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html

Description of the problem:
The meaning is opposite

Suggested fix:
The issue with the tuple code in Listing 4-5 is that we have to return the String to the calling function so we [can > can't] still use the String after the call to calculate_length, because the String was moved into calculate_length.