### PR TITLE
Improve awkward phrasing around the kinds of closures

### DIFF
--- a/src/ch13-01-closures.md
+++ b/src/ch13-01-closures.md
@@ -329,13 +329,13 @@ Using `FnOnce` in the trait bound expresses the constraint that
 `unwrap_or_else` is only going to call `f` at most one time. In the body of
 `unwrap_or_else`, we can see that if the `Option` is `Some`, `f` won’t be
 called. If the `Option` is `None`, `f` will be called once. Because all
-closures implement `FnOnce`, `unwrap_or_else` accepts all closures and is as
-flexible as it can be.
+closures implement `FnOnce`, `unwrap_or_else` accepts all three kinds of
+closures and is as flexible as it can be.
 
 > Note: Functions can implement all three of the `Fn` traits too. If what we
 > want to do doesn’t require capturing a value from the environment, we can use
 > the name of a function rather than a closure where we need something that
-> implements one of the `Fn` traits. For example, on an `Option<Vec<T>>` value
+> implements one of the `Fn` traits. For example, on an `Option<Vec<T>>` value,
 > we could call `unwrap_or_else(Vec::new)` to get a new, empty vector if the
 > value is `None`.
 

--- a/src/ch13-01-closures.md
+++ b/src/ch13-01-closures.md
@@ -329,13 +329,13 @@ Using `FnOnce` in the trait bound expresses the constraint that
 `unwrap_or_else` is only going to call `f` at most one time. In the body of
 `unwrap_or_else`, we can see that if the `Option` is `Some`, `f` won’t be
 called. If the `Option` is `None`, `f` will be called once. Because all
-closures implement `FnOnce`, `unwrap_or_else` accepts the most different kinds
-of closures and is as flexible as it can be.
+closures implement `FnOnce`, `unwrap_or_else` accepts all closures and is as
+flexible as it can be.
 
 > Note: Functions can implement all three of the `Fn` traits too. If what we
 > want to do doesn’t require capturing a value from the environment, we can use
 > the name of a function rather than a closure where we need something that
-> implements one of the `Fn` traits. For example, on an `Option<Vec<T>>` value,
+> implements one of the `Fn` traits. For example, on an `Option<Vec<T>>` value
 > we could call `unwrap_or_else(Vec::new)` to get a new, empty vector if the
 > value is `None`.
 


### PR DESCRIPTION
I was confused about the meaning of the sentence when I read "accepts the most different kinds of closures".

I believe this wording to be clearer. An unnecessary comma is also removed.