### PR TITLE
Replace `Rectangle` with `Self` type in ch05-03.

### DIFF
--- a/listings/ch05-using-structs-to-structure-related-data/listing-05-15/src/main.rs
+++ b/listings/ch05-using-structs-to-structure-related-data/listing-05-15/src/main.rs
@@ -10,7 +10,7 @@ impl Rectangle {
         self.width * self.height
     }
 
-    fn can_hold(&self, other: &Rectangle) -> bool {
+    fn can_hold(&self, other: &Self) -> bool {
         self.width > other.width && self.height > other.height
     }
 }

--- a/src/ch05-03-method-syntax.md
+++ b/src/ch05-03-method-syntax.md
@@ -161,17 +161,17 @@ Can rect1 hold rect3? false
 
 We know we want to define a method, so it will be within the `impl Rectangle`
 block. The method name will be `can_hold`, and it will take an immutable borrow
-of another `Rectangle` as a parameter. We can tell what the type of the
-parameter will be by looking at the code that calls the method:
-`rect1.can_hold(&rect2)` passes in `&rect2`, which is an immutable borrow to
-`rect2`, an instance of `Rectangle`. This makes sense because we only need to
-read `rect2` (rather than write, which would mean we’d need a mutable borrow),
-and we want `main` to retain ownership of `rect2` so we can use it again after
-calling the `can_hold` method. The return value of `can_hold` will be a
-Boolean, and the implementation will check whether the width and height of
-`self` are greater than the width and height of the other `Rectangle`,
-respectively. Let’s add the new `can_hold` method to the `impl` block from
-Listing 5-13, shown in Listing 5-15.
+of another `Rectangle` as a parameter, which is aliased by the `Self` type. We
+can tell what the type of the parameter will be by looking at the code that
+calls the method: `rect1.can_hold(&rect2)` passes in `&rect2`, which is an
+immutable borrow to `rect2`, an instance of `Rectangle`. This makes sense
+because we only need to read `rect2` (rather than write, which would mean we’d
+need a mutable borrow), and we want `main` to retain ownership of `rect2` so we
+can use it again after calling the `can_hold` method. The return value of
+`can_hold` will be a Boolean, and the implementation will check whether the
+width and height of `self` are greater than the width and height of the other
+`Rectangle`, respectively. Let’s add the new `can_hold` method to the `impl`
+block from Listing 5-13, shown in Listing 5-15.
 
 <span class="filename">Filename: src/main.rs</span>
 


### PR DESCRIPTION
Listing 5-15 uses the signature
```
fn can_hold(&self, other: &Rectangle) -> bool
```
but
```
fn can_hold(&self, other: &Self) -> bool
```
would be a better fit with the several references to `Self` being an alias to `Rectangle` scatted throughout ch05-03. It would also teach better patterns.