### PR TITLE
suggestion to clarify the scope of references

### DIFF
--- a/listings/ch04-understanding-ownership/no-listing-13-reference-scope-ends/src/main.rs
+++ b/listings/ch04-understanding-ownership/no-listing-13-reference-scope-ends/src/main.rs
@@ -5,9 +5,8 @@ fn main() {
     let r1 = &s; // no problem
     let r2 = &s; // no problem
     println!("{} and {}", r1, r2);
-    // variables r1 and r2 will not be used after this point
 
-    let r3 = &mut s; // no problem
+    let r3 = &mut s; // no problem, variables r1 and r2 will not be used after this point
     println!("{}", r3);
     // ANCHOR_END: here
 }

--- a/src/ch04-02-references-and-borrowing.md
+++ b/src/ch04-02-references-and-borrowing.md
@@ -177,8 +177,8 @@ occurs before the mutable reference is introduced:
 The scopes of the immutable references `r1` and `r2` end after the `println!`
 where they are last used, which is before the mutable reference `r3` is
 created. These scopes don’t overlap, so this code is allowed: the compiler can
-tell that the reference is no longer being used at a point before the end of
-the scope.
+tell that the reference is no longer being used at a point after the start of
+a new scope.
 
 Even though borrowing errors may be frustrating at times, remember that it’s
 the Rust compiler pointing out a potential bug early (at compile time rather


### PR DESCRIPTION
To clarify the scope of references, 
I suggest the comment should be moved after the  "let r3 = &mut s;" statement.
"println!("{}", r1);" or "println!("{}", r2);" is possible before "let r3 = &mut s;" .