### PR TITLE
Resolved Button- instance redundancy ch17-02-trait-objects.md

### DIFF
--- a/src/ch17-02-trait-objects.md
+++ b/src/ch17-02-trait-objects.md
@@ -193,7 +193,7 @@ rather than the value’s concrete type—is similar to the concept of *duck
 typing* in dynamically typed languages: if it walks like a duck and quacks
 like a duck, then it must be a duck! In the implementation of `run` on `Screen`
 in Listing 17-5, `run` doesn’t need to know what the concrete type of each
-component is. It doesn’t check whether a component is an instance of a `Button`
+component is. It doesn’t check whether a component is a `Button`
 or a `SelectBox`, it just calls the `draw` method on the component. By
 specifying `Box<dyn Draw>` as the type of the values in the `components`
 vector, we’ve defined `Screen` to need values that we can call the `draw`


### PR DESCRIPTION
This PR will fix  #3632 .
**Changes**: Replaced instance of Button to a Button in [ch17-02-trait-objects](https://github.com/rust-lang/book/blob/main/src/ch17-02-trait-objects.md).