### PR TITLE
Remove confusion with `cargo run .`

### DIFF
--- a/src/ch01-03-hello-cargo.md
+++ b/src/ch01-03-hello-cargo.md
@@ -158,7 +158,7 @@ Hello, world!
 
 Using `cargo run` is more convenient than having to remember to run `cargo
 build` and then use the whole path to the binary, so most developers use `cargo
-run`.
+run` instead.
 
 Notice that this time we didn’t see output indicating that Cargo was compiling
 `hello_cargo`. Cargo figured out that the files hadn’t changed, so it didn’t


### PR DESCRIPTION
Added the word "instead", which won't change the meaning of the sentence, but separates the `.` to avoid confusion about what the command is.

...most developers use `cargo run`.
...most developers use `cargo run .`
...most developers use `cargo run` instead.