### PR TITLE
Adding Uzbek translated rust-book repository to the list

### DIFF
--- a/src/appendix-06-translation.md
+++ b/src/appendix-06-translation.md
@@ -27,3 +27,4 @@ For resources in languages other than English. Most are still in progress; see
 - [हिंदी](https://github.com/venkatarun95/rust-book-hindi)
 - [ไทย](https://github.com/rust-lang-th/book-th)
 - [Danske](https://github.com/DanKHansen/book-dk)
+- [Uzbek](https://github.com/rust-lang-uz/i10n)

--- a/src/appendix-06-translation.md
+++ b/src/appendix-06-translation.md
@@ -27,4 +27,4 @@ For resources in languages other than English. Most are still in progress; see
 - [हिंदी](https://github.com/venkatarun95/rust-book-hindi)
 - [ไทย](https://github.com/rust-lang-th/book-th)
 - [Danske](https://github.com/DanKHansen/book-dk)
-- [Uzbek](https://github.com/rust-lang-uz/i10n)
+- [O'zbek](https://github.com/rust-lang-uz/i10n)


### PR DESCRIPTION
We also have deployed version at: https://book.rust-lang.uz