### PR TITLE
Update formatting explanation to syntax used

### DIFF
--- a/src/ch02-00-guessing-game-tutorial.md
+++ b/src/ch02-00-guessing-game-tutorial.md
@@ -271,18 +271,17 @@ the code so far:
 {{#rustdoc_include ../listings/ch02-guessing-game-tutorial/listing-02-01/src/main.rs:print_guess}}
 ```
 
-This line prints the string that now contains the user’s input. The `{}` set of
-curly brackets is a placeholder: think of `{}` as little crab pincers that hold
-a value in place. You can print more than one value using curly brackets: the
-first set of curly brackets holds the first value listed after the format
-string, the second set holds the second value, and so on. Printing multiple
-values in one call to `println!` would look like this:
+This line prints the string that now contains the user’s input. `{guess}` 
+is a placeholder: think of `{...}` as little crab pincers that hold
+a value in place. The referenced value must exist in the current scope.
+You can print more than one value using curly brackets.
+Printing multiple values in one call to `println!` would look like this:
 
 ```rust
 let x = 5;
 let y = 10;
 
-println!("x = {} and y = {}", x, y);
+println!("x = {x} and y = {y}");
 ```
 
 This code would print `x = 5 and y = 10`.


### PR DESCRIPTION
The example uses named parameters from the current scope, the explanation still used positional ones.