### PR TITLE
Remove awkward phrase about types of strings.

### DIFF
--- a/src/ch08-02-strings.md
+++ b/src/ch08-02-strings.md
@@ -28,10 +28,9 @@ string slices.
 The `String` type, which is provided by Rust’s standard library rather than
 coded into the core language, is a growable, mutable, owned, UTF-8 encoded
 string type. When Rustaceans refer to “strings” in Rust, they might be
-referring to either the `String` or the string slice `&str` types, not just one
-of those types. Although this section is largely about `String`, both types are
-used heavily in Rust’s standard library, and both `String` and string slices
-are UTF-8 encoded.
+referring to either the `String` or the string slice `&str` types. Although this
+section is largely about `String`, both types are used heavily in Rust’s
+standard library, and both `String` and string slices are UTF-8 encoded.
 
 ### Creating a New String
 


### PR DESCRIPTION
"Not just one of these" is unclear and confusing. The purpose of the sentence is to say that when people say "string", they could either mean String or &str. The meaning is conveyed perfectly well without the phrase "not just one of these", and that phrase makes the sentence significantly more difficult to read.