### PR TITLE
Fix wrong println!-syntax

### DIFF
--- a/listings/ch12-an-io-project/listing-12-04/src/main.rs
+++ b/listings/ch12-an-io-project/listing-12-04/src/main.rs
@@ -17,6 +17,6 @@ fn main() {
     let contents = fs::read_to_string(file_path)
         .expect("Should have been able to read the file");
 
-    println!("With text:\n{contents}");
+    println!("With text:\n{}", contents);
 }
 // ANCHOR_END: here


### PR DESCRIPTION
The old version throws an error: there is no argument named `contents`

Note that I am a very early beginner in rust.
Therefore I am especially grateful for people doublechecking my contribution and giving feedback.