### PR TITLE
Likely minimistake

### DIFF
--- a/src/ch19-03-advanced-traits.md
+++ b/src/ch19-03-advanced-traits.md
@@ -442,7 +442,7 @@ that holds an instance of `Vec<T>`; then we can implement `Display` on
 
 The implementation of `Display` uses `self.0` to access the inner `Vec<T>`,
 because `Wrapper` is a tuple struct and `Vec<T>` is the item at index 0 in the
-tuple. Then we can use the functionality of the `Display` type on `Wrapper`.
+tuple. Then we can use the functionality of the `Display` trait on `Wrapper` type.
 
 The downside of using this technique is that `Wrapper` is a new type, so it
 doesn’t have the methods of the value it’s holding. We would have to implement


### PR DESCRIPTION
I came accross phrase

> Then we can use the functionality of the `Display` trait on `Wrapper` type.

, thinking through if `Display` implementation could be told **type**, but looking at [Types](https://doc.rust-lang.org/reference/types.html?highlight=type#types) in Rust Reference, I got reassured about minimistake.