### PR TITLE
Fix ch07-01 statement of binary and library crates

### DIFF
--- a/src/ch07-01-packages-and-crates.md
+++ b/src/ch07-01-packages-and-crates.md
@@ -35,8 +35,8 @@ package also contains a library crate that the binary crate depends on. Other
 projects can depend on the Cargo library crate to use the same logic the Cargo
 command-line tool uses.
 
-A package can contain as many binary crates as you like, but at most only one
-library crate. A package must contain at least one crate, whether that’s a
+A package can contain as many library crates as you like, but at most only one
+binary crate. A package must contain at least one crate, whether that’s a
 library or binary crate.
 
 Let’s walk through what happens when we create a package. First, we enter the


### PR DESCRIPTION
The sentence stated "A package can contain as many binary crates as you like, but at most only one library crate." for which I believe it reversed the position for "binary" and "library" wrt where they should be. A binary crates which has a main function is the one a package should at most have one.