### PR TITLE
Use an example for structs methods that complies with Liskov principle

### DIFF
--- a/listings/ch05-using-structs-to-structure-related-data/no-listing-03-associated-functions/src/main.rs
+++ b/listings/ch05-using-structs-to-structure-related-data/no-listing-03-associated-functions/src/main.rs
@@ -1,20 +1,22 @@
 #[derive(Debug)]
 struct Rectangle {
-    width: u32,
-    height: u32,
+    width: f32,
+    height: f32,
 }
+
+const GOLDEN_RATIO: f32 = 1.618;
 
 // ANCHOR: here
 impl Rectangle {
-    fn square(size: u32) -> Self {
+    fn golden_rectangle(width: f32) -> Self {
         Self {
-            width: size,
-            height: size,
+            width,
+            height: GOLDEN_RATIO * width,
         }
     }
 }
 // ANCHOR_END: here
 
 fn main() {
-    let sq = Rectangle::square(3);
+    let sq = Rectangle::golden_rectangle(3.0);
 }

--- a/src/ch05-03-method-syntax.md
+++ b/src/ch05-03-method-syntax.md
@@ -215,7 +215,7 @@ aliases for the type that appears after the `impl` keyword, which in this case
 is `Rectangle`.
 
 To call this associated function, we use the `::` syntax with the struct name;
-`let sq = Rectangle::square(3);` is an example. This function is namespaced by
+`let sq = Rectangle::golden_rectangle(3.0);` is an example. This function is namespaced by
 the struct: the `::` syntax is used for both associated functions and
 namespaces created by modules. We’ll discuss modules in [Chapter
 7][modules]<!-- ignore -->.


### PR DESCRIPTION
As suggested in #3587, is-a relationship between square and rectangle should be avoided to respect [Liskov Substitution Principle](https://en.wikipedia.org/wiki/Liskov_substitution_principle).

As such, I suggest a small fix in the book to use a golden rectangle instead which satisfies LSP.