### PR TITLE
[WIP]: Update to comply with Foundation Trademark policy

### DIFF
--- a/src/ch01-00-getting-started.md
+++ b/src/ch01-00-getting-started.md
@@ -1,8 +1,8 @@
 # Getting Started
 
-Let’s start your Rust journey! There’s a lot to learn, but every journey starts
+Let’s start your Rust® journey! There’s a lot to learn, but every journey starts
 somewhere. In this chapter, we’ll discuss:
 
-* Installing Rust on Linux, macOS, and Windows
+* Installing the Rust® toolchain on Linux, macOS, and Windows
 * Writing a program that prints `Hello, world!`
-* Using `cargo`, Rust’s package manager and build system
+* Using `cargo`, the package manager and build system for the Rust® programming language

--- a/src/ch01-01-installation.md
+++ b/src/ch01-01-installation.md
@@ -1,18 +1,20 @@
 ## Installation
 
-The first step is to install Rust. We’ll download Rust through `rustup`, a
-command line tool for managing Rust versions and associated tools. You’ll need
-an internet connection for the download.
+The first step is to install the Rust® toolchain. We’ll download the Rust®
+toolchain through `rustup`, a command line tool for managing versions of the
+Rust® compiler and associated tools. You’ll need an internet connection for the
+download.
 
 > Note: If you prefer not to use `rustup` for some reason, please see the
-> [Other Rust Installation Methods page][otherinstall] for more options.
+> [Other Rust® Installation Methods page][otherinstall] for more options.
 
-The following steps install the latest stable version of the Rust compiler.
-Rust’s stability guarantees ensure that all the examples in the book that
-compile will continue to compile with newer Rust versions. The output might
-differ slightly between versions because Rust often improves error messages and
-warnings. In other words, any newer, stable version of Rust you install using
-these steps should work as expected with the content of this book.
+The following steps install the latest stable version of the Rust® compiler.  The
+stability guarantees of the Rust® programming language ensure that all the
+examples in the book that compile will continue to compile with newer versions
+of the Rust® language.  The output might differ slightly between versions because
+the Rust® compiler often improves error messages and warnings. In other words,
+any newer, stable version of the Rust® toolchain you install using these steps
+should work as expected with the content of this book.
 
 > ### Command Line Notation
 >
@@ -31,19 +33,20 @@ If you’re using Linux or macOS, open a terminal and enter the following comman
 $ curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | sh
 ```
 
-The command downloads a script and starts the installation of the `rustup`
-tool, which installs the latest stable version of Rust. You might be prompted
-for your password. If the install is successful, the following line will appear:
+The command downloads a script and starts the installation of the `rustup` tool,
+which installs the latest stable version of the Rust® toolchain. You might be
+prompted for your password. If the install is successful, the following line
+will appear:
 
 ```text
-Rust is installed now. Great!
+The Rust® compiler is installed now. Great!
 ```
 
-You will also need a *linker*, which is a program that Rust uses to join its
-compiled outputs into one file. It is likely you already have one. If you get
-linker errors, you should install a C compiler, which will typically include a
-linker. A C compiler is also useful because some common Rust packages depend on
-C code and will need a C compiler.
+You will also need a *linker*, which is a program that the Rust® compiler uses to
+join its compiled outputs into one file. It is likely you already have one. If
+you get linker errors, you should install a C compiler, which will typically
+include a linker. A C compiler is also useful because some common Rust® packages
+depend on C code and will need a C compiler.
 
 On macOS, you can get a C compiler by running:
 
@@ -58,9 +61,9 @@ the `build-essential` package.
 ### Installing `rustup` on Windows
 
 On Windows, go to [https://www.rust-lang.org/tools/install][install] and follow
-the instructions for installing Rust. At some point in the installation, you’ll
-receive a message explaining that you’ll also need the MSVC build tools for
-Visual Studio 2013 or later.
+the instructions for installing the Rust® toolchain. At some point in the
+installation, you’ll receive a message explaining that you’ll also need the MSVC
+build tools for Visual Studio 2013 or later.
 
 To acquire the build tools, you’ll need to install [Visual Studio
 2022][visualstudio]. When asked which workloads to install, include:
@@ -75,8 +78,8 @@ If there are specific differences, we’ll explain which to use.
 
 ### Troubleshooting
 
-To check whether you have Rust installed correctly, open a shell and enter this
-line:
+To check whether you have the Rust® compiler installed correctly, open a shell
+and enter this line:
 
 ```console
 $ rustc --version
