### PR TITLE
Add a missing line generated by 'cargo new'

### DIFF
--- a/src/ch01-03-hello-cargo.md
+++ b/src/ch01-03-hello-cargo.md
@@ -66,6 +66,8 @@ name = "hello_cargo"
 version = "0.1.0"
 edition = "2021"
 
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
 [dependencies]
 ```
 


### PR DESCRIPTION
When running `cargo new hello_cargo` in the command line, one of the lines automatically generated in the Cargo.toml file of the `hello_cargo` project is a comment regarding more keys and their definitions. This comment is currently missing in the book chapter, and it probably should be added there.