### PR TITLE
redirects: change link for the `#![no_std]` tutorial

### DIFF
--- a/redirects/using-rust-without-the-standard-library.md
+++ b/redirects/using-rust-without-the-standard-library.md
@@ -7,11 +7,11 @@
 
 ---
 
-This particular chapter has moved to [the Unstable Book][2].
+This particular chapter has moved to [the Rustonomicon][2].
 
-* **[In the Unstable Rust Book: `lang_items` — Writing an executable without stdlib][2]**
+* **[In the Rustonomicon: Beneath std][2]**
 * <small>[In the first edition: Ch 4.12 — Using Rust without the Standard Library][1]</small>
 
 
 [1]: https://doc.rust-lang.org/1.30.0/book/first-edition/using-rust-without-the-standard-library.html
-[2]: ../unstable-book/language-features/lang-items.html#writing-an-executable-without-stdlib
+[2]: ../nomicon/beneath-std.html


### PR DESCRIPTION
rust-lang/rust#113715 is blocked on this PR. Click there for context.

Changes the link in `redirects/using-rust-without-the-standard-library.md` to <https://doc.rust-lang.org/nomicon/beneath-std.html>, which is currently empty but will be filled if rust-lang/nomicon#413 gets merged.