@@ -89,9 +92,9 @@ stable version that has been released, in the following format:
 rustc x.y.z (abcabcabc yyyy-mm-dd)
 ```
 
-If you see this information, you have installed Rust successfully! If you don’t
-see this information, check that Rust is in your `%PATH%` system variable as
-follows.
+If you see this information, you have installed the Rust® compiler successfully!
+If you don’t see this information, check that the Rust® compiler is in your
+`%PATH%` system variable as follows.
 
 In Windows CMD, use:
 
@@ -111,21 +114,22 @@ In Linux and macOS, use:
 $ echo $PATH
 ```
 
-If that’s all correct and Rust still isn’t working, there are a number of
-places you can get help. Find out how to get in touch with other Rustaceans (a
-silly nickname we call ourselves) on [the community page][community].
+If that’s all correct and the Rust® compiler still isn’t working, there are a
+number of places you can get help. Find out how to get in touch with other
+Rustaceans (a silly nickname we call ourselves) on [the community
+page][community].
 
 ### Updating and Uninstalling
 
-Once Rust is installed via `rustup`, updating to a newly released version is
-easy. From your shell, run the following update script:
+Once the Rust® toolchain is installed via `rustup`, updating to a newly released
+version is easy. From your shell, run the following update script:
 
 ```console
 $ rustup update
 ```
 
-To uninstall Rust and `rustup`, run the following uninstall script from your
-shell:
+To uninstall the Rust® toolchain and `rustup`, run the following uninstall
+script from your shell:
 
 ```console
 $ rustup self uninstall
@@ -133,9 +137,9 @@ $ rustup self uninstall
 
 ### Local Documentation
 
-The installation of Rust also includes a local copy of the documentation so
-that you can read it offline. Run `rustup doc` to open the local documentation
-in your browser.
+The installation of the Rust® toolchain also includes a local copy of the
+documentation so that you can read it offline. Run `rustup doc` to open the
+local documentation in your browser.
 
 Any time a type or function is provided by the standard library and you’re not
 sure what it does or how to use it, use the application programming interface

--- a/src/ch01-02-hello-world.md
+++ b/src/ch01-02-hello-world.md
@@ -1,23 +1,24 @@
 ## Hello, World!
 
-Now that you’ve installed Rust, it’s time to write your first Rust program.
-It’s traditional when learning a new language to write a little program that
-prints the text `Hello, world!` to the screen, so we’ll do the same here!
+Now that you’ve installed the Rust® toolchain, it’s time to write your first
+Rust® program.  It’s traditional when learning a new language to write a little
+program that prints the text `Hello, world!` to the screen, so we’ll do the same
+here!
 
-> Note: This book assumes basic familiarity with the command line. Rust makes
+> Note: This book assumes basic familiarity with the command line. Rust® makes
 > no specific demands about your editing or tooling or where your code lives, so
 > if you prefer to use an integrated development environment (IDE) instead of
 > the command line, feel free to use your favorite IDE. Many IDEs now have some
-> degree of Rust support; check the IDE’s documentation for details. The Rust
+> degree of Rust® support; check the IDE’s documentation for details. The Rust®
 > team has been focusing on enabling great IDE support via `rust-analyzer`. See
 > [Appendix D][devtools]<!-- ignore --> for more details.
 
 ### Creating a Project Directory
 
-You’ll start by making a directory to store your Rust code. It doesn’t matter
-to Rust where your code lives, but for the exercises and projects in this book,
-we suggest making a *projects* directory in your home directory and keeping all
-your projects there.
+You’ll start by making a directory to store your Rust® code. It doesn’t matter
+to the Rust® compiler where your code lives, but for the exercises and projects
+in this book, we suggest making a *projects* directory in your home directory
+and keeping all your projects there.
 
 Open a terminal and enter the following commands to make a *projects* directory
 and a directory for the “Hello, world!” project within the *projects* directory.
@@ -40,9 +41,9 @@ For Windows CMD, enter this:
 > cd hello_world
 ```
 
