### PR TITLE
Change Chapter 2 error messages to recommended style

### DIFF
--- a/listings/ch02-guessing-game-tutorial/listing-02-01/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/listing-02-01/src/main.rs
@@ -21,7 +21,7 @@ fn main() {
         .read_line(&mut guess)
         // ANCHOR_END: read
         // ANCHOR: expect
-        .expect("Failed to read line");
+        .expect("String variable `guess` should be set by `read_line`");
     // ANCHOR_END: expect
 
     // ANCHOR: print_guess

--- a/listings/ch02-guessing-game-tutorial/listing-02-02/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/listing-02-02/src/main.rs
@@ -9,7 +9,7 @@ fn main() {
 
     io::stdin()
         .read_line(&mut guess)
-        .expect("Failed to read line");
+        .expect("String variable `guess` should be set by `read_line`");
 
     println!("You guessed: {guess}");
 }

--- a/listings/ch02-guessing-game-tutorial/listing-02-03/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/listing-02-03/src/main.rs
@@ -19,7 +19,7 @@ fn main() {
 
     io::stdin()
         .read_line(&mut guess)
-        .expect("Failed to read line");
+        .expect("String variable `guess` should be set by `read_line`");
 
     println!("You guessed: {guess}");
     // ANCHOR: ch07-04

--- a/listings/ch02-guessing-game-tutorial/listing-02-04/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/listing-02-04/src/main.rs
@@ -18,7 +18,7 @@ fn main() {
 
     io::stdin()
         .read_line(&mut guess)
-        .expect("Failed to read line");
+        .expect("String variable `guess` should be set by `read_line`");
     // ANCHOR: here
 
     println!("You guessed: {guess}");

--- a/listings/ch02-guessing-game-tutorial/listing-02-05/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/listing-02-05/src/main.rs
@@ -19,7 +19,7 @@ fn main() {
 
         io::stdin()
             .read_line(&mut guess)
-            .expect("Failed to read line");
+            .expect("String variable `guess` should be set by `read_line`");
 
         // ANCHOR: ch19
         let guess: u32 = match guess.trim().parse() {

--- a/listings/ch02-guessing-game-tutorial/listing-02-06/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/listing-02-06/src/main.rs
@@ -14,7 +14,7 @@ fn main() {
 
         io::stdin()
             .read_line(&mut guess)
-            .expect("Failed to read line");
+            .expect("String variable `guess` should be set by `read_line`");
 
         let guess: u32 = match guess.trim().parse() {
             Ok(num) => num,

--- a/listings/ch02-guessing-game-tutorial/no-listing-03-convert-string-to-number/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/no-listing-03-convert-string-to-number/src/main.rs
@@ -18,7 +18,7 @@ fn main() {
 
     io::stdin()
         .read_line(&mut guess)
-        .expect("Failed to read line");
+        .expect("String variable `guess` should be set by `read_line`");
 
     let guess: u32 = guess.trim().parse().expect("Please type a number!");
 

--- a/listings/ch02-guessing-game-tutorial/no-listing-04-looping/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/no-listing-04-looping/src/main.rs
@@ -23,7 +23,7 @@ fn main() {
 
         io::stdin()
             .read_line(&mut guess)
-            .expect("Failed to read line");
+            .expect("String variable `guess` should be set by `read_line`");
 
         let guess: u32 = guess.trim().parse().expect("Please type a number!");
 

--- a/listings/ch02-guessing-game-tutorial/no-listing-05-quitting/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/no-listing-05-quitting/src/main.rs
@@ -16,7 +16,7 @@ fn main() {
 
         io::stdin()
             .read_line(&mut guess)
-            .expect("Failed to read line");
+            .expect("String variable `guess` should be set by `read_line`");
 
         let guess: u32 = guess.trim().parse().expect("Please type a number!");
 


### PR DESCRIPTION
Change error messages to the recommended message style from [the `expect` documentation](https://doc.rust-lang.org/std/result/enum.Result.html#method.expect).