### PR TITLE
Fix punctuation in ch03-05-control-flow.md

### DIFF
--- a/src/ch03-05-control-flow.md
+++ b/src/ch03-05-control-flow.md
@@ -379,7 +379,7 @@ do the following:
 
 * Convert temperatures between Fahrenheit and Celsius.
 * Generate the *n*th Fibonacci number.
-* Print the lyrics to the Christmas carol “The Twelve Days of Christmas,”
+* Print the lyrics to the Christmas carol “The Twelve Days of Christmas",
   taking advantage of the repetition in the song.
 
 When you’re ready to move on, we’ll talk about a concept in Rust that *doesn’t*


### PR DESCRIPTION
Fix typo in "summary" section by swapping ," -> ",