### PR TITLE
Fixed the dead code warning in ch05-02-example-structs.md

### DIFF
--- a/listings/ch05-using-structs-to-structure-related-data/listing-05-12/output.txt
+++ b/listings/ch05-using-structs-to-structure-related-data/listing-05-12/output.txt
@@ -1,5 +1,19 @@
 $ cargo run
    Compiling rectangles v0.1.0 (file:///projects/rectangles)
+warning: fields `width` and `height` are never read
+ --> src\main.rs:3:5
+  |
+2 | struct Rectangle {
+  |        --------- fields in this struct
+3 |     width: u32,
+  |     ^^^^^
+4 |     height: u32,
+  |     ^^^^^^
+  |
+  = note: `#[warn(dead_code)]` on by default
+  = note: `Rectangle` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis
+
+warning: `rectangles` (bin "rectangles") generated 1 warning
     Finished dev [unoptimized + debuginfo] target(s) in 0.48s
      Running `target/debug/rectangles`
 rect1 is Rectangle { width: 30, height: 50 }

--- a/listings/ch05-using-structs-to-structure-related-data/no-listing-05-dbg-macro/output.txt
+++ b/listings/ch05-using-structs-to-structure-related-data/no-listing-05-dbg-macro/output.txt
@@ -1,5 +1,19 @@
 $ cargo run
    Compiling rectangles v0.1.0 (file:///projects/rectangles)
+warning: fields `width` and `height` are never read
+ --> src\main.rs:3:5
+  |
+2 | struct Rectangle {
+  |        --------- fields in this struct
+3 |     width: u32,
+  |     ^^^^^
+4 |     height: u32,
+  |     ^^^^^^
+  |
+  = note: `#[warn(dead_code)]` on by default
+  = note: `Rectangle` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis
+
+warning: `rectangles` (bin "rectangles") generated 1 warning
     Finished dev [unoptimized + debuginfo] target(s) in 0.61s
      Running `target/debug/rectangles`
 [src/main.rs:10] 30 * scale = 60

--- a/listings/ch05-using-structs-to-structure-related-data/output-only-02-pretty-debug/output.txt
+++ b/listings/ch05-using-structs-to-structure-related-data/output-only-02-pretty-debug/output.txt
@@ -1,5 +1,19 @@
 $ cargo run
    Compiling rectangles v0.1.0 (file:///projects/rectangles)
+warning: fields `width` and `height` are never read
+ --> src\main.rs:3:5
+  |
+2 | struct Rectangle {
+  |        --------- fields in this struct
+3 |     width: u32,
+  |     ^^^^^
+4 |     height: u32,
+  |     ^^^^^^
+  |
+  = note: `#[warn(dead_code)]` on by default
+  = note: `Rectangle` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis
+
+warning: `rectangles` (bin "rectangles") generated 1 warning
     Finished dev [unoptimized + debuginfo] target(s) in 0.48s
      Running `target/debug/rectangles`
 rect1 is Rectangle {

--- a/src/ch05-02-example-structs.md
+++ b/src/ch05-02-example-structs.md
@@ -172,8 +172,10 @@ struct definition, as shown in Listing 5-12.
 <span class="caption">Listing 5-12: Adding the attribute to derive the `Debug`
 trait and printing the `Rectangle` instance using debug formatting</span>
 
-Now when we run the program, we won’t get any errors, and we’ll see the
-following output:
+Now the program triggers a warning about dead code. In this situation, it's 
+normal, as we're only using slices of code. The error will solve after our 
+code gets completed. For now, we can ignore it. We should see this output 
+after running our program:
 
 ```console
 {{#include ../listings/ch05-using-structs-to-structure-related-data/listing-05-12/output.txt}}


### PR DESCRIPTION
I mentioned the warning when compiling code from ch05-02, fixing the issue https://github.com/rust-lang/book/issues/3409.