### PR TITLE
Change email text to different one on Chapter 5

### DIFF
--- a/nostarch/chapter05.md
+++ b/nostarch/chapter05.md
@@ -191,7 +191,7 @@ fn main() {
 
 
     let user2 = User {
-        email: String::from("another@example.com"),
+        email: String::from("newuser@example.com"),
         ..user1
     };
 }


### PR DESCRIPTION
Hi. While reading this chapter I realised that showing the same email for update operation on specific field (email in this case) is a bit confusing as new and previous emails showed exactly the same. I thought this change should prevent this.