### PR TITLE
Remove direction to authenticate with `cargo login {API token}`

### DIFF
--- a/src/ch14-02-publishing-to-crates-io.md
+++ b/src/ch14-02-publishing-to-crates-io.md
@@ -273,10 +273,12 @@ in via a GitHub account. (The GitHub account is currently a requirement, but
 the site might support other ways of creating an account in the future.) Once
 you’re logged in, visit your account settings at
 [https://crates.io/me/](https://crates.io/me/)<!-- ignore --> and retrieve your
-API key. Then run the `cargo login` command with your API key, like this:
+API key. Then run the `cargo login` command and paste your API key when prompted, like this:
 
 ```console
-$ cargo login abcdefghijklmnopqrstuvwxyz012345
+$ cargo login
+please paste the API Token found on https://crates.io/me below
+abcdefghijklmnopqrstuvwxyz012345
 ```
 
 This command will inform Cargo of your API token and store it locally in


### PR DESCRIPTION
This is potentially a security issue. Running `cargo login {API key}` will save the issued command in the history in most shells, potentially exposing the API key.

Granted it’s usually not any less secure than Cargo storing the API key anyways, but I think it’s still good practice to keep history clean of these things. It’s always nasty when things crop up in unexpected places.
