### PR TITLE
clarify implicit function returns

### DIFF
--- a/src/ch03-03-how-functions-work.md
+++ b/src/ch03-03-how-functions-work.md
@@ -182,12 +182,13 @@ next.
 ### Functions with Return Values
 
 Functions can return values to the code that calls them. We don’t name return
-values, but we must declare their type after an arrow (`->`). In Rust, the
-return value of the function is synonymous with the value of the final
-expression in the block of the body of a function. You can return early from a
-function by using the `return` keyword and specifying a value, but most
-functions return the last expression implicitly. Here’s an example of a
-function that returns a value:
+values, but we must declare their type after an arrow (`->`). In Rust, a
+function will implicitly default to returning the value of the final
+instruction in its body: if it's an expression, the resulting value is returned;
+and if instead the last instruction is a statement, the `()` unit value will
+be returned. You may also choose to return early from a function by using
+the `return` keyword and specifying a value, but most functions return
+implicitly. Here’s an example of a function that returns a value:
 
 <span class="filename">Filename: src/main.rs</span>
 


### PR DESCRIPTION
* remove the "synonymous with" wording, as it's misleading: early explicit returns means function return values ARE NOT synonymous with the implicit returns.
* clarify that the implicit return value is that of the last _instruction_ rather than _expression_:
```rust
fn five() -> i32 {
    5

    let x = 2;
}
```
    This will implicitly return `()` (because the last instruction is
    a statement), but the last _expression_ in the function is `5`
    (which would be the expected return value according to
    text prior to the current edit).