### PR TITLE
`Box<T>` instead of "box"

### DIFF
--- a/src/ch15-02-deref.md
+++ b/src/ch15-02-deref.md
@@ -73,11 +73,11 @@ Listing 15-6:
 `Box<i32>`</span>
 
 The main difference between Listing 15-7 and Listing 15-6 is that here we set
-`y` to be an instance of a box pointing to a copied value of `x` rather than a
+`y` to be an instance of a `Box<T>` pointing to a copied value of `x` rather than a
 reference pointing to the value of `x`. In the last assertion, we can use the
-dereference operator to follow the box’s pointer in the same way that we did
+dereference operator to follow the `Box<T>`’s pointer in the same way that we did
 when `y` was a reference. Next, we’ll explore what is special about `Box<T>`
-that enables us to use the dereference operator by defining our own box type.
+that enables us to use the dereference operator by defining our own kind of box type.
 
 ### Defining Our Own Smart Pointer
 


### PR DESCRIPTION
Since no other _simple_ forms of `Box<T>` occurrences, I found this as bug.