### PR TITLE
Reword "`union`s" to "a `union`"

### DIFF
--- a/src/ch19-01-unsafe-rust.md
+++ b/src/ch19-01-unsafe-rust.md
@@ -34,7 +34,7 @@ include the ability to:
 * Call an unsafe function or method
 * Access or modify a mutable static variable
 * Implement an unsafe trait
-* Access fields of `union`s
+* Access fields of a `union`
 
 It’s important to understand that `unsafe` doesn’t turn off the borrow checker
 or disable any other of Rust’s safety checks: if you use a reference in unsafe


### PR DESCRIPTION
As I was reading about unsafe Rust I came across the line "Access fields of `union`s". 

The generated HTML from Markdown displayed the "s" as a separate letter from the intended word "unions".

This led me to think that there was an 's' union, perhaps some sort of sensitive union that you can only access in unsafe mode.

I'm reworded this line to "Access fields of a `union`" to make it more clear and display cleanly.