### PR TITLE
Update lib.rs of listing-12-19

### DIFF
--- a/listings/ch12-an-io-project/listing-12-19/src/lib.rs
+++ b/listings/ch12-an-io-project/listing-12-19/src/lib.rs
@@ -47,7 +47,7 @@ mod tests {
 
     #[test]
     fn one_result() {
-        let query = "duct";
+        let query = "safe";
         let contents = "\
 Rust:
 safe, fast, productive.


### PR DESCRIPTION
In line 50, the query variable was assigned to a string slice of value "duct".
The test of this listing was intedend to pass, but no line of the content variable included the the string slice "duct", so I updated it to "safe" in order for the search function to return `vec!["safe, fast, productive."]` which passes the test.

Aside:
Thank you so much, I love this book.