### PR TITLE
Change "Under the covers" to "Under the hood"

### DIFF
--- a/src/ch04-01-what-is-ownership.md
+++ b/src/ch04-01-what-is-ownership.md
@@ -260,7 +260,7 @@ same: that is, the second line would make a copy of the value in `s1` and bind
 it to `s2`. But this isn’t quite what happens.
 
 Take a look at Figure 4-1 to see what is happening to `String` under the
-covers. A `String` is made up of three parts, shown on the left: a pointer to
+hood. A `String` is made up of three parts, shown on the left: a pointer to
 the memory that holds the contents of the string, a length, and a capacity.
 This group of data is stored on the stack. On the right is the memory on the
 heap that holds the contents.


### PR DESCRIPTION
In chapter 4.1, the authors write: "Take a look at Figure 4-1 to see what is happening to String *under the covers.*"  Isn't the the common figure of speech "under the hood"?

"Under the hood"  is a reference to a car's bonnet (or hood), which conceals the complex inner workings of the engine. "Under the covers"  seems like a reference to something else. 