### PR TITLE
Fix Install MdBook command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ rust-lang/rust uses in [this file][rust-mdbook]. To get it:
 [rust-mdbook]: https://github.com/rust-lang/rust/blob/master/src/tools/rustbook/Cargo.toml
 
 ```bash
-$ cargo install mdbook --vers [version-num]
+$ cargo install mdbook --version <version_num>
 ```
 
 ## Building


### PR DESCRIPTION
The command to install mdbook specified the version the wrong way and it failed on zsh