### PR TITLE
fix macos installation problem

### DIFF
--- a/src/ch01-01-installation.md
+++ b/src/ch01-01-installation.md
@@ -28,7 +28,7 @@ these steps should work as expected with the content of this book.
 If you’re using Linux or macOS, open a terminal and enter the following command:
 
 ```console
-$ curl --proto '=https' --tlsv1.3 https://sh.rustup.rs -sSf | sh
+$ curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | sh
 ```
 
 The command downloads a script and starts the installation of the `rustup`


### PR DESCRIPTION
when installing rust on macos just copy pasting the command throw an error about curl, on the official rust-lang website the command uses tlsv1.2 and roll backing seems to fix the issue