### PR TITLE
Update MSVC instructions

### DIFF
--- a/src/ch01-01-installation.md
+++ b/src/ch01-01-installation.md
@@ -59,16 +59,9 @@ the `build-essential` package.
 
 On Windows, go to [https://www.rust-lang.org/tools/install][install] and follow
 the instructions for installing Rust. At some point in the installation, you’ll
-receive a message explaining that you’ll also need the MSVC build tools for
-Visual Studio 2013 or later.
-
-To acquire the build tools, you’ll need to install [Visual Studio
-2022][visualstudio]. When asked which workloads to install, include:
-
-* “Desktop Development with C++”
-* The Windows 10 or 11 SDK
-* The English language pack component, along with any other language pack of
-  your choosing
+be prompted to install Visual Studio. This provides a linker and the native
+libraries needed to compile programs. If you need more help with this step, see
+[https://rust-lang.github.io/rustup/installation/windows-msvc.html][msvc]
 
 The rest of this book uses commands that work in both *cmd.exe* and PowerShell.
 If there are specific differences, we’ll explain which to use.
@@ -143,5 +136,5 @@ sure what it does or how to use it, use the application programming interface
 
 [otherinstall]: https://forge.rust-lang.org/infra/other-installation-methods.html
 [install]: https://www.rust-lang.org/tools/install
-[visualstudio]: https://visualstudio.microsoft.com/downloads/
+[msvc]: https://rust-lang.github.io/rustup/installation/windows-msvc.html
 [community]: https://www.rust-lang.org/community


### PR DESCRIPTION
This simplifies the Windows install instructions and points people towards the rustup docs for more help. The rustup installer itself should give instructions on installing Visual Studio and the rustup documentation can offer more in-depth, up to date, guidance than can be provided by The Book.

cc @rbtcollins, for linking to rustup docs (if this is merged, I'll also need to add a note to rustup's dev docs about keeping the link url stable)