### PR TITLE
Clarified underscore pattern

### DIFF
--- a/listings/ch18-patterns-and-matching/no-listing-02-multiple-patterns/src/main.rs
+++ b/listings/ch18-patterns-and-matching/no-listing-02-multiple-patterns/src/main.rs
@@ -5,7 +5,7 @@ fn main() {
     match x {
         1 | 2 => println!("one or two"),
         3 => println!("three"),
-        _ => println!("anything"),
+        _ => println!("anything else"),
     }
     // ANCHOR_END: here
 }


### PR DESCRIPTION
Clarified underscore pattern from "anything" to "anything else".
[18-3 Pattern Matching](https://doc.rust-lang.org/book/ch18-03-pattern-syntax.html#multiple-patterns)