### PR TITLE
Remove hebrew niqqud in 8-14 String::from example

### DIFF
--- a/listings/ch08-common-collections/listing-08-14/src/main.rs
+++ b/listings/ch08-common-collections/listing-08-14/src/main.rs
@@ -3,7 +3,7 @@ fn main() {
     let hello = String::from("السلام عليكم");
     let hello = String::from("Dobrý den");
     let hello = String::from("Hello");
-    let hello = String::from("שָׁלוֹם");
+    let hello = String::from("שלום");
     let hello = String::from("नमस्ते");
     let hello = String::from("こんにちは");
     let hello = String::from("안녕하세요");


### PR DESCRIPTION
Niqqud (hebrew diacrital system to represent vowels) is mainly used in poetry and in children's book. Israelis do not use niqqud when they write.