### PR TITLE
Change Korean translation repo to newer

### DIFF
--- a/src/appendix-06-translation.md
+++ b/src/appendix-06-translation.md
@@ -13,7 +13,7 @@ For resources in languages other than English. Most are still in progress; see
 - [Español](https://github.com/thecodix/book), [alternate](https://github.com/ManRR/rust-book-es)
 - [Italiano](https://github.com/EmanueleGurini/book_it)
 - [Русский](https://github.com/rust-lang-ru/book)
-- [한국어](https://github.com/rinthel/rust-lang-book-ko)
+- [한국어](https://github.com/rust-kr/doc.rust-kr.org)
 - [日本語](https://github.com/rust-lang-ja/book-ja)
 - [Français](https://github.com/Jimskapt/rust-book-fr)
 - [Polski](https://github.com/paytchoo/book-pl)


### PR DESCRIPTION
- The previous URL is my personal repo, which is stopped after translation of 2nd edition.
- The new URL is in the Korean Rust user group, and it still continue to update.