### PR TITLE
ch01-03: Fix inaccurate cli output for `cargo run`

### DIFF
--- a/src/ch01-03-hello-cargo.md
+++ b/src/ch01-03-hello-cargo.md
@@ -151,6 +151,7 @@ code and then run the resultant executable all in one command:
 
 ```console
 $ cargo run
+   Compiling hello_cargo v0.1.0 (file:///projects/hello_cargo)
     Finished dev [unoptimized + debuginfo] target(s) in 0.0 secs
      Running `target/debug/hello_cargo`
 Hello, world!


### PR DESCRIPTION
The documentation is missing the `Compiling...` line in the output of `cargo run` when doing a build+run. This change adds the line to the documentation to be accurate to what's seen in the cli.