-### Writing and Running a Rust Program
+### Writing and Running a Rust® Program
 
-Next, make a new source file and call it *main.rs*. Rust files always end with
+Next, make a new source file and call it *main.rs*. Rust® files always end with
 the *.rs* extension. If you’re using more than one word in your filename, the
 convention is to use an underscore to separate them. For example, use
 *hello_world.rs* rather than *helloworld.rs*.
@@ -82,10 +83,10 @@ the terminal. If you don’t see this output, refer back to the
 [“Troubleshooting”][troubleshooting]<!-- ignore --> part of the Installation
 section for ways to get help.
 
-If `Hello, world!` did print, congratulations! You’ve officially written a Rust
-program. That makes you a Rust programmer—welcome!
+If `Hello, world!` did print, congratulations! You’ve officially written a Rust®
+program. That makes you a Rust® programmer—welcome!
 
-### Anatomy of a Rust Program
+### Anatomy of a Rust® Program
 
 Let’s review this “Hello, world!” program in detail. Here’s the first piece of
 the puzzle:
@@ -97,19 +98,19 @@ fn main() {
 ```
 
 These lines define a function named `main`. The `main` function is special: it
-is always the first code that runs in every executable Rust program. Here, the
+is always the first code that runs in every executable Rust® program. Here, the
 first line declares a function named `main` that has no parameters and returns
 nothing. If there were parameters, they would go inside the parentheses `()`.
 
-The function body is wrapped in `{}`. Rust requires curly brackets around all
-function bodies. It’s good style to place the opening curly bracket on the same
-line as the function declaration, adding one space in between.
+The function body is wrapped in `{}`. The Rust® language requires curly brackets
+around all function bodies. It’s good style to place the opening curly bracket
+on the same line as the function declaration, adding one space in between.
 
-> Note: If you want to stick to a standard style across Rust projects, you can
+> Note: If you want to stick to a standard style across Rust® projects, you can
 > use an automatic formatter tool called `rustfmt` to format your code in a
 > particular style (more on `rustfmt` in
-> [Appendix D][devtools]<!-- ignore -->). The Rust team has included this tool
-> with the standard Rust distribution, as `rustc` is, so it should already be
+> [Appendix D][devtools]<!-- ignore -->). The Rust® team has included this tool
+> with the standard Rust® distribution, as `rustc` is, so it should already be
 > installed on your computer!
 
 The body of the `main` function holds the following code:
@@ -121,10 +122,10 @@ The body of the `main` function holds the following code:
 This line does all the work in this little program: it prints text to the
 screen. There are four important details to notice here.
 
-First, Rust style is to indent with four spaces, not a tab.
+First, Rust® style is to indent with four spaces, not a tab.
 
-Second, `println!` calls a Rust macro. If it had called a function instead, it
-would be entered as `println` (without the `!`). We’ll discuss Rust macros in
+Second, `println!` calls a Rust® macro. If it had called a function instead, it
+would be entered as `println` (without the `!`). We’ll discuss Rust® macros in
 more detail in Chapter 19. For now, you just need to know that using a `!`
 means that you’re calling a macro instead of a normal function and that macros
 don’t always follow the same rules as functions.
@@ -133,7 +134,7 @@ Third, you see the `"Hello, world!"` string. We pass this string as an argument
 to `println!`, and the string is printed to the screen.
 
 Fourth, we end the line with a semicolon (`;`), which indicates that this
-expression is over and the next one is ready to begin. Most lines of Rust code
+expression is over and the next one is ready to begin. Most lines of Rust® code
 end with a semicolon.
 
 ### Compiling and Running Are Separate Steps
@@ -141,7 +142,7 @@ end with a semicolon.
 You’ve just run a newly created program, so let’s examine each step in the
 process.
 
-Before running a Rust program, you must compile it using the Rust compiler by
+Before running a Rust® program, you must compile it using the Rust® compiler by
 entering the `rustc` command and passing it the name of your source file, like
 this:
 
@@ -150,7 +151,8 @@ $ rustc main.rs
 ```
 
 If you have a C or C++ background, you’ll notice that this is similar to `gcc`
-or `clang`. After compiling successfully, Rust outputs a binary executable.
+or `clang`. After compiling successfully, the Rust® compiler outputs a binary
+executable.
 
 On Linux, macOS, and PowerShell on Windows, you can see the executable by
 entering the `ls` command in your shell:
@@ -184,18 +186,19 @@ If your *main.rs* is your “Hello, world!” program, this line prints `Hello,
 world!` to your terminal.
 
 If you’re more familiar with a dynamic language, such as Ruby, Python, or
-JavaScript, you might not be used to compiling and running a program as
-separate steps. Rust is an *ahead-of-time compiled* language, meaning you can
-compile a program and give the executable to someone else, and they can run it
-even without having Rust installed. If you give someone a *.rb*, *.py*, or
-*.js* file, they need to have a Ruby, Python, or JavaScript implementation
-installed (respectively). But in those languages, you only need one command to
-compile and run your program. Everything is a trade-off in language design.
+JavaScript, you might not be used to compiling and running a program as separate
+steps. The Rust® language is an *ahead-of-time compiled* language, meaning you
+can compile a program and give the executable to someone else, and they can run
+it even without having the Rust® compiler installed. If you give someone a
+*.rb*, *.py*, or *.js* file, they need to have a Ruby, Python, or JavaScript
+implementation installed (respectively). But in those languages, you only need
+one command to compile and run your program. Everything is a trade-off in
+language design.
 
 Just compiling with `rustc` is fine for simple programs, but as your project
 grows, you’ll want to manage all the options and make it easy to share your
 code. Next, we’ll introduce you to the Cargo tool, which will help you write
-real-world Rust programs.
+real-world Rust® programs.
 
 [troubleshooting]: ch01-01-installation.html#troubleshooting
 [devtools]: appendix-04-useful-development-tools.md

--- a/src/ch01-03-hello-cargo.md
+++ b/src/ch01-03-hello-cargo.md
@@ -1,23 +1,26 @@
-## Hello, Cargo!
+## Hello, the Cargo™ package manager!
 
-Cargo is Rust’s build system and package manager. Most Rustaceans use this tool
-to manage their Rust projects because Cargo handles a lot of tasks for you,
-such as building your code, downloading the libraries your code depends on, and
-building those libraries. (We call the libraries that your code needs
+The Cargo™ package manager is the Rust® programming language build system and
+package manager. Most Rustaceans use this tool to manage their Rust® projects
+because the Cargo™ package manager handles a lot of tasks for you, such as
+building your code, downloading the libraries your code depends on, and building
+those libraries.  (We call the libraries that your code needs
 *dependencies*.)
 
-The simplest Rust programs, like the one we’ve written so far, don’t have any
-dependencies. If we had built the “Hello, world!” project with Cargo, it would
-only use the part of Cargo that handles building your code. As you write more
-complex Rust programs, you’ll add dependencies, and if you start a project
-using Cargo, adding dependencies will be much easier to do.
+The simplest Rust® programs, like the one we’ve written so far, don’t have any
+dependencies. If we had built the “Hello, world!” project with the Cargo™
+package manager, it would only use the part of the Cargo™ package manager that
+handles building your code. As you write more complex Rust® programs, you’ll add
+dependencies, and if you start a project using the Cargo™ package manager,
+adding dependencies will be much easier to do.
 
-Because the vast majority of Rust projects use Cargo, the rest of this book
-assumes that you’re using Cargo too. Cargo comes installed with Rust if you
-used the official installers discussed in the
-[“Installation”][installation]<!-- ignore --> section. If you installed Rust
-through some other means, check whether Cargo is installed by entering the
-following in your terminal:
+Because the vast majority of Rust® projects use the Cargo™ package manager, the
+rest of this book assumes that you’re using the Cargo™ package manager too. The
+Cargo™ package manager comes installed with the Rust® language if you used the
+official installers discussed in the
+[“Installation”][installation]<!-- ignore --> section. If you installed the Rust®
+language through some other means, check whether the Cargo™ package manager is
+installed by entering the following in your terminal:
 
 ```console
 $ cargo --version
@@ -25,14 +28,14 @@ $ cargo --version
 
 If you see a version number, you have it! If you see an error, such as `command
 not found`, look at the documentation for your method of installation to
-determine how to install Cargo separately.
+determine how to install the Cargo™ package manager separately.
 
-### Creating a Project with Cargo
+### Creating a Project with the Cargo™ package manager
 
-Let’s create a new project using Cargo and look at how it differs from our
-original “Hello, world!” project. Navigate back to your *projects* directory
-(or wherever you decided to store your code). Then, on any operating system,
-run the following:
+Let’s create a new project using the Cargo™ package manager and look at how it
+differs from our original “Hello, world!” project. Navigate back to your
+*projects* directory (or wherever you decided to store your code). Then, on any
+operating system, run the following:
 
 ```console
 $ cargo new hello_cargo
@@ -40,12 +43,12 @@ $ cd hello_cargo
 ```
 
 The first command creates a new directory and project called *hello_cargo*.
-We’ve named our project *hello_cargo*, and Cargo creates its files in a
-directory of the same name.
+We’ve named our project *hello_cargo*, and the Cargo™ package manager creates
+its files in a directory of the same name.
 
-Go into the *hello_cargo* directory and list the files. You’ll see that Cargo
-has generated two files and one directory for us: a *Cargo.toml* file and a
-*src* directory with a *main.rs* file inside.
+Go into the *hello_cargo* directory and list the files. You’ll see that the
+Cargo™ package manager has generated two files and one directory for us: a
+*Cargo.toml* file and a *src* directory with a *main.rs* file inside.
 
 It has also initialized a new Git repository along with a *.gitignore* file.
 Git files won’t be generated if you run `cargo new` within an existing Git
@@ -75,20 +78,23 @@ edition = "2021"
 new`</span>
 
 This file is in the [*TOML*][toml]<!-- ignore --> (*Tom’s Obvious, Minimal
-Language*) format, which is Cargo’s configuration format.
+Language*) format, which is the configuration format of the Cargo™ package
+manager.
 
 The first line, `[package]`, is a section heading that indicates that the
 following statements are configuring a package. As we add more information to
 this file, we’ll add other sections.
 
-The next three lines set the configuration information Cargo needs to compile
-your program: the name, the version, and the edition of Rust to use. We’ll talk
-about the `edition` key in [Appendix E][appendix-e]<!-- ignore -->.
+The next three lines set the configuration information the Cargo™ package
+manager needs to compile your program: the name, the version, and the edition of
+the Rust® programming language to use. We’ll talk about the `edition` key in
+[Appendix E][appendix-e]<!-- ignore -->.
 
 The last line, `[dependencies]`, is the start of a section for you to list any
-of your project’s dependencies. In Rust, packages of code are referred to as
-*crates*. We won’t need any other crates for this project, but we will in the
-first project in Chapter 2, so we’ll use this dependencies section then.
+of your project’s dependencies. In the Rust® programming language, packages of
+code are referred to as *crates*. We won’t need any other crates for this
+project, but we will in the first project in Chapter 2, so we’ll use this
+dependencies section then.
 
 Now open *src/main.rs* and take a look:
 
@@ -100,27 +106,28 @@ fn main() {
 }
 ```
 
-Cargo has generated a “Hello, world!” program for you, just like the one we
-wrote in Listing 1-1! So far, the differences between our project and the
-project Cargo generated are that Cargo placed the code in the *src* directory
-and we have a *Cargo.toml* configuration file in the top directory.
+The Cargo™ package manager has generated a “Hello, world!” program for you, just
+like the one we wrote in Listing 1-1! So far, the differences between our
+project and the project the Cargo™ package manager generated are that the Cargo™
+package manager placed the code in the *src* directory and we have a
+*Cargo™.toml* configuration file in the top directory.
 
-Cargo expects your source files to live inside the *src* directory. The
-top-level project directory is just for README files, license information,
-configuration files, and anything else not related to your code. Using Cargo
-helps you organize your projects. There’s a place for everything, and
-everything is in its place.
+The Cargo™ package manager expects your source files to live inside the *src*
+directory. The top-level project directory is just for README files, license
+information, configuration files, and anything else not related to your code.
+Using the Cargo™ package manager helps you organize your projects. There’s a
+place for everything, and everything is in its place.
 
-If you started a project that doesn’t use Cargo, as we did with the “Hello,
-world!” project, you can convert it to a project that does use Cargo. Move the
-project code into the *src* directory and create an appropriate *Cargo.toml*
-file.
+If you started a project that doesn’t use the Cargo™ package manager, as we did
+with the “Hello, world!” project, you can convert it to a project that does use
+the Cargo™ package manager. Move the project code into the *src* directory and
+create an appropriate *Cargo.toml* file.
 
-### Building and Running a Cargo Project
+### Building and Running a Project with the Cargo™ Package Manager
 
 Now let’s look at what’s different when we build and run the “Hello, world!”
-program with Cargo! From your *hello_cargo* directory, build your project by
-entering the following command:
+program with the Cargo™ package manager! From your *hello_cargo* directory,
+build your project by entering the following command:
 
 ```console
 $ cargo build
@@ -130,8 +137,9 @@ $ cargo build
 
 This command creates an executable file in *target/debug/hello_cargo* (or
 *target\debug\hello_cargo.exe* on Windows) rather than in your current
-directory. Because the default build is a debug build, Cargo puts the binary in
-a directory named *debug*. You can run the executable with this command:
+directory. Because the default build is a debug build, the Cargo™ package
+manager puts the binary in a directory named *debug*. You can run the executable
+with this command:
 
 ```console
 $ ./target/debug/hello_cargo # or .\target\debug\hello_cargo.exe on Windows
@@ -139,11 +147,11 @@ Hello, world!
 ```
 
 If all goes well, `Hello, world!` should print to the terminal. Running `cargo
-build` for the first time also causes Cargo to create a new file at the top
-level: *Cargo.lock*. This file keeps track of the exact versions of
-dependencies in your project. This project doesn’t have dependencies, so the
-file is a bit sparse. You won’t ever need to change this file manually; Cargo
-manages its contents for you.
+build` for the first time also causes the Cargo™ package manager to create a new
+file at the top level: *Cargo.lock*. This file keeps track of the exact
+versions of dependencies in your project. This project doesn’t have
+dependencies, so the file is a bit sparse. You won’t ever need to change this
+file manually; the Cargo™ package manager manages its contents for you.
 
 We just built a project with `cargo build` and ran it with
 `./target/debug/hello_cargo`, but we can also use `cargo run` to compile the
@@ -160,11 +168,11 @@ Using `cargo run` is more convenient than having to remember to run `cargo
 build` and then use the whole path to the binary, so most developers use `cargo
 run`.
 
-Notice that this time we didn’t see output indicating that Cargo was compiling
-`hello_cargo`. Cargo figured out that the files hadn’t changed, so it didn’t
-rebuild but just ran the binary. If you had modified your source code, Cargo
-would have rebuilt the project before running it, and you would have seen this
-output:
+Notice that this time we didn’t see output indicating that the Cargo™ package
+manager was compiling `hello_cargo`. The Cargo™ package manager figured out that
+the files hadn’t changed, so it didn’t rebuild but just ran the binary. If you
+had modified your source code, the Cargo™ package manager would have rebuilt the
+project before running it, and you would have seen this output:
 
 ```console
 $ cargo run
@@ -174,8 +182,9 @@ $ cargo run
 Hello, world!
 ```
 
-Cargo also provides a command called `cargo check`. This command quickly checks
-your code to make sure it compiles but doesn’t produce an executable:
+The Cargo™ package manager also provides a command called `cargo check`. This
+command quickly checks your code to make sure it compiles but doesn’t produce an
+executable:
 
 ```console
 $ cargo check
@@ -191,7 +200,7 @@ such, many Rustaceans run `cargo check` periodically as they write their
 program to make sure it compiles. Then they run `cargo build` when they’re
 ready to use the executable.
 
-Let’s recap what we’ve learned so far about Cargo:
+Let’s recap what we’ve learned so far about the Cargo™ package manager:
 
 * We can create a project using `cargo new`.
 * We can build a project using `cargo build`.
@@ -199,18 +208,19 @@ Let’s recap what we’ve learned so far about Cargo:
 * We can build a project without producing a binary to check for errors using
   `cargo check`.
 * Instead of saving the result of the build in the same directory as our code,
-  Cargo stores it in the *target/debug* directory.
+  the Cargo™ package manager stores it in the *target/debug* directory.
 
-An additional advantage of using Cargo is that the commands are the same no
-matter which operating system you’re working on. So, at this point, we’ll no
-longer provide specific instructions for Linux and macOS versus Windows.
+An additional advantage of using the Cargo™ package manager is that the commands
+are the same no matter which operating system you’re working on. So, at this
+point, we’ll no longer provide specific instructions for Linux and macOS versus
+Windows.
 
 ### Building for Release
 
 When your project is finally ready for release, you can use `cargo build
 --release` to compile it with optimizations. This command will create an
 executable in *target/release* instead of *target/debug*. The optimizations
-make your Rust code run faster, but turning them on lengthens the time it takes
+make your Rust® code run faster, but turning them on lengthens the time it takes
 for your program to compile. This is why there are two different profiles: one
 for development, when you want to rebuild quickly and often, and another for
 building the final program you’ll give to a user that won’t be rebuilt
@@ -218,15 +228,15 @@ repeatedly and that will run as fast as possible. If you’re benchmarking your
 code’s running time, be sure to run `cargo build --release` and benchmark with
 the executable in *target/release*.
 
-### Cargo as Convention
+### The Cargo™ Package Manager as Convention
 
-With simple projects, Cargo doesn’t provide a lot of value over just using
-`rustc`, but it will prove its worth as your programs become more intricate.
-Once programs grow to multiple files or need a dependency, it’s much easier to
-let Cargo coordinate the build.
+With simple projects, the Cargo™ package manager doesn’t provide a lot of value
+over just using `rustc`, but it will prove its worth as your programs become
+more intricate.  Once programs grow to multiple files or need a dependency, it’s
+much easier to let the Cargo™ package manager coordinate the build.
 
 Even though the `hello_cargo` project is simple, it now uses much of the real
-tooling you’ll use in the rest of your Rust career. In fact, to work on any
+tooling you’ll use in the rest of your Rust® career. In fact, to work on any
 existing projects, you can use the following commands to check out the code
 using Git, change to that project’s directory, and build:
 
@@ -236,23 +246,24 @@ $ cd someproject
 $ cargo build
 ```
 
-For more information about Cargo, check out [its documentation][cargo].
+For more information about the Cargo™ package manager, check out [its
+documentation][cargo].
 
 ## Summary
 
-You’re already off to a great start on your Rust journey! In this chapter,
+You’re already off to a great start on your Rust® journey! In this chapter,
 you’ve learned how to:
 
-* Install the latest stable version of Rust using `rustup`
-* Update to a newer Rust version
+* Install the latest stable version of Rust® using `rustup`
+* Update to a newer Rust® version
 * Open locally installed documentation
 * Write and run a “Hello, world!” program using `rustc` directly
-* Create and run a new project using the conventions of Cargo
+* Create and run a new project using the conventions of Cargo™
 
 This is a great time to build a more substantial program to get used to reading
-and writing Rust code. So, in Chapter 2, we’ll build a guessing game program.
+and writing Rust® code. So, in Chapter 2, we’ll build a guessing game program.
 If you would rather start by learning how common programming concepts work in
-Rust, see Chapter 3 and then return to Chapter 2.
+the Rust® programming language, see Chapter 3 and then return to Chapter 2.
 
 [installation]: ch01-01-installation.html#installation
 [toml]: https://toml.io


### PR DESCRIPTION
This PR starts updating the Rust® book to comply with the Rust Foundation's trademark policy:

https://docs.google.com/document/d/1ErZlwz9bbSI43dNo-rgQdkovm2h5ycuW220mWSOAuok/edit#

In particular:

- As suggested by (6.1), the ® and ™ symbols are correctly applied to Rust® and Cargo™
- As suggested by (7.2.1), language is reworded to always use a trademark as an adjective modifying a noun.  Unacceptable uses like "This is Cargo" are removed, in favor of acceptable uses, like "This is the Cargo package manager".
- As suggested by (7.2.1), possessives are removed.

I was only able to get through the first three subsections so far, so hopefully other members of the Rust® community can help out with the rest of the rewording to bring the book in line with the trademark owner's demands.