### PR TITLE
Fix Typo for ch07-04

### DIFF
--- a/src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md
+++ b/src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md
@@ -71,7 +71,7 @@ into scope with `use`, which is unidiomatic</span>
 
 Although both Listing 7-11 and 7-13 accomplish the same task, Listing 7-11 is
 the idiomatic way to bring a function into scope with `use`. Bringing the
-function’s parent module into scope with `use` means we have to specify the
+function’s parent module into scope with `use` means we don't have to specify the
 parent module when calling the function. Specifying the parent module when
 calling the function makes it clear that the function isn’t locally defined
 while still minimizing repetition of the full path. The code in Listing 7-13 is


### PR DESCRIPTION
I think it's a typo. Bringing with `use` means we `don't` have to specify the parent.