### PR TITLE
Remove unnecessary 'but' in paragraph about closure accessibility

### DIFF
--- a/src/ch13-01-closures.md
+++ b/src/ch13-01-closures.md
@@ -194,7 +194,7 @@ if the variable name were a function name.
 
 Because we can have multiple immutable references to `list` at the same time,
 `list` is still accessible from the code before the closure definition, after
-the closure definition but before the closure is called, and after the closure
+the closure definition, before the closure is called, and after the closure
 is called. This code compiles, runs, and prints:
 
 ```console


### PR DESCRIPTION
Hi, 
The [example explaining the closure accessibility](https://doc.rust-lang.org/book/ch13-01-closures.html#capturing-references-or-moving-ownership:~:text=the%20closure%20definition-,but,-before%20the%20closure) seems to have a typo which makes it say a wrong (contrasting) statement.
Since the `list` variable is accessible both before & after the closure is called, the "but" becomes un-necessary, so it's removed in this commit.

Please let me know if you've any suggestions. Thanks!