### PR TITLE
ch11-03: Unnecessary import removal

### DIFF
--- a/listings/ch11-writing-automated-tests/listing-11-13/tests/integration_test.rs
+++ b/listings/ch11-writing-automated-tests/listing-11-13/tests/integration_test.rs
@@ -1,5 +1,3 @@
-use adder;
-
 #[test]
 fn it_adds_two() {
     assert_eq!(4, adder::add_two(2));

--- a/listings/ch11-writing-automated-tests/listing-11-13/tests/integration_test.rs
+++ b/listings/ch11-writing-automated-tests/listing-11-13/tests/integration_test.rs
@@ -1,4 +1,6 @@
+use adder::add_two;
+
 #[test]
 fn it_adds_two() {
-    assert_eq!(4, adder::add_two(2));
+    assert_eq!(4, add_two(2));
 }

--- a/src/ch11-03-test-organization.md
+++ b/src/ch11-03-test-organization.md
@@ -117,6 +117,11 @@ Enter the code in Listing 11-13 into the *tests/integration_test.rs* file:
 <span class="caption">Listing 11-13: An integration test of a function in the
 `adder` crate</span>
 
+Each file in the `tests` directory is a separate crate, so we need to bring our
+library into each test crate’s scope. For that reason we add `use
+adder::add_two` at the top of the code, which we didn’t need in the unit
+tests.
+
 We don’t need to annotate any code in *tests/integration_test.rs* with
 `#[cfg(test)]`. Cargo treats the `tests` directory specially and compiles files
 in this directory only when we run `cargo test`. Run `cargo test` now:

--- a/src/ch11-03-test-organization.md
+++ b/src/ch11-03-test-organization.md
@@ -117,10 +117,6 @@ Enter the code in Listing 11-13 into the *tests/integration_test.rs* file:
 <span class="caption">Listing 11-13: An integration test of a function in the
 `adder` crate</span>
 
-Each file in the `tests` directory is a separate crate, so we need to bring our
-library into each test crate’s scope. For that reason we add `use adder` at the
-top of the code, which we didn’t need in the unit tests.
-
 We don’t need to annotate any code in *tests/integration_test.rs* with
 `#[cfg(test)]`. Cargo treats the `tests` directory specially and compiles files
 in this directory only when we run `cargo test`. Run `cargo test` now:


### PR DESCRIPTION
Qualified call to `add_two`  is sufficient. There is no need to import `adder` with `use adder;`.