### PR TITLE
Extend the documentation and clarify some things for beginners

### DIFF
--- a/src/ch08-01-vectors.md
+++ b/src/ch08-01-vectors.md
@@ -58,6 +58,12 @@ as shown in Listing 8-3.
 <span class="caption">Listing 8-3: Using the `push` method to add values to a
 vector</span>
 
+If you expand the `vec!` macro, you'll find that it essentially performs
+the same operations shown above. It creates a new vector using the `Vec::new`
+method and adds the listed values using the `push` method. This functionality
+is further explained in the ["Macros"][macros]<!-- ignore --> section of
+Chapter 19.
+
 As with any variable, if we want to be able to change its value, we need to
 make it mutable using the `mut` keyword, as discussed in Chapter 3. The numbers
 we place inside are all of type `i32`, and Rust infers this from the data, so
@@ -243,7 +249,7 @@ are dropped</span>
 When the vector gets dropped, all of its contents are also dropped, meaning the
 integers it holds will be cleaned up. The borrow checker ensures that any
 references to contents of a vector are only used while the vector itself is
-valid.
+valid. 
 
 Let’s move on to the next collection type: `String`!
 
@@ -251,3 +257,4 @@ Let’s move on to the next collection type: `String`!
 [nomicon]: ../nomicon/vec/vec.html
 [vec-api]: ../std/vec/struct.Vec.html
 [deref]: ch15-02-deref.html#following-the-pointer-to-the-value-with-the-dereference-operator
+[macros]: ch19-06-macros.html#declarative-macros-with-macro_rules-for-general-metaprogramming

--- a/src/ch08-01-vectors.md
+++ b/src/ch08-01-vectors.md
@@ -249,7 +249,7 @@ are dropped</span>
 When the vector gets dropped, all of its contents are also dropped, meaning the
 integers it holds will be cleaned up. The borrow checker ensures that any
 references to contents of a vector are only used while the vector itself is
-valid. 
+valid.
 
 Let’s move on to the next collection type: `String`!
 

--- a/src/ch08-03-hash-maps.md
+++ b/src/ch08-03-hash-maps.md
@@ -75,11 +75,11 @@ Yellow: 50
 Blue: 10
 ```
 
-In the above code, you can see that when iterating over a hashmap, the
+In the above code, you can see that when iterating over a hash map, the
 (key, value) pairs are returned as a tuple. You can then use pattern matching
 to destructure the tuple and get the individual key, value variables. Their
 types are automatically inferred by the compiler depending on the types stored
-in the hashmap.
+in the hash map.
 
 ### Hash Maps and Ownership
 

--- a/src/ch08-03-hash-maps.md
+++ b/src/ch08-03-hash-maps.md
@@ -75,6 +75,12 @@ Yellow: 50
 Blue: 10
 ```
 
+In the above code, you can see that when iterating over a hashmap, the
+(key, value) pairs are returned as a tuple. You can then use pattern matching
+to destructure the tuple and get the individual key, value variables. Their
+types are automatically inferred by the compiler depending on the types stored
+in the hashmap.
+
 ### Hash Maps and Ownership
 
 For types that implement the `Copy` trait, like `i32`, the values are copied

--- a/src/ch10-02-traits.md
+++ b/src/ch10-02-traits.md
@@ -290,6 +290,9 @@ This function’s signature is less cluttered: the function name, parameter list
 and return type are close together, similar to a function without lots of trait
 bounds.
 
+The functionality is the same as the example using the `impl +` syntax, but it
+is easier to read.
+
 ### Returning Types that Implement Traits
 
 We can also use the `impl Trait` syntax in the return position to return a

--- a/src/ch14-05-extending-cargo.md
+++ b/src/ch14-05-extending-cargo.md
@@ -3,9 +3,11 @@
 Cargo is designed so you can extend it with new subcommands without having to
 modify Cargo. If a binary in your `$PATH` is named `cargo-something`, you can
 run it as if it was a Cargo subcommand by running `cargo something`. Custom
-commands like this are also listed when you run `cargo --list`. Being able to
-use `cargo install` to install extensions and then run them just like the
-built-in Cargo tools is a super convenient benefit of Cargo’s design!
+commands like this are also listed when you run `cargo --list`. This can allow
+you to write programs that enable users to run them through Cargo just like
+`cargo run` or `cargo build`. Being able to use `cargo install` to install
+extensions and then run them just like the built-in Cargo tools is a super
+convenient benefit of Cargo’s design!
 
 ## Summary
 

--- a/src/ch19-01-unsafe-rust.md
+++ b/src/ch19-01-unsafe-rust.md
@@ -15,7 +15,7 @@ doing.” Be warned, however, that you use unsafe Rust at your own risk: if you
 use unsafe code incorrectly, problems can occur due to memory unsafety, such as
 null pointer dereferencing.
 
-Because many other languages are inherently usafe, using Rust to call their
+Because many other languages are inherently unsafe, using Rust to call their
 code and functions can break the runtime safety that Rust guarantees. For
 example, if you were to use an external C library like the Windows API, you
 would need to tell Rust that all the functions from that library are unsafe.

--- a/src/ch19-01-unsafe-rust.md
+++ b/src/ch19-01-unsafe-rust.md
@@ -15,6 +15,14 @@ doing.” Be warned, however, that you use unsafe Rust at your own risk: if you
 use unsafe code incorrectly, problems can occur due to memory unsafety, such as
 null pointer dereferencing.
 
+Because many other languages are inherently usafe, using Rust to call their
+code and functions can break the runtime safety that Rust guarantees. For
+example, if you were to use an external C library like the Windows API, you
+would need to tell Rust that all the functions from that library are unsafe.
+Because calling external code and libraries is a very common thing to do in
+systems programming, Rust allows you to step outside of its rules and do things
+that were otherwise not possible with safe code.
+
 Another reason Rust has an unsafe alter ego is that the underlying computer
 hardware is inherently unsafe. If Rust didn’t let you do unsafe operations, you
 couldn’t do certain tasks. Rust needs to allow you to do low-level systems
@@ -320,7 +328,11 @@ Within the `extern "C"` block, we list the names and signatures of external
 functions from another language we want to call. The `"C"` part defines which
 *application binary interface (ABI)* the external function uses: the ABI
 defines how to call the function at the assembly level. The `"C"` ABI is the
-most common and follows the C programming language’s ABI.
+most common and follows the C programming language’s ABI. This can allow you to
+call functions and libraries that have not yet been written in Rust. For
+example, most operating system APIs are written in C. Using the `extern "C"`
+block allows you to call the API functions and interact with your operating
+system.
 
 > #### Calling Rust Functions from Other Languages
 >


### PR DESCRIPTION
I added some new information and clarifications for beginners. The documentation I added were things that I did not realize or know when first reading the book and things that I learned later after much confusion. I added these to hopefully help those new to Rust in order to not have them misunderstand the same things I did at first.

- _vector_: I mentioned how the `vec!` macro works as this was very confusing to me at first
- _hash maps_: I explained that when iterating over a hash map, the resulting values are tuples of (key, value)
- _traits_: I explained that using the function `impl trait` syntax is functionally the same as a generic `where` clause
- _cargo_: I explained how cargo extension binary crates can be used
- _unsafe_: I gave another example of when the `unsafe` keyword is used in relation to calling external code like C libraries and OS APIs, as this was not explicitly stated and is a very common way to use unsafe code in Rust

