### PR TITLE
Add link to experimental Rust Book

### DIFF
--- a/src/title-page.md
+++ b/src/title-page.md
@@ -20,3 +20,5 @@ Press][nsprust].
 [editions]: appendix-05-editions.html
 [nsprust]: https://nostarch.com/rust
 [translations]: appendix-06-translation.html
+
+**🚨 NEW: Want a more interactive learning experience? Try out a new version of the Rust Book, featuring: quizzes, highlighting, visualizations, and more**: <https://rust-book.cs.brown.edu>


### PR DESCRIPTION
This PR adds a link in the title page to the experimental Rust Book at https://rust-book.cs.brown.edu/.

For those I haven't talked to: my postdoctoral research with [Shriram Krishnamurthi](https://cs.brown.edu/~sk/) is about making Rust easier to learn. As a part of this research, we are going to analyze and (hopefully) improve the content of the Rust Book. In the first phase of this experiment, we have added interactive quizzes to each section of the Book. Our goal is to use the quizzes to identify sections where readers are struggling and make targeted improvements.

Adding this link to the main Rust Book will help provide exposure for the experiment, hopefully increasing the number of participants.

cc @carols10cents 