### PR TITLE
ch06-06: Add explicit Option type to 

### DIFF
--- a/listings/ch06-enums-and-pattern-matching/listing-06-06/src/main.rs
+++ b/listings/ch06-enums-and-pattern-matching/listing-06-06/src/main.rs
@@ -1,6 +1,6 @@
 fn main() {
     // ANCHOR: here
-    let config_max = Some(3u8);
+    let config_max: Option<u8> = Some(3u8);
     match config_max {
         Some(max) => println!("The maximum is configured to be {}", max),
         _ => (),

--- a/listings/ch06-enums-and-pattern-matching/no-listing-12-if-let/src/main.rs
+++ b/listings/ch06-enums-and-pattern-matching/no-listing-12-if-let/src/main.rs
@@ -1,6 +1,6 @@
 fn main() {
     // ANCHOR: here
-    let config_max = Some(3u8);
+    let config_max: Option<u8> = Some(3u8);
     if let Some(max) = config_max {
         println!("The maximum is configured to be {}", max);
     }


### PR DESCRIPTION
By defining config_max as an Option enum type instead of the Some enum value, the examples for if let ... = becomes more clear. By passing an Option type to the if let ... = condition it better shows it purpose of running the inner code block only when a Some enum value is passed to it.