### PR TITLE
Format `where` clause example in 10.2 traits

### DIFF
--- a/src/ch10-02-traits.md
+++ b/src/ch10-02-traits.md
@@ -284,8 +284,9 @@ we can use a `where` clause, like this:
 
 ```rust,ignore
 fn some_function<T, U>(t: &T, u: &U) -> i32
-    where T: Display + Clone,
-          U: Clone + Debug
+where
+    T: Display + Clone,
+    U: Clone + Debug,
 {
 ```
 


### PR DESCRIPTION
Use `rustfmt` to format this example.