### PR TITLE
Update appendix-02-operators.md

### DIFF
--- a/src/appendix-02-operators.md
+++ b/src/appendix-02-operators.md
@@ -17,6 +17,7 @@ overload that operator is listed.
 |----------|---------|-------------|---------------|
 | `!` | `ident!(...)`, `ident!{...}`, `ident![...]` | Macro expansion | |
 | `!` | `!expr` | Bitwise or logical complement | `Not` |
+| `!` | `!auto_trait` | Defines a removal trait for an auto_trait | `Not` |
 | `!=` | `expr != expr` | Nonequality comparison | `PartialEq` |
 | `%` | `expr % expr` | Arithmetic remainder | `Rem` |
 | `%=` | `var %= expr` | Arithmetic remainder and assignment | `RemAssign` |
@@ -69,6 +70,7 @@ overload that operator is listed.
 | <code>&vert;=</code> | <code>var &vert;= expr</code> | Bitwise OR and assignment | `BitOrAssign` |
 | <code>&vert;&vert;</code> | <code>expr &vert;&vert; expr</code> | Short-circuiting logical OR | |
 | `?` | `expr?` | Error propagation | |
+| `?` | `?Sized` | Marks the trait optional; such as, allow generic parameters to be unsized | |
 
 ### Non-operator Symbols
 


### PR DESCRIPTION
Provide inclusion of the operators `!` and `?` for their use on auto traits. "Keywords" and "Operators" serve as a central index the documentation and therefore must be comprehensive. In particular, documentation for these symbols appearance in code on traits cannot be easily discovered since they are overloaded and heavily used in other circumstances, especially `!`.