### PR TITLE
Update loop to Result: 10

### DIFF
--- a/listings/ch16-fearless-concurrency/listing-16-15/src/main.rs
+++ b/listings/ch16-fearless-concurrency/listing-16-15/src/main.rs
@@ -5,12 +5,6 @@ fn main() {
     let counter = Arc::new(Mutex::new(0));
     let mut handles = vec![];
 
-    // The chapters accompanying text states that the print should be :
-    // Result: 10
-    // But the current code yields :
-    // Result: 9
-    // An update to this should resolve the drift between text and code :
-    // 1..=10 - is a range that is inclusive of 1 and inclusive of 10
     for _ in 0..=10 {
         let counter = Arc::clone(&counter);
         let handle = thread::spawn(move || {

--- a/listings/ch16-fearless-concurrency/listing-16-15/src/main.rs
+++ b/listings/ch16-fearless-concurrency/listing-16-15/src/main.rs
@@ -5,7 +5,13 @@ fn main() {
     let counter = Arc::new(Mutex::new(0));
     let mut handles = vec![];
 
-    for _ in 0..10 {
+    // The chapters accompanying text states that the print should be :
+    // Result: 10
+    // But the current code yields :
+    // Result: 9
+    // An update to this should resolve the drift between text and code :
+    // 1..=10 - is a range that is inclusive of 1 and inclusive of 10
+    for _ in 0..=10 {
         let counter = Arc::clone(&counter);
         let handle = thread::spawn(move || {
             let mut num = counter.lock().unwrap();


### PR DESCRIPTION
Chapter 16-15 has drift between the book text and the code that this PR tries to address 

1. The current code print output is `Result: 9`
2. The text describes that the output should be `Result: 10`

First time OS contribution attempt lol, so any critique and advice appreciated~

For reference the book text :

> Listing 16-15: Using an Arc<T> to wrap the Mutex<T> to be able to share  
ownership across multiple threads

This code will print the following:

```sh
Result: 10
```

We did it! We counted from 0 to 10, which may not seem very impressive, but it  
did teach us a lot about Mutex<T> and thread safety ... <snip>