### PR TITLE
Iterator definition wording (minor chage)

### DIFF
--- a/src/ch13-02-iterators.md
+++ b/src/ch13-02-iterators.md
@@ -63,7 +63,7 @@ pub trait Iterator {
 Notice this definition uses some new syntax: `type Item` and `Self::Item`,
 which are defining an *associated type* with this trait. We’ll talk about
 associated types in depth in Chapter 19. For now, all you need to know is that
-this code says implementing the `Iterator` trait requires that you also define
+this code says implementing the `Iterator` trait requires that you also specify
 an `Item` type, and this `Item` type is used in the return type of the `next`
 method. In other words, the `Item` type will be the type returned from the
 iterator.


### PR DESCRIPTION
In iterators, it is more precise to say that we need to _specify_ an
`Item` type rather than to _define_ it. It can be already defined
elsewhere but _specify_ also includes the posibility of defining it.
