### PR TITLE
Fix missing ampersand in listing 10-11

### DIFF
--- a/listings/ch10-generic-types-traits-and-lifetimes/listing-10-11/src/main.rs
+++ b/listings/ch10-generic-types-traits-and-lifetimes/listing-10-11/src/main.rs
@@ -4,7 +4,7 @@ struct Point<X1, Y1> {
 }
 
 impl<X1, Y1> Point<X1, Y1> {
-    fn mixup<X2, Y2>(self, other: Point<X2, Y2>) -> Point<X1, Y2> {
+    fn mixup<X2, Y2>(&self, other: Point<X2, Y2>) -> Point<X1, Y2> {
         Point {
             x: self.x,
             y: other.y,


### PR DESCRIPTION
I was reading through this incredible book until I found a little error in listing 10-11, now I'm pretty new to Rust so if I'm missing some automatic referencing in `self` feel free to correct me that I'll happily close this pr.