### PR TITLE
Edit a paragraph in ch02-00

### DIFF
--- a/src/ch02-00-guessing-game-tutorial.md
+++ b/src/ch02-00-guessing-game-tutorial.md
@@ -680,11 +680,11 @@ often used when you want to convert a value from one type to another type.
 We bind this new variable to the expression `guess.trim().parse()`. The `guess`
 in the expression refers to the original `guess` variable that contained the
 input as a string. The `trim` method on a `String` instance will eliminate any
-whitespace at the beginning and end, which we must do to be able to compare the
-string to the `u32`, which can only contain numerical data. The user must press
-<span class="keystroke">enter</span> to satisfy `read_line` and input their
-guess, which adds a newline character to the string. For example, if the user
-types <span class="keystroke">5</span> and presses <span
+whitespace at the beginning and end. This is important because to be able to
+compare the string to the `u32`, the string can only contain numerical data. The
+user must press <span class="keystroke">enter</span> to satisfy `read_line` and
+input their guess, which adds a newline character to the string. For example, if
+the user types <span class="keystroke">5</span> and presses <span
 class="keystroke">enter</span>, `guess` looks like this: `5\n`. The `\n`
 represents “newline.” (On Windows, pressing <span
 class="keystroke">enter</span> results in a carriage return and a newline,


### PR DESCRIPTION
The `trim` method on a `String` instance will eliminate any whitespace at the beginning and end. This is important because to be able to compare the string to the `u32`, the string can only contain numerical data.

In the previous version, the dependant clause "can only contain numerical data" described the `u32`. The revised paragraph makes it clear that we are trimming the string so that it contains numerical data only.