### PR TITLE
Fix broken link to the No Starch Press version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,10 +38,12 @@ that governs all sub-projects, including this one. Please respect it!
 
 ## Expectations
 
-Because the book is [printed](https://nostarch.com/rust), and because we want
+Because the book is [printed][nostarch], and because we want
 to keep the online version of the book close to the print version when
 possible, it may take longer than you're used to for us to address your issue
 or pull request.
+
+[nostarch]: https://nostarch.com/rust-programming-language-2nd-edition
 
 So far, we've been doing a larger revision to coincide with [Rust
 Editions](https://doc.rust-lang.org/edition-guide/). Between those larger

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains the source of "The Rust Programming Language" book.
 
 [The book is available in dead-tree form from No Starch Press][nostarch].
 
-[nostarch]: https://nostarch.com/rust
+[nostarch]: https://nostarch.com/rust-programming-language-2nd-edition
 
 You can also read the book for free online. Please see the book as shipped with
 the latest [stable], [beta], or [nightly] Rust releases. Be aware that issues
@@ -73,7 +73,7 @@ kinds of contributions we're looking for.
 
 [contrib]: https://github.com/rust-lang/book/blob/main/CONTRIBUTING.md
 
-Because the book is [printed](https://nostarch.com/rust), and because we want
+Because the book is [printed][nostarch], and because we want
 to keep the online version of the book close to the print version when
 possible, it may take longer than you're used to for us to address your issue
 or pull request.

--- a/src/ch00-00-introduction.md
+++ b/src/ch00-00-introduction.md
@@ -4,7 +4,7 @@
 > Language][nsprust] available in print and ebook format from [No Starch
 > Press][nsp].
 
-[nsprust]: https://nostarch.com/rust
+[nsprust]: https://nostarch.com/rust-programming-language-2nd-edition
 [nsp]: https://nostarch.com/
 
 Welcome to *The Rust Programming Language*, an introductory book about Rust.

--- a/src/title-page.md
+++ b/src/title-page.md
@@ -18,7 +18,7 @@ Press][nsprust].
 
 [install]: ch01-01-installation.html
 [editions]: appendix-05-editions.html
-[nsprust]: https://nostarch.com/rust
+[nsprust]: https://nostarch.com/rust-programming-language-2nd-edition
 [translations]: appendix-06-translation.html
 
 > **🚨 Want a more interactive learning experience? Try out a different version


### PR DESCRIPTION
This fixes the broken URL to the [No Starch Press](https://nostarch.com/rust-programming-language-2nd-edition) version of the book, which is broken on the [title page](https://doc.rust-lang.org/stable/book/title-page.html) and in the [introduction](https://doc.rust-lang.org/stable/book/ch00-00-introduction.html).

Previous URL: https://nostarch.com/rust
New URL: https://nostarch.com/rust-programming-language-2nd-edition