### PR TITLE
change format of cargo compile finish time taken

### DIFF
--- a/listings/ch12-an-io-project/listing-12-02/output.txt
+++ b/listings/ch12-an-io-project/listing-12-02/output.txt
@@ -1,6 +1,6 @@
 $ cargo run -- test sample.txt
    Compiling minigrep v0.1.0 (file:///projects/minigrep)
-    Finished dev [unoptimized + debuginfo] target(s) in 0.0s
+    Finished dev [unoptimized + debuginfo] target(s) in 0.00s
      Running `target/debug/minigrep test sample.txt`
 Searching for test
 In file sample.txt

--- a/listings/ch12-an-io-project/listing-12-04/output.txt
+++ b/listings/ch12-an-io-project/listing-12-04/output.txt
@@ -1,6 +1,6 @@
 $ cargo run -- the poem.txt
    Compiling minigrep v0.1.0 (file:///projects/minigrep)
-    Finished dev [unoptimized + debuginfo] target(s) in 0.0s
+    Finished dev [unoptimized + debuginfo] target(s) in 0.00s
      Running `target/debug/minigrep the poem.txt`
 Searching for the
 In file poem.txt

--- a/listings/ch12-an-io-project/listing-12-07/output.txt
+++ b/listings/ch12-an-io-project/listing-12-07/output.txt
@@ -1,6 +1,6 @@
 $ cargo run
    Compiling minigrep v0.1.0 (file:///projects/minigrep)
-    Finished dev [unoptimized + debuginfo] target(s) in 0.0s
+    Finished dev [unoptimized + debuginfo] target(s) in 0.00s
      Running `target/debug/minigrep`
 thread 'main' panicked at 'index out of bounds: the len is 1 but the index is 1', src/main.rs:27:21
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/listings/ch12-an-io-project/listing-12-08/output.txt
+++ b/listings/ch12-an-io-project/listing-12-08/output.txt
@@ -1,6 +1,6 @@
 $ cargo run
    Compiling minigrep v0.1.0 (file:///projects/minigrep)
-    Finished dev [unoptimized + debuginfo] target(s) in 0.0s
+    Finished dev [unoptimized + debuginfo] target(s) in 0.00s
      Running `target/debug/minigrep`
 thread 'main' panicked at 'not enough arguments', src/main.rs:26:13
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/listings/ch12-an-io-project/listing-12-23/output.txt
+++ b/listings/ch12-an-io-project/listing-12-23/output.txt
@@ -1,6 +1,6 @@
 $ cargo run -- to poem.txt
    Compiling minigrep v0.1.0 (file:///projects/minigrep)
-    Finished dev [unoptimized + debuginfo] target(s) in 0.0s
+    Finished dev [unoptimized + debuginfo] target(s) in 0.00s
      Running `target/debug/minigrep to poem.txt`
 Are you nobody, too?
 How dreary to be somebody!

--- a/listings/ch12-an-io-project/output-only-03-multiple-matches/output.txt
+++ b/listings/ch12-an-io-project/output-only-03-multiple-matches/output.txt
@@ -1,6 +1,6 @@
 $ cargo run -- body poem.txt
    Compiling minigrep v0.1.0 (file:///projects/minigrep)
-    Finished dev [unoptimized + debuginfo] target(s) in 0.0s
+    Finished dev [unoptimized + debuginfo] target(s) in 0.00s
      Running `target/debug/minigrep body poem.txt`
 I'm nobody! Who are you?
 Are you nobody, too?

--- a/listings/ch12-an-io-project/output-only-04-no-matches/output.txt
+++ b/listings/ch12-an-io-project/output-only-04-no-matches/output.txt
@@ -1,4 +1,4 @@
 $ cargo run -- monomorphization poem.txt
    Compiling minigrep v0.1.0 (file:///projects/minigrep)
-    Finished dev [unoptimized + debuginfo] target(s) in 0.0s
+    Finished dev [unoptimized + debuginfo] target(s) in 0.00s
      Running `target/debug/minigrep monomorphization poem.txt`

--- a/nostarch/chapter01.md
+++ b/nostarch/chapter01.md
@@ -482,7 +482,7 @@ entering the following command:
 ```
 $ cargo build
    Compiling hello_cargo v0.1.0 (file:///projects/hello_cargo)
-    Finished dev [unoptimized + debuginfo] target(s) in 2.85 secs
+    Finished dev [unoptimized + debuginfo] target(s) in 2.85s
 ```
 
 This command creates an executable file in *target/debug/hello_cargo* (or
@@ -508,7 +508,7 @@ code and then run the resultant executable all in one command:
 
 ```
 $ cargo run
-    Finished dev [unoptimized + debuginfo] target(s) in 0.0 secs
+    Finished dev [unoptimized + debuginfo] target(s) in 0.00s
      Running `target/debug/hello_cargo`
 Hello, world!
 ```
@@ -526,7 +526,7 @@ output:
 ```
 $ cargo run
    Compiling hello_cargo v0.1.0 (file:///projects/hello_cargo)
-    Finished dev [unoptimized + debuginfo] target(s) in 0.33 secs
+    Finished dev [unoptimized + debuginfo] target(s) in 0.33s
      Running `target/debug/hello_cargo`
 Hello, world!
 ```
@@ -537,7 +537,7 @@ your code to make sure it compiles but doesn’t produce an executable:
 ```
 $ cargo check
    Checking hello_cargo v0.1.0 (file:///projects/hello_cargo)
-    Finished dev [unoptimized + debuginfo] target(s) in 0.32 secs
+    Finished dev [unoptimized + debuginfo] target(s) in 0.32s
 ```
 
 Why would you not want an executable? Often, `cargo check` is much faster than

--- a/nostarch/chapter02.md
+++ b/nostarch/chapter02.md
@@ -445,7 +445,7 @@ build again, you’ll only see two lines of output:
 ```
 $ cargo build
    Compiling guessing_game v0.1.0 (file:///projects/guessing_game)
-    Finished dev [unoptimized + debuginfo] target(s) in 2.53 secs
+    Finished dev [unoptimized + debuginfo] target(s) in 2.53s
 ```
 
 These lines show that Cargo only updates the build with your tiny change to the

--- a/nostarch/chapter12.md
+++ b/nostarch/chapter12.md
@@ -194,7 +194,7 @@ and `sample.txt`:
 ```
 $ cargo run -- test sample.txt
    Compiling minigrep v0.1.0 (file:///projects/minigrep)
-    Finished dev [unoptimized + debuginfo] target(s) in 0.0s
+    Finished dev [unoptimized + debuginfo] target(s) in 0.00s
      Running `target/debug/minigrep test sample.txt`
 Searching for test
 In file sample.txt
@@ -270,7 +270,7 @@ second argument:
 ```
 $ cargo run -- the poem.txt
    Compiling minigrep v0.1.0 (file:///projects/minigrep)
-    Finished dev [unoptimized + debuginfo] target(s) in 0.0s
+    Finished dev [unoptimized + debuginfo] target(s) in 0.00s
      Running `target/debug/minigrep the poem.txt`
 Searching for the
 In file poem.txt
@@ -553,7 +553,7 @@ without any arguments; it will look like this:
 ```
 $ cargo run
    Compiling minigrep v0.1.0 (file:///projects/minigrep)
-    Finished dev [unoptimized + debuginfo] target(s) in 0.0s
+    Finished dev [unoptimized + debuginfo] target(s) in 0.00s
      Running `target/debug/minigrep`
 thread 'main' panicked at 'index out of bounds: the len is 1 but
 the index is 1', src/main.rs:27:21
@@ -598,7 +598,7 @@ arguments again to see what the error looks like now:
 ```
 $ cargo run
    Compiling minigrep v0.1.0 (file:///projects/minigrep)
-    Finished dev [unoptimized + debuginfo] target(s) in 0.0s
+    Finished dev [unoptimized + debuginfo] target(s) in 0.00s
      Running `target/debug/minigrep`
 thread 'main' panicked at 'not enough arguments',
 src/main.rs:26:13
@@ -1275,7 +1275,7 @@ Cool! Now let’s try a word that will match multiple lines, like *body*:
 
 ```
 $ cargo run -- body poem.txt
-    Finished dev [unoptimized + debuginfo] target(s) in 0.0s
+    Finished dev [unoptimized + debuginfo] target(s) in 0.00s
      Running `target/debug/minigrep body poem.txt`
 I'm nobody! Who are you?
 Are you nobody, too?
@@ -1287,7 +1287,7 @@ word that isn’t anywhere in the poem, such as *monomorphization*:
 
 ```
 $ cargo run -- monomorphization poem.txt
-    Finished dev [unoptimized + debuginfo] target(s) in 0.0s
+    Finished dev [unoptimized + debuginfo] target(s) in 0.00s
      Running `target/debug/minigrep monomorphization poem.txt`
 ```
 
@@ -1545,7 +1545,7 @@ the word *to* in all lowercase:
 ```
 $ cargo run -- to poem.txt
    Compiling minigrep v0.1.0 (file:///projects/minigrep)
-    Finished dev [unoptimized + debuginfo] target(s) in 0.0s
+    Finished dev [unoptimized + debuginfo] target(s) in 0.00s
      Running `target/debug/minigrep to poem.txt`
 Are you nobody, too?
 How dreary to be somebody!

--- a/nostarch/chapter14.md
+++ b/nostarch/chapter14.md
@@ -38,9 +38,9 @@ These profile names might be familiar from the output of your builds:
 
 ```
 $ cargo build
-    Finished dev [unoptimized + debuginfo] target(s) in 0.0s
+    Finished dev [unoptimized + debuginfo] target(s) in 0.00s
 $ cargo build --release
-    Finished release [optimized] target(s) in 0.0s
+    Finished release [optimized] target(s) in 0.00s
 ```
 
 The `dev` and `release` are these different profiles used by the compiler.
@@ -773,7 +773,7 @@ with `cargo run`:
 
 ```
 $ cargo run -p adder
-    Finished dev [unoptimized + debuginfo] target(s) in 0.0s
+    Finished dev [unoptimized + debuginfo] target(s) in 0.00s
      Running `target/debug/adder`
 Hello, world! 10 plus one is 11!
 ```

--- a/src/ch01-03-hello-cargo.md
+++ b/src/ch01-03-hello-cargo.md
@@ -125,7 +125,7 @@ entering the following command:
 ```console
 $ cargo build
    Compiling hello_cargo v0.1.0 (file:///projects/hello_cargo)
-    Finished dev [unoptimized + debuginfo] target(s) in 2.85 secs
+    Finished dev [unoptimized + debuginfo] target(s) in 2.85s
 ```
 
 This command creates an executable file in *target/debug/hello_cargo* (or
@@ -151,7 +151,7 @@ code and then run the resultant executable all in one command:
 
 ```console
 $ cargo run
-    Finished dev [unoptimized + debuginfo] target(s) in 0.0 secs
+    Finished dev [unoptimized + debuginfo] target(s) in 0.00s
      Running `target/debug/hello_cargo`
 Hello, world!
 ```
@@ -169,7 +169,7 @@ output:
 ```console
 $ cargo run
    Compiling hello_cargo v0.1.0 (file:///projects/hello_cargo)
-    Finished dev [unoptimized + debuginfo] target(s) in 0.33 secs
+    Finished dev [unoptimized + debuginfo] target(s) in 0.33s
      Running `target/debug/hello_cargo`
 Hello, world!
 ```
@@ -180,7 +180,7 @@ your code to make sure it compiles but doesn’t produce an executable:
 ```console
 $ cargo check
    Checking hello_cargo v0.1.0 (file:///projects/hello_cargo)
-    Finished dev [unoptimized + debuginfo] target(s) in 0.32 secs
+    Finished dev [unoptimized + debuginfo] target(s) in 0.32s
 ```
 
 Why would you not want an executable? Often, `cargo check` is much faster than

--- a/src/ch02-00-guessing-game-tutorial.md
+++ b/src/ch02-00-guessing-game-tutorial.md
@@ -433,7 +433,7 @@ cargo build -->
 ```console
 $ cargo build
    Compiling guessing_game v0.1.0 (file:///projects/guessing_game)
-    Finished dev [unoptimized + debuginfo] target(s) in 2.53 secs
+    Finished dev [unoptimized + debuginfo] target(s) in 2.53s
 ```
 
 These lines show that Cargo only updates the build with your tiny change to the

--- a/src/ch14-01-release-profiles.md
+++ b/src/ch14-01-release-profiles.md
@@ -21,9 +21,9 @@ and ensure output below is accurate
 
 ```console
 $ cargo build
-    Finished dev [unoptimized + debuginfo] target(s) in 0.0s
+    Finished dev [unoptimized + debuginfo] target(s) in 0.00s
 $ cargo build --release
-    Finished release [optimized] target(s) in 0.0s
+    Finished release [optimized] target(s) in 0.00s
 ```
 
 The `dev` and `release` are these different profiles used by the compiler.

--- a/src/ch14-03-cargo-workspaces.md
+++ b/src/ch14-03-cargo-workspaces.md
@@ -179,7 +179,7 @@ copy output below; the output updating script doesn't handle subdirectories in p
 
 ```console
 $ cargo run -p adder
-    Finished dev [unoptimized + debuginfo] target(s) in 0.0s
+    Finished dev [unoptimized + debuginfo] target(s) in 0.00s
      Running `target/debug/adder`
 Hello, world! 10 plus one is 11!
 ```


### PR DESCRIPTION
Very very minor change that changes the format of cargo's compile message.

There were a couple of cargo messages formatted as `1.23 secs`, which doesn't seem to be what cargo outputs nowadays. Also, there were a couple of `0.0s` instead of `0.00s`. Changed all of them to match what cargo actually outputs now, which is `1.23s`.

Not exactly sure which version of cargo this changes in, but at least on stable windows and stable linux this is the correct format.