### PR TITLE
Fix cargo doc links

### DIFF
--- a/src/ch02-00-guessing-game-tutorial.md
+++ b/src/ch02-00-guessing-game-tutorial.md
@@ -930,8 +930,8 @@ discusses structs and method syntax, and Chapter 6 explains how enums work.
 [randcrate]: https://crates.io/crates/rand
 [semver]: http://semver.org
 [cratesio]: https://crates.io/
-[doccargo]: http://doc.crates.io
-[doccratesio]: http://doc.crates.io/crates-io.html
+[doccargo]: https://doc.rust-lang.org/cargo/
+[doccratesio]: https://doc.rust-lang.org/cargo/reference/publishing.html
 [match]: ch06-02-match.html
 [shadowing]: ch03-01-variables-and-mutability.html#shadowing
 [parse]: ../std/primitive.str.html#method.parse


### PR DESCRIPTION
A long time ago, doc.crates.io was changed to redirect to doc.rust-lang.org/cargo/. This PR updates the links to use the more modern locations. This is motivated by the fact that we have accidentally broken those redirects. We hope to have them fixed eventually, but I'm not sure when. I think it would be good to update these links regardless.