### PR TITLE
Clarify we can still use user1.email after assignment

### DIFF
--- a/src/ch05-01-defining-structs.md
+++ b/src/ch05-01-defining-structs.md
@@ -149,12 +149,13 @@ Note that the struct update syntax uses `=` like an assignment; this is because
 it moves the data, just as we saw in the [“Variables and Data Interacting with
 Move”][move]<!-- ignore --> section. In this example, we can no longer use
 `user1` as a whole after creating `user2` because the `String` in the
-`username` field of `user1` was moved into `user2`. If we had given `user2` new
-`String` values for both `email` and `username`, and thus only used the
-`active` and `sign_in_count` values from `user1`, then `user1` would still be
-valid after creating `user2`. Both `active` and `sign_in_count` are types that
-implement the `Copy` trait, so the behavior we discussed in the [“Stack-Only
-Data: Copy”][copy]<!-- ignore --> section would apply.
+`username` field of `user1` was moved into `user2` (note that in this example
+however, we can still use `user1.email` after the assignment). If we had given
+`user2` new `String` values for both `email` and `username`, and thus only used
+the `active` and `sign_in_count` values from `user1`, then `user1` would still
+be valid after creating `user2`. Both `active` and `sign_in_count` are types
+that implement the `Copy` trait, so the behavior we discussed in the
+[“Stack-Only Data: Copy”][copy]<!-- ignore --> section would apply.
 
 ### Using Tuple Structs Without Named Fields to Create Different Types
 


### PR DESCRIPTION
https://github.com/rust-lang/book/issues/2978 was filed to track the fact that the text in `ch05-01` was not clear enough to indicate that you could use a struct's un-borrowed properties after its borrowed properties were moved into another struct via assignment. https://github.com/rust-lang/book/commit/a371f82b0916cf21de2d56bd386ca5d72f7699b0 fixed this for the most part, by clarifying that you cannot use `user1` as a whole, but I felt it would be good to clarify even more (via the new text this PR adds wrapped in parenthesis) that even if `user1.username` gets moved into `user2`, you can still use `user1.email` for example.

If this is too granular a clarification, feel free to dismiss, but I think it could be good!