### PR TITLE
matched type of absent_number to Option<i32>

### DIFF
--- a/listings/ch06-enums-and-pattern-matching/no-listing-06-option-examples/src/main.rs
+++ b/listings/ch06-enums-and-pattern-matching/no-listing-06-option-examples/src/main.rs
@@ -3,6 +3,6 @@ fn main() {
     let some_number = Some(5);
     let some_char = Some('e');
 
-    let absent_number: Option<i32> = None;
+    let absent_number: Option<i32> = Option::None;
     // ANCHOR_END: here
 }


### PR DESCRIPTION
Changing this gets rid of the mismatched types error.
expected enum 'Option<i32>'
found enum 'std::option::Option<_>'