### PR TITLE
Fix em dashes

### DIFF
--- a/src/ch16-02-message-passing.md
+++ b/src/ch16-02-message-passing.md
@@ -52,7 +52,7 @@ producer for now, but we’ll add multiple producers when we get this example
 working.
 
 The `mpsc::channel` function returns a tuple, the first element of which is the
-sending end--the transmitter--and the second element is the receiving end--the
+sending end—the transmitter—and the second element is the receiving end—the
 receiver. The abbreviations `tx` and `rx` are traditionally used in many fields
 for *transmitter* and *receiver* respectively, so we name our variables as such
 to indicate each end. We’re using a `let` statement with a pattern that


### PR DESCRIPTION
When reading this section as HTML, these double hyphens stood out to me. It looks like this was introduced last year in #3135. I found other parts of the book where em dashes used standard Unicode em dash characters (rather than some Markdown representation) so I updated these to use them.

(Note that I actually think this would read more clearly if it used parentheses rather than em dashes, but I figured I'd start with the smallest possible suggestion.)