### PR TITLE
update listings 11-01 and 11-03 with add function generated by cargo

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "rust-analyzer.linkedProjects": [
+    "./listings/ch11-writing-automated-tests/listing-11-01/Cargo.toml",
+    "./listings/ch11-writing-automated-tests/listing-11-03/Cargo.toml"
+  ]
+}

--- a/listings/ch11-writing-automated-tests/listing-11-01/src/lib.rs
+++ b/listings/ch11-writing-automated-tests/listing-11-01/src/lib.rs
@@ -1,8 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
 #[cfg(test)]
 mod tests {
+    use super::*;
+    
     #[test]
     fn it_works() {
-        let result = 2 + 2;
+        let result = add(2, 2);
         assert_eq!(result, 4);
     }
 }

--- a/listings/ch11-writing-automated-tests/listing-11-03/src/lib.rs
+++ b/listings/ch11-writing-automated-tests/listing-11-03/src/lib.rs
@@ -1,8 +1,7 @@
+// ANCHOR: here
 pub fn add(left: usize, right: usize) -> usize {
     left + right
 }
-
-// ANCHOR: here
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/listings/ch11-writing-automated-tests/listing-11-03/src/lib.rs
+++ b/listings/ch11-writing-automated-tests/listing-11-03/src/lib.rs
@@ -1,9 +1,15 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
 // ANCHOR: here
 #[cfg(test)]
 mod tests {
+    use super::*;
     #[test]
     fn exploration() {
-        assert_eq!(2 + 2, 4);
+        let result = add(2, 2);
+        assert_eq!(result, 4);
     }
 
     #[test]


### PR DESCRIPTION
This updates the testing code in chapter 11 to reflect what cargo will generate when running `cargo new adder --lib`.