### PR TITLE
ch04-02-references-and-borrowing add real life analogy

### DIFF
--- a/src/ch04-02-references-and-borrowing.md
+++ b/src/ch04-02-references-and-borrowing.md
@@ -98,7 +98,7 @@ with just a few small tweaks that use, instead, a *mutable reference*:
 First we change `s` to be `mut`. Then we create a mutable reference with `&mut
 s` where we call the `change` function, and update the function signature to
 accept a mutable reference with `some_string: &mut String`. This makes it very
-clear that the `change` function will mutate the value it borrows.
+clear that the `change` function will mutate the value it borrows. Again, as in real life, if someone lends you something, they might allow you to modify it as needed before returning it to them. However, ultimately the item still belongs to the original owner.
 
 Mutable references have one big restriction: if you have a mutable reference to
 a value, you can have no other references to that value. This code that


### PR DESCRIPTION
There is an analogy to real life a few paragraphs above: "We call the action of creating a reference borrowing. As in real life, if a person owns something, you can borrow it from them. When you’re done, you have to give it back. You don’t own it."

I think it would be appropriate to have a similar analogy for the mutable reference example.