### PR TITLE
Ownership "`move`" chapter link fix

### DIFF
--- a/src/ch16-01-threads.md
+++ b/src/ch16-01-threads.md
@@ -173,7 +173,7 @@ threads run at the same time.
 We'll often use the `move` keyword with closures passed to `thread::spawn`
 because the closure will then take ownership of the values it uses from the
 environment, thus transferring ownership of those values from one thread to
-another. In the [“Capturing the Environment with Closures”][capture]<!-- ignore
+another. In the [“Capturing References or Moving Ownership”][capture]<!-- ignore
 --> section of Chapter 13, we discussed `move` in the context of closures. Now,
 we’ll concentrate more on the interaction between `move` and `thread::spawn`.
 
@@ -278,4 +278,4 @@ ownership rules.
 With a basic understanding of threads and the thread API, let’s look at what we
 can *do* with threads.
 
-[capture]: ch13-01-closures.html#capturing-the-environment-with-closures
+[capture]: ch13-01-closures.html#capturing-references-or-moving-ownership


### PR DESCRIPTION
Ownership move into closure is discussed in [_Capturing References or Moving Ownership_](https://doc.rust-lang.org/book/ch13-01-closures.html#capturing-references-or-moving-ownership) section in part

> If you want to force the closure to take ownership of the values it uses in the environment even though the body of the closure doesn’t strictly need ownership, you can use the `move` keyword before the parameter list. This technique is mostly useful when passing a closure to a new thread to move the data so that it’s owned by the new thread. We’ll have more examples of move closures in Chapter 16 when we talk about concurrency.

---
❕ I made brief fix to this but while [content in book](https://doc.rust-lang.org/book/ch13-01-closures.html#capturing-references-or-moving-ownership) differs from [that in source file](https://github.com/rust-lang/book/blob/main/src/ch13-01-closures.md#capturing-references-or-moving-ownership), I expect some problems around.

![Book vs src](https://user-images.githubusercontent.com/26486200/189758571-c6512ad2-3cd2-412c-a66e-09058f939d3b.png)
