### PR TITLE
Listing 8-14: Add example of emoji use

### DIFF
--- a/listings/ch08-common-collections/listing-08-14/src/main.rs
+++ b/listings/ch08-common-collections/listing-08-14/src/main.rs
@@ -15,5 +15,6 @@ fn main() {
     // ANCHOR: spanish
     let hello = String::from("Hola");
     // ANCHOR_END: spanish
+    let hello = String::from("👋");
     // ANCHOR_END: here
 }


### PR DESCRIPTION
While mentioned earlier in the book, it might be appropriate to include an indication that emoji are valid UTF-8 in Section 8.2. Done here by including an additional line amongst the examples of valid Strings.