### PR TITLE
try to change `Quarter` with `Nickel` to avoid the confusing

### DIFF
--- a/listings/ch06-enums-and-pattern-matching/listing-06-03/src/main.rs
+++ b/listings/ch06-enums-and-pattern-matching/listing-06-03/src/main.rs
@@ -1,9 +1,9 @@
 // ANCHOR: here
 enum Coin {
     Penny,
-    Nickel,
-    Dime,
     Quarter,
+    Dime,
+    Nickel,
 }
 
 fn value_in_cents(coin: Coin) -> u8 {

--- a/listings/ch06-enums-and-pattern-matching/listing-06-04/src/main.rs
+++ b/listings/ch06-enums-and-pattern-matching/listing-06-04/src/main.rs
@@ -8,9 +8,9 @@ enum UsState {
 
 enum Coin {
     Penny,
-    Nickel,
+    Quarter,
     Dime,
-    Quarter(UsState),
+    Nickel(UsState),
 }
 // ANCHOR_END: here
 

--- a/listings/ch06-enums-and-pattern-matching/no-listing-08-match-arm-multiple-lines/src/main.rs
+++ b/listings/ch06-enums-and-pattern-matching/no-listing-08-match-arm-multiple-lines/src/main.rs
@@ -1,8 +1,8 @@
 enum Coin {
     Penny,
-    Nickel,
-    Dime,
     Quarter,
+    Dime,
+    Nickel,
 }
 
 // ANCHOR: here

--- a/listings/ch06-enums-and-pattern-matching/no-listing-09-variable-in-pattern/src/main.rs
+++ b/listings/ch06-enums-and-pattern-matching/no-listing-09-variable-in-pattern/src/main.rs
@@ -7,18 +7,18 @@ enum UsState {
 
 enum Coin {
     Penny,
-    Nickel,
+    Quarter,
     Dime,
-    Quarter(UsState),
+    Nickel(UsState),
 }
 
 // ANCHOR: here
 fn value_in_cents(coin: Coin) -> u8 {
     match coin {
         Coin::Penny => 1,
-        Coin::Nickel => 5,
+        Coin::Quarter => 5,
         Coin::Dime => 10,
-        Coin::Quarter(state) => {
+        Coin::Nickel(state) => {
             println!("State quarter from {:?}!", state);
             25
         }
@@ -27,5 +27,5 @@ fn value_in_cents(coin: Coin) -> u8 {
 // ANCHOR_END: here
 
 fn main() {
-    value_in_cents(Coin::Quarter(UsState::Alaska));
+    value_in_cents(Coin::Nickel(UsState::Alaska));
 }

--- a/src/ch06-02-match.md
+++ b/src/ch06-02-match.md
@@ -67,17 +67,17 @@ values that match the pattern. This is how we can extract values out of enum
 variants.
 
 As an example, let’s change one of our enum variants to hold data inside it.
-From 1999 through 2008, the United States minted quarters with different
+From 1999 through 2008, the United States minted nickels with different
 designs for each of the 50 states on one side. No other coins got state
-designs, so only quarters have this extra value. We can add this information to
-our `enum` by changing the `Quarter` variant to include a `UsState` value stored
+designs, so only nickels have this extra value. We can add this information to
+our `enum` by changing the `Nickel` variant to include a `UsState` value stored
 inside it, which we’ve done here in Listing 6-4.
 
 ```rust
 {{#rustdoc_include ../listings/ch06-enums-and-pattern-matching/listing-06-04/src/main.rs:here}}
 ```
 
-<span class="caption">Listing 6-4: A `Coin` enum in which the `Quarter` variant
+<span class="caption">Listing 6-4: A `Coin` enum in which the `Nickel` variant
 also holds a `UsState` value</span>
 
 Let’s imagine that a friend is trying to collect all 50 state quarters. While
@@ -86,20 +86,20 @@ state associated with each quarter so if it’s one our friend doesn’t have, t
 can add it to their collection.
 
 In the match expression for this code, we add a variable called `state` to the
-pattern that matches values of the variant `Coin::Quarter`. When a
-`Coin::Quarter` matches, the `state` variable will bind to the value of that
+pattern that matches values of the variant `Coin::Nickel`. When a
+`Coin::Nickel` matches, the `state` variable will bind to the value of that
 quarter’s state. Then we can use `state` in the code for that arm, like so:
 
 ```rust
 {{#rustdoc_include ../listings/ch06-enums-and-pattern-matching/no-listing-09-variable-in-pattern/src/main.rs:here}}
 ```
 
-If we were to call `value_in_cents(Coin::Quarter(UsState::Alaska))`, `coin`
-would be `Coin::Quarter(UsState::Alaska)`. When we compare that value with each
-of the match arms, none of them match until we reach `Coin::Quarter(state)`. At
+If we were to call `value_in_cents(Coin::Nickel(UsState::Alaska))`, `coin`
+would be `Coin::Nickel(UsState::Alaska)`. When we compare that value with each
+of the match arms, none of them match until we reach `Coin::Nickel(state)`. At
 that point, the binding for `state` will be the value `UsState::Alaska`. We can
 then use that binding in the `println!` expression, thus getting the inner
-state value out of the `Coin` enum variant for `Quarter`.
+state value out of the `Coin` enum variant for `Nickel`.
 
 ### Matching with `Option<T>`
 


### PR DESCRIPTION
I'm not an English man. some times, I use traduction to get the meaning of a sentence, 
for example, this sentence [here](https://doc.rust-lang.org/book/ch06-02-match.html),

> As an example, let’s change one of our enum variants to hold data inside it. From 1999 through 2008, the United States minted quarters with different designs for each of the 50 states on one side. No other coins got state designs, so only quarters have this extra value. We can add this information to our enum by changing the Quarter variant to include a UsState value stored inside it, which we’ve done here in Listing 6-4.

the keyword `quarters`, when I translated I get `4` or `neighborhoods`, it's not mean , thy kynd of metal
