### PR TITLE
Fix small typo in chapter 6.2.

### DIFF
--- a/src/ch06-02-match.md
+++ b/src/ch06-02-match.md
@@ -139,7 +139,7 @@ next arm.
 {{#rustdoc_include ../listings/ch06-enums-and-pattern-matching/listing-06-05/src/main.rs:second_arm}}
 ```
 
-Does `Some(5)` match `Some(i)`? Why yes it does! We have the same variant. The
+Does `Some(5)` match `Some(i)`? Well, yes, it does! We have the same variant. The
 `i` binds to the value contained in `Some`, so `i` takes the value `5`. The
 code in the match arm is then executed, so we add 1 to the value of `i` and
 create a new `Some` value with our total `6` inside.


### PR DESCRIPTION
I think it's supposed to mean "Well, yes, it does!" instead of "Why yes it does!". Alternatively, one could simply write "Yes it does!".