### PR TITLE
Output order does not indicate thread execution order

### DIFF
--- a/src/ch20-03-graceful-shutdown-and-cleanup.md
+++ b/src/ch20-03-graceful-shutdown-and-cleanup.md
@@ -191,13 +191,15 @@ Shutting down worker 2
 Shutting down worker 3
 ```
 
-You might see a different ordering of workers and messages printed. We can see
-how this code works from the messages: workers 0 and 3 got the first two
-requests. The server stopped accepting connections after the second connection,
-and the `Drop` implementation on `ThreadPool` starts executing before worker 3
-even starts its job. Dropping the `sender` disconnects all the workers and
-tells them to shut down. The workers each print a message when they disconnect,
-and then the thread pool calls `join` to wait for each worker thread to finish.
+You might see a different ordering of workers and messages printed. While in 
+multithreaded compositions attempts to interpret output seqeunces are rather
+speculative, we can make assumptions on how this code works from the messages:
+workers 0 and 3 got the first two requests. The server stopped accepting 
+connections after the second connection, and the `Drop` implementation on
+`ThreadPool` starts executing before worker 3 even starts its job. Dropping
+the `sender` disconnects all the workers and tells them to shut down. The 
+workers each print a message when they disconnect, and then the thread pool 
+calls `join` to wait for each worker thread to finish.
 
 Notice one interesting aspect of this particular execution: the `ThreadPool`
 dropped the `sender`, and before any worker received an error, we tried to join

--- a/src/ch20-03-graceful-shutdown-and-cleanup.md
+++ b/src/ch20-03-graceful-shutdown-and-cleanup.md
@@ -192,7 +192,7 @@ Shutting down worker 3
 ```
 
 You might see a different ordering of workers and messages printed. While in 
-multithreaded compositions attempts to interpret output seqeunces are rather
+multithreaded compositions attempts to interpret output sequences are rather
 speculative, we can make assumptions on how this code works from the messages:
 workers 0 and 3 got the first two requests. The server stopped accepting 
 connections after the second connection, and the `Drop` implementation on


### PR DESCRIPTION
As per my understanding on how parallel thread execution works there is no guarantee that thread which outputted 1ˢᵗ is that one that executed such common command 1ˢᵗ in common timeline.

I do not know exact details of stdout handle acquisition nor `println!` locking but I suppose this case is no exception.

Use [rich diff](https://github.com/rust-lang/book/compare/main...bravequickcleverfibreyarn:rust-lang-book:ch20-03-graceful-shutdown-and-cleanup.md?expand=1&short_path=7fdba56#diff-7fdba56439b400c5a8b840458894c443c7ba6292805a5eda30b6f378fc7ed6fa).