### PR TITLE
Clarify how deref coercions interact with traits

### DIFF
--- a/src/ch15-02-deref.md
+++ b/src/ch15-02-deref.md
@@ -294,6 +294,15 @@ initial immutable reference is the only immutable reference to that data, but
 the borrowing rules don’t guarantee that. Therefore, Rust can’t make the
 assumption that converting an immutable reference to a mutable reference is
 possible.
+  
+### Deref Coercion and Traits
+  
+The compiler only performs deref coercion when matching traits if the trait method is
+called via the dot operator (e.g `x.into()`), and not when the method is called
+using 'fully-qualified' syntax (e.g `SomeType::from(&x)`).
+
+For more information, see the [Nomicon][nomicon-coercions].
 
 [impl-trait]: ch10-02-traits.html#implementing-a-trait-on-a-type
 [tuple-structs]: ch05-01-defining-structs.html#using-tuple-structs-without-named-fields-to-create-different-types
+[nomicon-coercions]: https://doc.rust-lang.org/nomicon/coercions.html


### PR DESCRIPTION
The book currently doesn't state that deref coercions don't always happen when matching traits, which has led to some confusion (see https://github.com/rust-lang/rust/issues/109829). The nomicon does state this, but that is aimed at a different audience to the book.

