### PR TITLE
Edit on line no. 153. Replaced fn add_to_waitlist with fn eat_at_restaurant. 

### DIFF
--- a/src/ch07-03-paths-for-referring-to-an-item-in-the-module-tree.md
+++ b/src/ch07-03-paths-for-referring-to-an-item-in-the-module-tree.md
@@ -150,7 +150,7 @@ and `fn add_to_waitlist` lets us call the function from
 `eat_at_restaurant`</span>
 
 Now the code will compile! To see why adding the `pub` keyword lets us use
-these paths in `add_to_waitlist` with respect to the privacy rules, let’s look
+these paths in `eat_at_restaurant` with respect to the privacy rules, let’s look
 at the absolute and the relative paths.
 
 In the absolute path, we start with `crate`, the root of our crate’s module


### PR DESCRIPTION
### Chapter 7.3 - Paths for referring to an item in the module-tree
The adding of pub keyword to mod hosting and fn add_to_waitlist enables us to use the absolute and relative paths in the "**_fn eat_at_restaurant_**" instead of **_fn add_to_waitlist_** according to the code specified in listing 7-7.