### PR TITLE
Ch. 4: Rephrase/clarify paragraph on reference scope

### DIFF
--- a/src/ch04-02-references-and-borrowing.md
+++ b/src/ch04-02-references-and-borrowing.md
@@ -167,8 +167,8 @@ reading of the data.
 
 Note that a reference’s scope starts from where it is introduced and continues
 through the last time that reference is used. For instance, this code will
-compile because at the last usage of the immutable references, the `println!`,
-occurs before the mutable reference is introduced:
+compile because the last usage of the immutable references is in the `println!`,
+before the mutable reference is introduced:
 
 ```rust,edition2021
 {{#rustdoc_include ../listings/ch04-understanding-ownership/no-listing-13-reference-scope-ends/src/main.rs:here}}

--- a/src/ch04-02-references-and-borrowing.md
+++ b/src/ch04-02-references-and-borrowing.md
@@ -167,7 +167,7 @@ reading of the data.
 
 Note that a reference’s scope starts from where it is introduced and continues
 through the last time that reference is used. For instance, this code will
-compile because the last usage of the immutable references, the `println!`,
+compile because at the last usage of the immutable references, the `println!`,
 occurs before the mutable reference is introduced:
 
 ```rust,edition2021


### PR DESCRIPTION
I had to read this line more than 4 times to understand it. Having the "at" makes it more readable