### PR TITLE
Apply clippy::uninlined_format_args fix

### DIFF
--- a/tools/src/bin/convert_quotes.rs
+++ b/tools/src/bin/convert_quotes.rs
@@ -21,7 +21,7 @@ fn main() {
         if is_in_code_block {
             is_in_inline_code = false;
             is_in_html_tag = false;
-            println!("{}", line);
+            println!("{line}");
         } else {
             let modified_line = &mut String::new();
             let mut previous_char = std::char::REPLACEMENT_CHARACTER;
@@ -72,7 +72,7 @@ fn main() {
                 modified_line.push(char_to_push);
                 previous_char = char_to_push;
             }
-            println!("{}", modified_line);
+            println!("{modified_line}");
         }
     }
 }

--- a/tools/src/bin/lfp.rs
+++ b/tools/src/bin/lfp.rs
@@ -18,7 +18,7 @@ fn main() {
         .map(|entry| match entry {
             Ok(entry) => entry,
             Err(err) => {
-                eprintln!("{:?}", err);
+                eprintln!("{err:?}");
                 std::process::exit(911)
             }
         })

--- a/tools/src/bin/link2print.rs
+++ b/tools/src/bin/link2print.rs
@@ -19,7 +19,7 @@ fn read_md() -> String {
 }
 
 fn write_md(output: String) {
-    print!("{}", output);
+    print!("{output}");
 }
 
 fn parse_references(buffer: String) -> (String, HashMap<String, String>) {
@@ -81,7 +81,7 @@ fn parse_links((buffer, ref_map): (String, HashMap<String, String>)) -> String {
                         }
                     }
                 };
-                format!("{} at *{}*", name, val)
+                format!("{name} at *{val}*")
             }
         }
     });

--- a/tools/src/bin/release_listings.rs
+++ b/tools/src/bin/release_listings.rs
@@ -149,7 +149,7 @@ fn copy_cleaned_rust_file(
         if !ANCHOR_OR_SNIP_COMMENTS.is_match(&line)
             && (item_name != "lib.rs" || !EMPTY_MAIN.is_match(&line))
         {
-            writeln!(&mut to_buf, "{}", line)?;
+            writeln!(&mut to_buf, "{line}")?;
         }
     }
 

--- a/tools/src/bin/remove_hidden_lines.rs
+++ b/tools/src/bin/remove_hidden_lines.rs
@@ -14,7 +14,7 @@ fn read_md() -> String {
 }
 
 fn write_md(output: String) {
-    print!("{}", output);
+    print!("{output}");
 }
 
 fn remove_hidden_lines(input: &str) -> String {

--- a/tools/src/bin/remove_links.rs
+++ b/tools/src/bin/remove_links.rs
@@ -41,5 +41,5 @@ fn main() {
         caps.get(0).unwrap().as_str().to_string()
     });
 
-    print!("{}", out);
+    print!("{out}");
 }

--- a/tools/src/bin/remove_markup.rs
+++ b/tools/src/bin/remove_markup.rs
@@ -17,7 +17,7 @@ fn read_md() -> String {
 }
 
 fn write_md(output: String) {
-    print!("{}", output);
+    print!("{output}");
 }
 
 fn remove_markup(input: String) -> String {


### PR DESCRIPTION
This is the result of running `clippy::uninlined_format_args` lint. Currently the lint is in `pedantic`, but there are plans/hopes to move it to `style`.

How can I add this specific lint to the current build/CI tools, or is this not possible?  It would be ideal not to make the lint as the default style and then end up with hundreds of changes in an unrelated PR due to CI requirements.

Locally, I ran this to generate the changes.  Not ideal because it has produced a number of compilation errors.

```bash
rustup run nightly cargo clippy --fix --no-deps --allow-dirty -- -A clippy::all -W clippy::uninlined_format_args
```