### PR TITLE
Use and_modify in the docs for hash map instead

### DIFF
--- a/listings/ch08-common-collections/listing-08-25/src/main.rs
+++ b/listings/ch08-common-collections/listing-08-25/src/main.rs
@@ -7,8 +7,9 @@ fn main() {
     let mut map = HashMap::new();
 
     for word in text.split_whitespace() {
-        let count = map.entry(word).or_insert(0);
-        *count += 1;
+        map.entry(word)
+            .and_modify(|existing_value| *existing_value += 1)
+            .or_insert(1);
     }
 
     println!("{:?}", map);


### PR DESCRIPTION
This PR updates the rust book to suggest and_modify.

Currently the rust book suggests using the following
```
use std::collections::HashMap;

    let text = "hello world wonderful world";

    let mut map = HashMap::new();

    for word in text.split_whitespace() {
        let count = map.entry(word).or_insert(0);
        *count += 1;
    }

    println!("{:?}", map);
```
https://doc.rust-lang.org/book/ch08-03-hash-maps.html?highlight=hashmap#creating-a-new-hash-map

The docs for hashmap use and_modify https://doc.rust-lang.org/std/collections/hash_map/enum.Entry.html
```
use std::collections::HashMap;

let mut map: HashMap<&str, u32> = HashMap::new();

map.entry("poneyland")
   .and_modify(|e| { *e += 1 })
   .or_insert(42);
assert_eq!(map["poneyland"], 42);

map.entry("poneyland")
   .and_modify(|e| { *e += 1 })
   .or_insert(42);
assert_eq!(map["poneyland"], 43);
```

