### PR TITLE
Fix the expected substring in ch11-01

### DIFF
--- a/src/ch11-01-writing-tests.md
+++ b/src/ch11-01-writing-tests.md
@@ -497,10 +497,10 @@ This time when we run the `should_panic` test, it will fail:
 ```
 
 The failure message indicates that this test did indeed panic as we expected,
-but the panic message did not include the expected string `'Guess value must be
-less than or equal to 100'`. The panic message that we did get in this case was
-`Guess value must be greater than or equal to 1, got 200.` Now we can start
-figuring out where our bug is!
+but the panic message did not include the expected string `less than or equal
+to 100`. The panic message that we did get in this case was `Guess value must
+be greater than or equal to 1, got 200.` Now we can start figuring out where
+our bug is!
 
 ### Using `Result<T, E>` in Tests
 


### PR DESCRIPTION
According to Listing 11-9, the substring expected to be included is `less than or equal to 100` (not `Guess value must be less than or equal to 100` as written in the book, which is strictly speaking not the expected substring - it's almost the entire panic message except the final `, got {}.` part). See [Listing 11-9](https://github.com/rust-lang/book/blob/f2a78f64b668f63f581203c6bac509903f7c00ee/listings/ch11-writing-automated-tests/listing-11-09/src/lib.rs#L31):

```rust
    #[should_panic(expected = "less than or equal to 100")]
```

Also I think this was the only place in this chapter / in the book where I saw a string quotation in inline code additionally surrounded with single quotes `'`, so I removed them.