### PR TITLE
Fix variable mutability in code example

### DIFF
--- a/listings/ch03-common-programming-concepts/no-listing-03-shadowing/src/main.rs
+++ b/listings/ch03-common-programming-concepts/no-listing-03-shadowing/src/main.rs
@@ -1,5 +1,5 @@
 fn main() {
-    let x = 5;
+    let mut x = 5;
 
     let x = x + 1;
 


### PR DESCRIPTION
The code example in the book had a mistake where the variable `x` was declared as immutable (`let x = 5;`) instead of mutable. This mistake was misleading to learners as it implied that the variable could not be modified. To rectify this issue, the commit corrects the variable mutability by adding the `mut` keyword (`let mut x = 5;`), enabling the modification of `x` later in the code.