### PR TITLE
Fix incorrect link for listing 13-06

### DIFF
--- a/src/ch13-01-closures.md
+++ b/src/ch13-01-closures.md
@@ -241,7 +241,7 @@ to print the vector in a new thread rather than in the main thread:
 <span class="filename">Filename: src/main.rs</span>
 
 ```rust
-{{#rustdoc_include ../listings/ch13-functional-features/listing-13-05/src/main.rs}}
+{{#rustdoc_include ../listings/ch13-functional-features/listing-13-06/src/main.rs}}
 ```
 
 <span class="caption">Listing 13-6: Using `move` to force the closure for the


### PR DESCRIPTION
Due to a wrong link currently listing 13-05 is shown again instead of 13-06. This PR fixes that.