### PR TITLE
Missing period at end of sentence Ch 09-02

### DIFF
--- a/src/ch09-02-recoverable-errors-with-result.md
+++ b/src/ch09-02-recoverable-errors-with-result.md
@@ -524,7 +524,7 @@ returns integers from executables to be compatible with this convention.
 
 The `main` function may return any types that implement [the
 `std::process::Termination` trait][termination]<!-- ignore -->, which contains
-a function `report` that returns an `ExitCode` Consult the standard library
+a function `report` that returns an `ExitCode`. Consult the standard library
 documentation for more information on implementing the `Termination` trait for
 your own types.
 


### PR DESCRIPTION
Add a period at the end of the sentence in line 527 to make it grammatically correct.