### PR TITLE
Add opacity to Ferris when hovering the code block

### DIFF
--- a/ferris.css
+++ b/ferris.css
@@ -24,6 +24,16 @@ body.ayu .not_desired_behavior {
   z-index: 99;
   right: 5px;
   top: 30px;
+  opacity: 1;
+  transition: opacity 0.1s;
+}
+
+pre:hover .ferris-container {
+  opacity: 0.15;
+}
+
+pre:hover .ferris-container:hover {
+  opacity: 1;
 }
 
 .ferris {

--- a/src/ch00-00-introduction.md
+++ b/src/ch00-00-introduction.md
@@ -185,6 +185,10 @@ error. Ferris will also help you distinguish code that isn’t meant to work:
 In most situations, we’ll lead you to the correct version of any code that
 doesn’t compile.
 
+> Note: If Ferris gets in your way by overlaying the code, you can hover on the
+> code block to make Ferris a little transparent. On mobile devices just click
+> on the code block.
+
 ## Source Code
 
 The source files from which this book is generated can be found on

--- a/src/ch00-00-introduction.md
+++ b/src/ch00-00-introduction.md
@@ -185,9 +185,9 @@ error. Ferris will also help you distinguish code that isn’t meant to work:
 In most situations, we’ll lead you to the correct version of any code that
 doesn’t compile.
 
-> Note: If Ferris gets in your way by overlaying the code, you can hover on the
-> code block to make Ferris a little transparent. On mobile devices just click
-> on the code block.
+> Note: If Ferris gets in your way by overlaying the code, you can hover your
+> mouse on the code block to make Ferris a little transparent. On touchscreen
+> devices just tap on the code block.
 
 ## Source Code
 


### PR DESCRIPTION
Fixes #2893

This PR fixes an issue which can be experienced especially on mobile devices. In some cases Ferris overlays the code as it can be seen here:

![photo_2023-10-25_09-05-36](https://github.com/rust-lang/book/assets/14234815/5840c8bf-a67b-4bae-b275-a8a3c8220b29)


This PR adds an opacity to Ferris as soon as the wrapper element (`<pre>`) is hovered.
On mobile the hover state is also given when the user taps an element. So if the user taps on the code, the container receives hover focus and Ferris becomes a little transparent. Then the user can see the code below.


![photo_2023-10-25_09-47-35](https://github.com/rust-lang/book/assets/14234815/7897374f-aa4c-4743-a68f-21dbea4994cd)


When hovering Ferris itself (or clicking it on mobile) the transparency is removed and it becomes "solid" again.


~~If this PR will be accepted it would make sense to add a little notice explaining this behavior to the introduction chapter where Ferris is introduced.~~ Edit: I added the note.
