### PR TITLE
Include rectangle rotation for fn can_hold

### DIFF
--- a/listings/ch05-using-structs-to-structure-related-data/listing-05-15/src/main.rs
+++ b/listings/ch05-using-structs-to-structure-related-data/listing-05-15/src/main.rs
@@ -12,6 +12,7 @@ impl Rectangle {
 
     fn can_hold(&self, other: &Rectangle) -> bool {
         self.width > other.width && self.height > other.height
+        || self.width > other.height && self.height > other.width
     }
 }
 // ANCHOR_END: here


### PR DESCRIPTION
In the example used for function can_hold the test to check is to see if the first rectangle has greater width than the second rectangle and greater height than the second rectangle. My proposal is to also allow the case that the second rectangle fits by "rotating" the rectangle so to speak. An example is if rectangle a has dimensions 10x5 and rectangle b has dimensions 4x6, then rectangle b would fit into rectangle a with this proposed change, but would not with the current function.