### PR TITLE
Improve wording to make a sentence more clear

### DIFF
--- a/src/ch20-02-multithreaded.md
+++ b/src/ch20-02-multithreaded.md
@@ -206,8 +206,8 @@ characteristics:
 ```
 
 We chose `usize` as the type of the `size` parameter, because we know that a
-negative number of threads doesn’t make any sense. We also know we’ll use this
-4 as the number of elements in a collection of threads, which is what the
+negative number of threads doesn’t make any sense. We also know we’ll use `size`
+as the number of elements in a collection of threads, which is what the
 `usize` type is for, as discussed in the [“Integer Types”][integer-types]<!--
 ignore --> section of Chapter 3.
 


### PR DESCRIPTION
"this 4" refers to a 4 mentioned in a previous paragraph. Changing the wording to mention the `size` parameter, instead of "this 4" makes it clear what this paragraph is referring to, especially given the code block between this paragraph and the previous one.