### PR TITLE
Regenerate ch09-02 error messages

### DIFF
--- a/src/ch09-02-recoverable-errors-with-result.md
+++ b/src/ch09-02-recoverable-errors-with-result.md
@@ -188,9 +188,9 @@ copy and paste relevant text
 -->
 
 ```text
-thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Error {
-repr: Os { code: 2, message: "No such file or directory" } }',
-src/libcore/result.rs:906:4
+thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os {
+code: 2, kind: NotFound, message: "No such file or directory" }',
+src/main.rs:4:49
 ```
 
 Similarly, the `expect` method lets us also choose the `panic!` error message.
@@ -216,9 +216,9 @@ copy and paste relevant text
 -->
 
 ```text
-thread 'main' panicked at 'hello.txt should be included in this project: Error
-{ repr: Os { code: 2, message: "No such file or directory" } }',
-src/libcore/result.rs:906:4
+thread 'main' panicked at 'hello.txt should be included in this project: Os {
+code: 2, kind: NotFound, message: "No such file or directory" }',
+src/main.rs:5:10
 ```
 
 In production-quality code, most Rustaceans choose `expect` rather than


### PR DESCRIPTION
In 1b9934783 the advantages of `expect` have been clarified to remove
the statements that it helps with locating the error. This is accurate
since 1.46.0 introduced the `#[track_caller]` attribute.

The original patch however did not regenerate all the errors with the
latest compiler, so this patch updates the errors to avoid potential
confusion.