### PR TITLE
Change ‘positive’ to ‘non-negative’ in ch02-00

### DIFF
--- a/src/ch02-00-guessing-game-tutorial.md
+++ b/src/ch02-00-guessing-game-tutorial.md
@@ -695,7 +695,7 @@ another type. Here, we use it to convert from a string to a number. We need to
 tell Rust the exact number type we want by using `let guess: u32`. The colon
 (`:`) after `guess` tells Rust we’ll annotate the variable’s type. Rust has a
 few built-in number types; the `u32` seen here is an unsigned, 32-bit integer.
-It’s a good default choice for a small positive number. You’ll learn about
+It’s a good default choice for a small non-negative number. You’ll learn about
 other number types in [Chapter 3][integers]<!-- ignore -->.
 
 Additionally, the `u32` annotation in this example program and the comparison


### PR DESCRIPTION
Positive integers are mathematically defined as those >0, mirroring how negative integers are those <0. Unsigned integers allow zero, so contain non-negative integers, not just positive integers.