### PR TITLE
Update ch13-01-closures.md

### DIFF
--- a/src/ch13-01-closures.md
+++ b/src/ch13-01-closures.md
@@ -121,7 +121,7 @@ to line up the relevant parts. This illustrates how closure syntax is similar
 to function syntax except for the use of pipes and the amount of syntax that is
 optional:
 
-```rust,ignore
+```rust,ignore,does_not_compile
 fn  add_one_v1   (x: u32) -> u32 { x + 1 }
 let add_one_v2 = |x: u32| -> u32 { x + 1 };
 let add_one_v3 = |x|             { x + 1 };


### PR DESCRIPTION
Just a quick non_compiling ferris added to the code between listing 13-2 and 13-3:
> ```
> fn  add_one_v1   (x: u32) -> u32 { x + 1 }
> let add_one_v2 = |x: u32| -> u32 { x + 1 };
> let add_one_v3 = |x|             { x + 1 };
> let add_one_v4 = |x|               x + 1  ;
> ```
for better understanding of closures and how v3 and v4 need to be called properly in order to compile, so without calling them, just declaring them as above it would not compile, i spent some time thinking this behaviour was not expected altough it is kind of explained a few sentences later