### PR TITLE
Make style of listings 9-7 and 9-8 consistent with 9-6

### DIFF
--- a/listings/ch09-error-handling/listing-09-07/src/main.rs
+++ b/listings/ch09-error-handling/listing-09-07/src/main.rs
@@ -1,7 +1,6 @@
 // ANCHOR: here
 use std::fs::File;
-use std::io;
-use std::io::Read;
+use std::io::{self, Read};
 
 fn read_username_from_file() -> Result<String, io::Error> {
     let mut username_file = File::open("hello.txt")?;

--- a/listings/ch09-error-handling/listing-09-08/src/main.rs
+++ b/listings/ch09-error-handling/listing-09-08/src/main.rs
@@ -1,7 +1,6 @@
 // ANCHOR: here
 use std::fs::File;
-use std::io;
-use std::io::Read;
+use std::io::{self, Read};
 
 fn read_username_from_file() -> Result<String, io::Error> {
     let mut username = String::new();


### PR DESCRIPTION
This PR removes superficial differences between listings the reader is asked to compare.

Previously, [9-6](https://github.com/rust-lang/book/blob/main/listings/ch09-error-handling/listing-09-06/src/main.rs#L3) used the style
```
use std::io::{self, Read};
```
while [9-7](https://github.com/rust-lang/book/blob/main/listings/ch09-error-handling/listing-09-07/src/main.rs#L3) and [9-8](https://github.com/rust-lang/book/blob/main/listings/ch09-error-handling/listing-09-08/src/main.rs#L3) used
```
use std::io;
use std::io::Read;
```
After the PR, all three listings will use the first style.