### PR TITLE
docs: Fix wrong method name in ch13-02-closures

### DIFF
--- a/src/ch13-01-closures.md
+++ b/src/ch13-01-closures.md
@@ -31,7 +31,7 @@ enum called `ShirtColor` that has the variants `Red` and `Blue` (limiting the
 number of colors available for simplicity). We represent the company’s
 inventory with an `Inventory` struct that has a field named `shirts` that
 contains a `Vec<ShirtColor>` representing the shirt colors currently in stock.
-The method `shirt_giveaway` defined on `Inventory` gets the optional shirt
+The method `giveaway` defined on `Inventory` gets the optional shirt
 color preference of the free shirt winner, and returns the shirt color the
 person will get. This setup is shown in Listing 13-1:
 


### PR DESCRIPTION
A method name in one of the paragraphs was wrong as `shirt_giveaway`