### PR TITLE
ch10-01: fix misplaced comma

### DIFF
--- a/src/ch10-01-syntax.md
+++ b/src/ch10-01-syntax.md
@@ -34,7 +34,7 @@ To parameterize the types in a new single function, we need to name the type
 parameter, just as we do for the value parameters to a function. You can use
 any identifier as a type parameter name. But we’ll use `T` because, by
 convention, type parameter names in Rust are short, often just a letter, and
-Rust’s type-naming convention is UpperCamelCase. Short for “type,” `T` is the
+Rust’s type-naming convention is UpperCamelCase. Short for “type”, `T` is the
 default choice of most Rust programmers.
 
 When we use a parameter in the body of the function, we have to declare the


### PR DESCRIPTION
old:
Short for “type,” \`T\` is [...]

new:
Short for “type”, \`T\` is [...]
