### PR TITLE
Parity with rustup's help

### DIFF
--- a/src/title-page.md
+++ b/src/title-page.md
@@ -8,7 +8,7 @@ to install or update Rust.
 
 The HTML format is available online at
 [https://doc.rust-lang.org/stable/book/](https://doc.rust-lang.org/stable/book/)
-and offline with installations of Rust made with `rustup`; run `rustup docs
+and offline with installations of Rust made with `rustup`; run `rustup doc
 --book` to open.
 
 Several community [translations] are also available.


### PR DESCRIPTION
When `rustup help` is run, it suggests using `rustup doc --book` rather than docs (as the book shows). While docs is a valid alias, I feel that both the book and the help should be the same.

The bottom of `rustup help`:
![image](https://github.com/rust-lang/book/assets/78649849/4e3a4c6f-1f70-41f5-b631-8244a24055a8) 