### PR TITLE
Removed "," typo on ch03-01 line 85

### DIFF
--- a/src/ch03-01-variables-and-mutability.md
+++ b/src/ch03-01-variables-and-mutability.md
@@ -82,7 +82,7 @@ First, you aren’t allowed to use `mut` with constants. Constants aren’t just
 immutable by default—they’re always immutable. You declare constants using the
 `const` keyword instead of the `let` keyword, and the type of the value *must*
 be annotated. We’ll cover types and type annotations in the next section,
-[“Data Types,”][data-types]<!-- ignore -->, so don’t worry about the details
+[“Data Types”][data-types]<!-- ignore -->, so don’t worry about the details
 right now. Just know that you must always annotate the type.
 
 Constants can be declared in any scope, including the global scope, which makes


### PR DESCRIPTION
Removed extra comma on line 85.

> We’ll cover types and type annotations in the next section, “Data Types`,`”, so don’t worry about the details right now.