### PR TITLE
ch12-03: `expect` is not used multitude times by this chapter

### DIFF
--- a/src/ch12-03-improving-error-handling-and-modularity.md
+++ b/src/ch12-03-improving-error-handling-and-modularity.md
@@ -23,13 +23,13 @@ example, the file could be missing, or we might not have permission to open it.
 Right now, regardless of the situation, we’d print the same error message for
 everything, which wouldn’t give the user any information!
 
-Fourth, we use `expect` repeatedly to handle different errors, and if the user
-runs our program without specifying enough arguments, they’ll get an `index out
-of bounds` error from Rust that doesn’t clearly explain the problem. It would
-be best if all the error-handling code were in one place so future maintainers
-had only one place to consult the code if the error-handling logic needed to
-change. Having all the error-handling code in one place will also ensure that
-we’re printing messages that will be meaningful to our end users.
+Fourth, if the user runs our program without specifying enough arguments, 
+they’ll get an `index out of bounds` error from Rust that doesn’t clearly 
+explain the problem. It would be best if all the error-handling code were
+in one place so future maintainers had only one place to consult the code
+if the error-handling logic needed to change. Having all the error-handling
+code in one place will also ensure that we’re printing messages that
+will be meaningful to our end users.
 
 Let’s address these four problems by refactoring our project.
 

--- a/src/ch12-03-improving-error-handling-and-modularity.md
+++ b/src/ch12-03-improving-error-handling-and-modularity.md
@@ -23,13 +23,13 @@ example, the file could be missing, or we might not have permission to open it.
 Right now, regardless of the situation, we’d print the same error message for
 everything, which wouldn’t give the user any information!
 
-Fourth, if the user runs our program without specifying enough arguments, 
-they’ll get an `index out of bounds` error from Rust that doesn’t clearly 
-explain the problem. It would be best if all the error-handling code were
-in one place so future maintainers had only one place to consult the code
-if the error-handling logic needed to change. Having all the error-handling
-code in one place will also ensure that we’re printing messages that
-will be meaningful to our end users.
+Fourth, we use `expect` to handle an error, and if the user runs our program
+without specifying enough arguments, they’ll get an `index out of bounds` error
+from Rust that doesn’t clearly explain the problem. It would be best if all the
+error-handling code were in one place so future maintainers had only one place
+to consult the code if the error-handling logic needed to change. Having all the
+error-handling code in one place will also ensure that we’re printing messages
+that will be meaningful to our end users.
 
 Let’s address these four problems by refactoring our project.
 


### PR DESCRIPTION
Closes https://github.com/rust-lang/book/issues/3343

By chapter 12.3 related code has visual like 

```rust
use std::env;
use std::fs;

fn main() {
    let args: Vec<String> = env::args().collect();
    
    let query = &args[1];
    let filename = &args[2];
    
    println!("Searching for {}", query);
    println!("In file {}", filename);
    
    let contents = fs::read_to_string(filename)
      .expect("Something went wrong reading the file");
      
    println!("With text:\n{}", contents);      
}
```

There is just 1 occurence of `expect`.

## Diff
Use [_rich diff_](https://github.com/rust-lang/book/commit/15616bc09bd7ab6e785680a364364e962c57bb21?diff=unified&short_path=6f933e7#diff-6f933e7ee55bc76cd5db57513e37d62c2f9dadcc1bcb9687fba4531de61d7415) for readable diff.