### PR TITLE
Update `cargo new --lib` output for chapter 11

### DIFF
--- a/listings/ch11-writing-automated-tests/listing-11-01/src/lib.rs
+++ b/listings/ch11-writing-automated-tests/listing-11-01/src/lib.rs
@@ -2,7 +2,7 @@
 mod tests {
     #[test]
     fn it_works() {
-        let result = 2 + 2;
+        let result = add(2, 2);
         assert_eq!(result, 4);
     }
 }


### PR DESCRIPTION
`cargo new adder --lib` command produces an output which differs from one in the book, checked on cargo 1.68.0 (115f34552 2023-02-26)