### PR TITLE
Add link from chapter 8.3 to HashMap documentation

### DIFF
--- a/src/ch08-03-hash-maps.md
+++ b/src/ch08-03-hash-maps.md
@@ -15,7 +15,8 @@ name, you can retrieve its score.
 
 We’ll go over the basic API of hash maps in this section, but many more goodies
 are hiding in the functions defined on `HashMap<K, V>` by the standard library.
-As always, check the standard library documentation for more information.
+As always, check the [standard library documentation](https://doc.rust-lang.org/std/collections/hash_map/struct.HashMap.html)<!-- ignore -->
+for more information.
 
 ### Creating a New Hash Map
 


### PR DESCRIPTION
This link makes it easier for a user reading the chapter about hash maps to navigate to the standard library documentation for `HashMap`.

Test plan:
1. run `mdbook build`
2. Open `book/index.html` in Google Chrome
3. Navigate to chapter 8.3
4. Verify that the "standard library documentation" in paragraph 3 is a hyperlink
5. Verify that clicking the hyperlink navigates the browser to the doc page for `HashMap`.