### PR TITLE
Clarified first slices paragraph

### DIFF
--- a/src/ch04-03-slices.md
+++ b/src/ch04-03-slices.md
@@ -1,7 +1,7 @@
 ## The Slice Type
 
 *Slices* are a kind of reference, which lets you access a contiguous sub-sequence
-of elements in a sequential [collection](book/src/ch08-00-common-collections.md).
+of elements in a sequential [collection](ch08-00-common-collections.md).
 Because slices are a kind of reference, they too can borrow access to memory, but
 not own it.
 

--- a/src/ch04-03-slices.md
+++ b/src/ch04-03-slices.md
@@ -1,8 +1,9 @@
 ## The Slice Type
 
-*Slices* let you reference a contiguous sequence of elements in a collection
-rather than the whole collection. A slice is a kind of reference, so it does
-not have ownership.
+*Slices* are a kind of reference, which lets you access a contiguous sub-sequence
+of elements in a sequential [collection](book/src/ch08-00-common-collections.md).
+Because slices are a kind of reference, they too can borrow access to memory, but
+not own it.
 
 Here’s a small programming problem: write a function that takes a string of
 words separated by spaces and returns the first word it finds in that string.

--- a/src/ch04-03-slices.md
+++ b/src/ch04-03-slices.md
@@ -1,9 +1,8 @@
 ## The Slice Type
 
-*Slices* are a kind of reference, which lets you access a contiguous sub-sequence
-of elements in a sequential [collection](ch08-00-common-collections.md).
-Because slices are a kind of reference, they too can borrow access to memory, but
-not own it.
+*Slices* let you reference a contiguous sequence of elements in a
+[collection](ch08-00-common-collections.md) rather than the whole collection. A
+slice is a kind of reference, so it does not have ownership.
 
 Here’s a small programming problem: write a function that takes a string of
 words separated by spaces and returns the first word it finds in that string.


### PR DESCRIPTION
Noticed the slice definition in the first paragraph relies on the reader recalling:
* what collections are
* that the previous page ended stating slices are a kind of reference

I think the first paragraph should be more clear to someone who lands on it and isn't reading the rest of the documentation ATM.