### PR TITLE
ch18-03: Guarded match arm exhaustivness clarification

### DIFF
--- a/src/ch18-03-pattern-syntax.md
+++ b/src/ch18-03-pattern-syntax.md
@@ -483,7 +483,7 @@ arms exhaustiveness anymore when match guard expressions are involved.
 ```rust
 match Some(100) {
     Some(_) if true => print!("Got Some"),
-    None => println!("Got None")
+    None => print!("Got None")
 }
 ```
 This `match` expression involves compilation error.

--- a/src/ch18-03-pattern-syntax.md
+++ b/src/ch18-03-pattern-syntax.md
@@ -480,7 +480,7 @@ the match guard gives us the ability to express this logic. The downside of
 this additional expressiveness is that the compiler is not smart enough about 
 arms exhaustiveness anymore when match guard expressions are involved.
 
-```rust
+```rust,ignore,does_not_compile
 match Some(100) {
     Some(_) if true => print!("Got Some"),
     None => print!("Got None")

--- a/src/ch18-03-pattern-syntax.md
+++ b/src/ch18-03-pattern-syntax.md
@@ -477,8 +477,27 @@ second arm doesn’t have a match guard and therefore matches any `Some` variant
 
 There is no way to express the `if x % 2 == 0` condition within a pattern, so
 the match guard gives us the ability to express this logic. The downside of
-this additional expressiveness is that the compiler doesn't try to check for
-exhaustiveness when match guard expressions are involved.
+this additional expressiveness is that the compiler is not smart enough about 
+arms exhaustiveness anymore when match guard expressions are involved.
+
+```rust
+match Some(100) {
+    Some(_) if true => print!("Got Some"),
+    None => println!("Got None")
+}
+```
+This `match` expression involves compilation error.
+```console
+error[E0004]: non-exhaustive patterns: `Some(_)` not covered
+   --> src/main.rs:33:11
+    |
+33  |     match Some(100) {
+    |           ^^^^^^^^^ pattern `Some(_)` not covered
+    | 
+```
+Compilation fails even though `Some(_) if true` guarded pattern matches 
+any possible `Some`. Same as unguarded `Some(_)` does.
+
 
 In Listing 18-11, we mentioned that we could use match guards to solve our
 pattern-shadowing problem. Recall that we created a new variable inside the


### PR DESCRIPTION

As per experimentation shows, `match` arms exhaustivness is checked even when arms use _match guard_.

This simple sample

```rust
pub fn test() {
    match Some(5) {
        Some(50) => println!("Got it"),
        Some(_n) if true  => println!("Exhausted"),
        None => (),
    }
}
```

produces output

![Not Exhausted](https://user-images.githubusercontent.com/26486200/197361831-4912c675-9f3b-4f98-b6f1-9d7f0557feea.png)

#### Notable observations are
- Arm `Some(_n) if true  => println!("Exhausted")` catches already any other `Some` other than `Some(50)`. 
- After `None => (),` change to `_ => (),`, compilation produces no error.

---

Obviously compiler does no heuristics on possible results of `match` guard. But it still acts as if **makes _strong_ check on arms exhaustivness**. 