### PR TITLE
"Actual number type" instead of "Real number type"

### DIFF
--- a/src/ch02-00-guessing-game-tutorial.md
+++ b/src/ch02-00-guessing-game-tutorial.md
@@ -641,8 +641,8 @@ an `i32`, which is the type of `secret_number` unless you add type information
 elsewhere that would cause Rust to infer a different numerical type. The reason
 for the error is that Rust cannot compare a string and a number type.
 
-Ultimately, we want to convert the `String` the program reads as input into a
-real number type so we can compare it numerically to the secret number. We do so
+Ultimately, we want to convert the `String` the program reads as input into an
+actual number type so we can compare it numerically to the secret number. We do so
 by adding this line to the `main` function body:
 
 <span class="filename">Filename: src/main.rs</span>


### PR DESCRIPTION
The example code converts the input into a whole number. Replace the text "convert the String the program reads as input into a real number type" to "an actual number type" as the word real might be understood as one of the number categories instead as a synonym to "actual".