### PR TITLE
Fix typo in Chapter 7 Section 3

### DIFF
--- a/src/ch07-03-paths-for-referring-to-an-item-in-the-module-tree.md
+++ b/src/ch07-03-paths-for-referring-to-an-item-in-the-module-tree.md
@@ -185,7 +185,7 @@ interested in this topic, see [The Rust API Guidelines][api-guidelines].
 > package name by default. Typically, packages with this pattern of containing
 > both a library and a binary crate will have just enough code in the binary
 > crate to start an executable that calls code with the library crate. This
-> lets other projects benefit from the most functionality that the package
+> lets other projects benefit from most of the functionality that the package
 > provides, because the library crate’s code can be shared.
 >
 > The module tree should be defined in *src/lib.rs*. Then, any public items can


### PR DESCRIPTION
Fix typo in Chapter 7 Section 3, changing "benefit from the most functionality" to "benefit from most of the functionality"