### PR TITLE
Replace `Range` operator with `RangeTo` operator

### DIFF
--- a/listings/ch04-understanding-ownership/no-listing-18-first-word-slice/src/main.rs
+++ b/listings/ch04-understanding-ownership/no-listing-18-first-word-slice/src/main.rs
@@ -4,7 +4,7 @@ fn first_word(s: &String) -> &str {
 
     for (i, &item) in bytes.iter().enumerate() {
         if item == b' ' {
-            return &s[0..i];
+            return &s[..i];
         }
     }
 


### PR DESCRIPTION
The start bound of the `Range` is `0`, so this keyword can be omitted. This use of `RangeTo` was recently explained before this listing.
NOTE:  May need to modify sentence "When we ... ending indices." on lines `186-188` in `src/ch04-03-slices.md`.