### PR TITLE
Duplicate fragment "mutation and borrowing"

### DIFF
--- a/src/ch15-05-interior-mutability.md
+++ b/src/ch15-05-interior-mutability.md
@@ -4,9 +4,9 @@
 data even when there are immutable references to that data; normally, this
 action is disallowed by the borrowing rules. To mutate data, the pattern uses
 `unsafe` code inside a data structure to bend Rust’s usual rules that govern
-mutation and borrowing. mutation and borrowing. Unsafe code indicates to the
-compiler that we’re checking the rules manually instead of relying on the
-compiler to check them for us; we will discuss unsafe code more in Chapter 19.
+mutation and borrowing. Unsafe code indicates to the compiler that we’re
+checking the rules manually instead of relying on the compiler to check them
+for us; we will discuss unsafe code more in Chapter 19.
 
 We can use types that use the interior mutability pattern only when we can
 ensure that the borrowing rules will be followed at runtime, even though the


### PR DESCRIPTION
The fragment "mutation and borrowing" is twice in a paragraph, seems to be a broken sentence. This PR removes the fragment.