### PR TITLE
Use more accurate term for numerals

### DIFF
--- a/src/ch08-02-strings.md
+++ b/src/ch08-02-strings.md
@@ -244,7 +244,7 @@ encoded UTF-8 example strings from Listing 8-14. First, this one:
 In this case, `len` will be 4, which means the vector storing the string “Hola”
 is 4 bytes long. Each of these letters takes 1 byte when encoded in UTF-8. The
 following line, however, may surprise you. (Note that this string begins with
-the capital Cyrillic letter Ze, not the Hindu-Arabic number 3.)
+the capital Cyrillic letter Ze, not the Indo-Arabic number 3.)
 
 ```rust
 {{#rustdoc_include ../listings/ch08-common-collections/listing-08-14/src/main.rs:russian}}

--- a/src/ch08-02-strings.md
+++ b/src/ch08-02-strings.md
@@ -244,7 +244,7 @@ encoded UTF-8 example strings from Listing 8-14. First, this one:
 In this case, `len` will be 4, which means the vector storing the string “Hola”
 is 4 bytes long. Each of these letters takes 1 byte when encoded in UTF-8. The
 following line, however, may surprise you. (Note that this string begins with
-the capital Cyrillic letter Ze, not the Arabic number 3.)
+the capital Cyrillic letter Ze, not the Hindu-Arabic number 3.)
 
 ```rust
 {{#rustdoc_include ../listings/ch08-common-collections/listing-08-14/src/main.rs:russian}}


### PR DESCRIPTION
Hi team,

I noticed that in the documentation, the number 3 is referred to as "Arabic number". But it can be misleading, as it could give the impression that the numerals were invented in Arabic-speaking countries.

For the sake of accuracy, I would suggest that we use the term "Hindu-Arabic number" in the documentation. This term is more accurate and would avoid any potential confusion.

Here is a link to a Wikipedia article that confirms the correct term: https://en.wikipedia.org/wiki/Hindu%E2%80%93Arabic_numeral_system

I have made a change to the documentation to reflect this. Please let me know if you have any questions.