### PR TITLE
Fix missing characters in example output

### DIFF
--- a/src/ch02-00-guessing-game-tutorial.md
+++ b/src/ch02-00-guessing-game-tutorial.md
@@ -291,7 +291,7 @@ let y = 10;
 println!("x = {x} and y + 2 = {}", y + 2);
 ```
 
-This code would print `x = 5 and y = 12`.
+This code would print `x = 5 and y + 2 = 12`.
 
 ### Testing the First Part
 


### PR DESCRIPTION
Changed "x = 5 and y = 12" to "x = 5 and y + 2 = 12" to match the actual output.