### PR TITLE
Add `use super::*;` to unit-test examples.

### DIFF
--- a/listings/ch11-writing-automated-tests/listing-11-01/src/lib.rs
+++ b/listings/ch11-writing-automated-tests/listing-11-01/src/lib.rs
@@ -1,8 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     #[test]
     fn it_works() {
-        let result = 2 + 2;
+        let result = add(2, 2);
         assert_eq!(result, 4);
     }
 }

--- a/listings/ch11-writing-automated-tests/listing-11-03/output.txt
+++ b/listings/ch11-writing-automated-tests/listing-11-03/output.txt
@@ -10,7 +10,7 @@ test tests::exploration ... ok
 failures:
 
 ---- tests::another stdout ----
-thread 'main' panicked at 'Make this test fail', src/lib.rs:10:9
+thread 'main' panicked at 'Make this test fail', src/lib.rs:17:9
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
 

--- a/listings/ch11-writing-automated-tests/listing-11-03/src/lib.rs
+++ b/listings/ch11-writing-automated-tests/listing-11-03/src/lib.rs
@@ -1,9 +1,16 @@
 // ANCHOR: here
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     #[test]
     fn exploration() {
-        assert_eq!(2 + 2, 4);
+        let result = add(2, 2);
+        assert_eq!(result, 4);
     }
 
     #[test]

--- a/listings/ch11-writing-automated-tests/no-listing-01-changing-test-name/src/lib.rs
+++ b/listings/ch11-writing-automated-tests/no-listing-01-changing-test-name/src/lib.rs
@@ -1,7 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     #[test]
     fn exploration() {
-        assert_eq!(2 + 2, 4);
+        let result = add(2, 2);
+        assert_eq!(result, 4);
     }
 }

--- a/listings/ch11-writing-automated-tests/no-listing-10-result-in-tests/src/lib.rs
+++ b/listings/ch11-writing-automated-tests/no-listing-10-result-in-tests/src/lib.rs
@@ -1,8 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     #[test]
     fn it_works() -> Result<(), String> {
-        if 2 + 2 == 4 {
+        if add(2, 2) == 4 {
             Ok(())
         } else {
             Err(String::from("two plus two does not equal four"))

--- a/listings/ch14-more-about-cargo/output-only-02-add-one/add/add_one/src/lib.rs
+++ b/listings/ch14-more-about-cargo/output-only-02-add-one/add/add_one/src/lib.rs
@@ -1,8 +1,14 @@
+fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     #[test]
     fn it_works() {
-        let result = 2 + 2;
+        let result = add(2, 2);
         assert_eq!(result, 4);
     }
 }

--- a/nostarch/chapter11.md
+++ b/nostarch/chapter11.md
@@ -172,11 +172,17 @@ the `it_works` function to a different name, such as `exploration`, like so:
 Filename: src/lib.rs
 
 ```
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     #[test]
     fn exploration() {
-        let result = 2 + 2;
+        let result = add(2, 2);
         assert_eq!(result, 4);
     }
 }
@@ -203,11 +209,18 @@ is to call the `panic!` macro. Enter the new test as a function named
 Filename: src/lib.rs
 
 ```
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     #[test]
     fn exploration() {
-        assert_eq!(2 + 2, 4);
+        let result = add(2, 2);
+        assert_eq!(result, 4);
     }
 
     #[test]
@@ -231,7 +244,7 @@ test tests::exploration ... ok
 2 failures:
 
 ---- tests::another stdout ----
-thread 'main' panicked at 'Make this test fail', src/lib.rs:10:9
+thread 'main' panicked at 'Make this test fail', src/lib.rs:17:9
 note: run with `RUST_BACKTRACE=1` environment variable to display
 a backtrace
 
@@ -867,11 +880,17 @@ E>` and return an `Err` instead of panicking:
 Filename: src/lib.rs
 
 ```
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     #[test]
     fn it_works() -> Result<(), String> {
-        if 2 + 2 == 4 {
+        if add(2, 2) == 4 {
             Ok(())
         } else {
             Err(String::from("two plus two does not equal four"))
@@ -1265,11 +1284,17 @@ this chapter, Cargo generated this code for us:
 Filename: src/lib.rs
 
 ```
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     #[test]
     fn it_works() {
-        let result = 2 + 2;
+        let result = add(2, 2);
         assert_eq!(result, 4);
     }
 }

--- a/src/ch11-01-writing-tests.md
+++ b/src/ch11-01-writing-tests.md
@@ -62,16 +62,19 @@ cd ../../..
 <span class="caption">Listing 11-1: The test module and function generated
 automatically by `cargo new`</span>
 
-For now, let’s ignore the top two lines and focus on the function. Note the
+The file starts with an example `add` function, so that we have something
+to test.
+
+For now, let’s ignore the next few lines and focus on the function with the
 `#[test]` annotation: this attribute indicates this is a test function, so the
 test runner knows to treat this function as a test. We might also have non-test
 functions in the `tests` module to help set up common scenarios or perform
 common operations, so we always need to indicate which functions are tests.
 
 The example function body uses the `assert_eq!` macro to assert that `result`,
-which contains the result of adding 2 and 2, equals 4. This assertion serves as
-an example of the format for a typical test. Let’s run it to see that this test
-passes.
+which contains the result of calling `add` with 2 and 2, equals 4. This
+assertion serves as an example of the format for a typical test. Let’s run it
+to see that this test passes.
 
 The `cargo test` command runs all tests in our project, as shown in Listing
 11-2.


### PR DESCRIPTION
rust-lang/cargo#10706 switched the `cargo init --lib`-generated src/lib.rs
to use a function and `use super::*;` inside the `mod test`. This makes
it easier for new users to write their own functions and add tests, as it
means the tests can refer to the new functions without any extra work, and
without rustc asking them to add explicit `use`s for each new thing they add.

This PR updates the parts of the book that use this src/lib.rs and
similar examples, to match the new output of `cargo init --lib`, and to
additionally help guide users to using `use super::*;` inside their
`mod test`s.

There is one non-example change, which is to update the wording in
src/ch11-01-writing-tests.md to better reflect the new content in the
associated example.