### PR TITLE
Refer to `--exact` for running the exact one test

### DIFF
--- a/src/ch11-02-running-tests.md
+++ b/src/ch11-02-running-tests.md
@@ -130,6 +130,10 @@ Only the test with the name `one_hundred` ran; the other two tests didn’t matc
 that name. The test output lets us know we had more tests that didn’t run by
 displaying `2 filtered out` at the end.
 
+If a test name is a substring of another test, we can use `-- --exact` argument,
+referring to test function with full path, for example
+`cargo test tests::one_hundred -- --exact`.
+
 We can’t specify the names of multiple tests in this way; only the first value
 given to `cargo test` will be used. But there is a way to run multiple tests.
 


### PR DESCRIPTION
The section on how to run a single test is not precise for cases where test names are substrings of other tests which generates questions like https://stackoverflow.com/questions/54585804/how-to-run-a-specific-unit-test-in-rust.

I propose to point to `--exact` argument for this case. 