### PR TITLE
ch15-06: None is for 1ˢᵗ time

### DIFF
--- a/src/ch15-06-reference-cycles.md
+++ b/src/ch15-06-reference-cycles.md
@@ -284,7 +284,7 @@ from `leaf.parent` has no bearing on whether or not `Node` is dropped, so we
 don’t get any memory leaks!
 
 If we try to access the parent of `leaf` after the end of the scope, we’ll get
-`None` again. At the end of the program, the `Rc<Node>` in `leaf` has a strong
+`None`. At the end of the program, the `Rc<Node>` in `leaf` has a strong
 count of 1 and a weak count of 0, because the variable `leaf` is now the only
 reference to the `Rc<Node>` again.
 


### PR DESCRIPTION
Listing _15-29_ has only 1 `println!("leaf parent = {:?}", leaf.parent.borrow().upgrade());`. Thus `None` option shows in output just once by end — `leaf parent = None`  — not “again”.

```console
leaf strong = 1, weak = 0
branch strong = 1, weak = 1
leaf strong = 2, weak = 0
leaf parent = None
leaf strong = 1, weak = 0
```