### PR TITLE
Clarify numerical input errors for users

### DIFF
--- a/listings/ch02-guessing-game-tutorial/listing-02-05/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/listing-02-05/src/main.rs
@@ -24,7 +24,10 @@ fn main() {
         // ANCHOR: ch19
         let guess: u32 = match guess.trim().parse() {
             Ok(num) => num,
-            Err(_) => continue,
+            Err(_) => {
+                println!("Invalid postive number");
+                continue;
+            },
         };
         // ANCHOR_END: ch19
 

--- a/listings/ch02-guessing-game-tutorial/listing-02-05/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/listing-02-05/src/main.rs
@@ -25,7 +25,7 @@ fn main() {
         let guess: u32 = match guess.trim().parse() {
             Ok(num) => num,
             Err(_) => {
-                println!("Invalid postive number");
+                println!("Invalid positive number");
                 continue;
             },
         };

--- a/listings/ch02-guessing-game-tutorial/listing-02-06/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/listing-02-06/src/main.rs
@@ -18,7 +18,10 @@ fn main() {
 
         let guess: u32 = match guess.trim().parse() {
             Ok(num) => num,
-            Err(_) => continue,
+            Err(_) => {
+                println!("Invalid number");
+                continue;
+            },
         };
 
         println!("You guessed: {guess}");

--- a/listings/ch02-guessing-game-tutorial/no-listing-03-convert-string-to-number/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/no-listing-03-convert-string-to-number/src/main.rs
@@ -20,7 +20,7 @@ fn main() {
         .read_line(&mut guess)
         .expect("Failed to read line");
 
-    let guess: u32 = guess.trim().parse().expect("Please type a postive number!");
+    let guess: u32 = guess.trim().parse().expect("Please type a number!");
 
     println!("You guessed: {guess}");
 

--- a/listings/ch02-guessing-game-tutorial/no-listing-03-convert-string-to-number/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/no-listing-03-convert-string-to-number/src/main.rs
@@ -20,7 +20,7 @@ fn main() {
         .read_line(&mut guess)
         .expect("Failed to read line");
 
-    let guess: u32 = guess.trim().parse().expect("Please type a number!");
+    let guess: u32 = guess.trim().parse().expect("Please type a postive number!");
 
     println!("You guessed: {guess}");
 

--- a/listings/ch02-guessing-game-tutorial/no-listing-03-convert-string-to-number/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/no-listing-03-convert-string-to-number/src/main.rs
@@ -20,7 +20,7 @@ fn main() {
         .read_line(&mut guess)
         .expect("Failed to read line");
 
-    let guess: u32 = guess.trim().parse().expect("Please type a postive number!");
+    let guess: u32 = guess.trim().parse().expect("Please type a positive number!");
 
     println!("You guessed: {guess}");
 

--- a/listings/ch02-guessing-game-tutorial/no-listing-04-looping/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/no-listing-04-looping/src/main.rs
@@ -25,7 +25,7 @@ fn main() {
             .read_line(&mut guess)
             .expect("Failed to read line");
 
-        let guess: u32 = guess.trim().parse().expect("Please type a number!");
+        let guess: u32 = guess.trim().parse().expect("Please type a positive number!");
 
         println!("You guessed: {guess}");
 

--- a/listings/ch02-guessing-game-tutorial/no-listing-05-quitting/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/no-listing-05-quitting/src/main.rs
@@ -18,7 +18,7 @@ fn main() {
             .read_line(&mut guess)
             .expect("Failed to read line");
 
-        let guess: u32 = guess.trim().parse().expect("Please type a number!");
+        let guess: u32 = guess.trim().parse().expect("Please type a positive number!");
 
         println!("You guessed: {guess}");
 

--- a/listings/ch03-common-programming-concepts/no-listing-15-invalid-array-access/src/main.rs
+++ b/listings/ch03-common-programming-concepts/no-listing-15-invalid-array-access/src/main.rs
@@ -14,7 +14,7 @@ fn main() {
     let index: usize = index
         .trim()
         .parse()
-        .expect("Index entered was not a number");
+        .expect("Index entered was not a positive number");
 
     let element = a[index];
 

--- a/listings/ch03-common-programming-concepts/output-only-01-no-type-annotations/output.txt
+++ b/listings/ch03-common-programming-concepts/output-only-01-no-type-annotations/output.txt
@@ -3,12 +3,12 @@ $ cargo build
 error[E0282]: type annotations needed
  --> src/main.rs:2:9
   |
-2 |     let guess = "42".parse().expect("Not a number!");
+2 |     let guess = "42".parse().expect("Not a positive number!");
   |         ^^^^^
   |
 help: consider giving `guess` an explicit type
   |
-2 |     let guess: _ = "42".parse().expect("Not a number!");
+2 |     let guess: _ = "42".parse().expect("Not a positive number!");
   |              +++
 
 For more information about this error, try `rustc --explain E0282`.

--- a/listings/ch03-common-programming-concepts/output-only-01-no-type-annotations/src/main.rs
+++ b/listings/ch03-common-programming-concepts/output-only-01-no-type-annotations/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    let guess = "42".parse().expect("Not a number!");
+    let guess = "42".parse().expect("Not a positive number!");
 }

--- a/nostarch/chapter03.md
+++ b/nostarch/chapter03.md
@@ -278,7 +278,7 @@ type using `parse` in “Comparing the Guess to the Secret Number” on page XX,
 must add a type annotation, like this:
 
 ```
-let guess: u32 = "42".parse().expect("Not a positive number!");
+let guess: u32 = "42".parse().expect("Not a number!");
 ```
 
 If we don’t add the `: u32` type annotation shown in the preceding code, Rust
@@ -291,7 +291,7 @@ $ cargo build
 error[E0282]: type annotations needed
  --> src/main.rs:2:9
   |
-2 |     let guess = "42".parse().expect("Not a positive number!");
+2 |     let guess = "42".parse().expect("Not a number!");
   |         ^^^^^ consider giving `guess` a type
 ```
 
@@ -670,7 +670,7 @@ fn main() {
     let index: usize = index
         .trim()
         .parse()
-        .expect("Index entered was not a positive number");
+        .expect("Index entered was not a number");
 
     let element = a[index];
 

--- a/nostarch/chapter03.md
+++ b/nostarch/chapter03.md
@@ -670,7 +670,7 @@ fn main() {
     let index: usize = index
         .trim()
         .parse()
-        .expect("Index entered was not a number");
+        .expect("Index entered was not a positive number");
 
     let element = a[index];
 

--- a/nostarch/chapter03.md
+++ b/nostarch/chapter03.md
@@ -278,7 +278,7 @@ type using `parse` in “Comparing the Guess to the Secret Number” on page XX,
 must add a type annotation, like this:
 
 ```
-let guess: u32 = "42".parse().expect("Not a number!");
+let guess: u32 = "42".parse().expect("Not a positive number!");
 ```
 
 If we don’t add the `: u32` type annotation shown in the preceding code, Rust
@@ -291,7 +291,7 @@ $ cargo build
 error[E0282]: type annotations needed
  --> src/main.rs:2:9
   |
-2 |     let guess = "42".parse().expect("Not a number!");
+2 |     let guess = "42".parse().expect("Not a positive number!");
   |         ^^^^^ consider giving `guess` a type
 ```
 

--- a/src/ch03-02-data-types.md
+++ b/src/ch03-02-data-types.md
@@ -13,7 +13,7 @@ Number”][comparing-the-guess-to-the-secret-number]<!-- ignore --> section in
 Chapter 2, we must add a type annotation, like this:
 
 ```rust
-let guess: u32 = "42".parse().expect("Not a number!");
+let guess: u32 = "42".parse().expect("Not a positive number!");
 ```
 
 If we don’t add the `: u32` type annotation shown in the preceding code, Rust


### PR DESCRIPTION
Clarifying that the user should provide a positive number for unsigned integers created from user input