### PR TITLE
Fixed incorrect mutex lock usage

### DIFF
--- a/listings/ch20-web-server/listing-20-24/src/lib.rs
+++ b/listings/ch20-web-server/listing-20-24/src/lib.rs
@@ -70,7 +70,9 @@ struct Worker {
 impl Worker {
     fn new(id: usize, receiver: Arc<Mutex<mpsc::Receiver<Job>>>) -> Worker {
         let thread = thread::spawn(move || loop {
-            match receiver.lock().unwrap().recv() {
+            let message = receiver.lock().unwrap().recv();
+
+            match message {
                 Ok(job) => {
                     println!("Worker {id} got a job; executing.");
 


### PR DESCRIPTION
Mutex lock spans through job execution, should be in a let statement as in the subsequent full code listing https://github.com/rust-lang/book/blob/main/listings/ch20-web-server/no-listing-07-final-code/src/lib.rs#L72-L74.