### PR TITLE
Fix Listing 20-24

### DIFF
--- a/listings/ch20-web-server/listing-20-24/src/lib.rs
+++ b/listings/ch20-web-server/listing-20-24/src/lib.rs
@@ -70,7 +70,9 @@ struct Worker {
 impl Worker {
     fn new(id: usize, receiver: Arc<Mutex<mpsc::Receiver<Job>>>) -> Worker {
         let thread = thread::spawn(move || loop {
-            match receiver.lock().unwrap().recv() {
+            let message = receiver.lock().unwrap().recv();
+
+            match message {
                 Ok(job) => {
                     println!("Worker {id} got a job; executing.");
 


### PR DESCRIPTION
Listing 20-24 in Chapter 20-03 "Graceful Shutdown and Cleanup" currently uses a  `match` expression to acquire and release the receiver lock, causing the lock to be held longer than expected.

This PR fixes the listing to ensure the lock is released as soon as possible
