### PR TITLE
Grammar: corrected 'as much' to 'as such'

### DIFF
--- a/src/ch15-00-smart-pointers.md
+++ b/src/ch15-00-smart-pointers.md
@@ -21,7 +21,7 @@ Rust, with its concept of ownership and borrowing, has an additional difference
 between references and smart pointers: while references only borrow data, in
 many cases, smart pointers *own* the data they point to.
 
-Though we didn't call them as much at the time, we’ve already encountered a few
+Though we didn't call them as such at the time, we’ve already encountered a few
 smart pointers in this book, including `String` and `Vec<T>` in Chapter 8. Both
 these types count as smart pointers because they own some memory and allow you
 to manipulate it. They also have metadata and extra capabilities or guarantees.


### PR DESCRIPTION
The context suggests that this sentence is meant to clarify that a detail was left out prior; i.e. "We did not call `String` by this name", as opposed to "We did not call `String` as frequently".