### PR TITLE
Fix language name typo

### DIFF
--- a/src/ch08-02-strings.md
+++ b/src/ch08-02-strings.md
@@ -244,7 +244,7 @@ encoded UTF-8 example strings from Listing 8-14. First, this one:
 In this case, `len` will be 4, which means the vector storing the string “Hola”
 is 4 bytes long. Each of these letters takes 1 byte when encoded in UTF-8. The
 following line, however, may surprise you. (Note that this string begins with
-the capital Cyrillic letter Ze, not the Arabic number 3.)
+the capital Cyrillic letter Ze, not the English number 3.)
 
 ```rust
 {{#rustdoc_include ../listings/ch08-common-collections/listing-08-14/src/main.rs:russian}}


### PR DESCRIPTION
A slight typo I have seen while reading the book. The Arabic number 3 is a mirrored version of the English number 3, I think the author was mistaken from earlier example, when they talked about Arabic letters appears in a String.