### PR TITLE
correction: multithreaded, but not asynchronous

### DIFF
--- a/src/ch20-02-multithreaded.md
+++ b/src/ch20-02-multithreaded.md
@@ -647,7 +647,7 @@ Worker 0 got a job; executing.
 Worker 2 got a job; executing.
 ```
 
-Success! We now have a thread pool that executes connections asynchronously.
+Success! We now have a thread pool that executes connections by multithreading (but not [`asynchronously`][async-book]).
 There are never more than four threads created, so our system won’t get
 overloaded if the server receives a lot of requests. If we make a request to
 */sleep*, the server will be able to serve other requests by having another
@@ -696,3 +696,4 @@ ch19-04-advanced-types.html#creating-type-synonyms-with-type-aliases
 ch13-01-closures.html#moving-captured-values-out-of-the-closure-and-the-fn-traits
 [builder]: ../std/thread/struct.Builder.html
 [builder-spawn]: ../std/thread/struct.Builder.html#method.spawn
+[async-book]: https://rust-lang.github.io//01_getting_started/01_chapter.html


### PR DESCRIPTION
This is not asynchronous, since you haven't actually used the async/await syntax. You have multiple threads (thus multithreaded) but each thread doesn't encounter a `Future` with missing values that makes the thread go do something else while waiting for the value to become available. 

I'm not sure if I wrote this syntax correctly:
`[async-book]: https://rust-lang.github.io//01_getting_started/01_chapter.html`

Maybe there's a better way to write this link?