### PR TITLE
Fix "`test` module" to "`tests` module" in ch11-03

### DIFF
--- a/src/ch11-03-test-organization.md
+++ b/src/ch11-03-test-organization.md
@@ -70,7 +70,7 @@ Note that the `internal_adder` function is not marked as `pub`. Tests are just
 Rust code, and the `tests` module is just another module. As we discussed in
 the [“Paths for Referring to an Item in the Module Tree”][paths]<!-- ignore -->
 section, items in child modules can use the items in their ancestor modules. In
-this test, we bring all of the `test` module’s parent’s items into scope with
+this test, we bring all of the `tests` module’s parent’s items into scope with
 `use super::*`, and then the test can call `internal_adder`. If you don’t think
 private functions should be tested, there’s nothing in Rust that will compel
 you to do so.


### PR DESCRIPTION
The module is called `tests`, not `test` - see Listing 11-12:

https://github.com/rust-lang/book/blob/21a2ed14f4480dab62438dcc1130291bebc65379/listings/ch11-writing-automated-tests/listing-11-12/src/lib.rs#L9-L10