### PR TITLE
Add link from chapter 8.3 to HashMap documentation

### DIFF
--- a/src/ch08-03-hash-maps.md
+++ b/src/ch08-03-hash-maps.md
@@ -15,7 +15,8 @@ name, you can retrieve its score.
 
 We’ll go over the basic API of hash maps in this section, but many more goodies
 are hiding in the functions defined on `HashMap<K, V>` by the standard library.
-As always, check the standard library documentation for more information.
+As always, check the [standard library documentation][hash-map-api]<!-- ignore -->
+for more information.
 
 ### Creating a New Hash Map
 
@@ -240,3 +241,4 @@ a perfect time to discuss error handling. We’ll do that next!
 [validating-references-with-lifetimes]:
 ch10-03-lifetime-syntax.html#validating-references-with-lifetimes
 [access]: #accessing-values-in-a-hash-map
+[hash-map-api]: ../std/collections/hash_map/struct.HashMap.html


### PR DESCRIPTION
This link makes it easier for a user reading the chapter about hash maps to navigate to the standard library documentation for `HashMap`.

Test plan:

1. Check out `rust-lang/rust.git` and build the standard library docs by [following the instructions](https://github.com/rust-lang/rust/blob/master/README.md#building-documentation).
2. run `mdbook build` to build `rust-lang/book.git` with the changes in this PR.
3. Copy the `book` directory from the build output of step 2, replacing the `book` directory in the build output of step 1.
4. Open `book/index.html` in Google Chrome.
5. Navigate to chapter 8.3.
6. Verify that the "standard library documentation" phrase in paragraph 3 is a hyperlink.
7. Verify that clicking the hyperlink navigates the browser to the doc page for `HashMap`.