### PR TITLE
Fixed incorrect "Too big!" output in ch02-00

### DIFF
--- a/src/ch02-00-guessing-game-tutorial.md
+++ b/src/ch02-00-guessing-game-tutorial.md
@@ -734,7 +734,7 @@ The secret number is: 58
 Please input your guess.
   76
 You guessed: 76
-Too big!
+You win!
 ```
 
 Nice! Even though spaces were added before the guess, the program still figured


### PR DESCRIPTION
`ch02-00-guessing-game-tutorial.md` contains an example output snippet, which incorrectly states "Too big!" when it should say "You win!".