### PR TITLE
fix off by 1 error in ch16-03 example

### DIFF
--- a/listings/ch16-fearless-concurrency/listing-16-15/src/main.rs
+++ b/listings/ch16-fearless-concurrency/listing-16-15/src/main.rs
@@ -5,7 +5,7 @@ fn main() {
     let counter = Arc::new(Mutex::new(0));
     let mut handles = vec![];
 
-    for _ in 0..10 {
+    for _ in 0..11 {
         let counter = Arc::clone(&counter);
         let handle = thread::spawn(move || {
             let mut num = counter.lock().unwrap();


### PR DESCRIPTION
The result in the book is 10, but the for loop in the example is called 9 times, that makes the result incorrect.

I've changed the for-loop to be from 1..10 to 1..11