### PR TITLE
Fixed ch03-05-control-flow.md, replaced `for` with `while`

### DIFF
--- a/src/ch03-05-control-flow.md
+++ b/src/ch03-05-control-flow.md
@@ -295,7 +295,7 @@ This construct eliminates a lot of nesting that would be necessary if you used
 `loop`, `if`, `else`, and `break`, and it’s clearer. While a condition
 evaluates to `true`, the code runs; otherwise, it exits the loop.
 
-#### Looping Through a Collection with `for`
+#### Looping Through a Collection with `while`
 
 You can choose to use the `while` construct to loop over the elements of a
 collection, such as an array. For example, the loop in Listing 3-4 prints each

--- a/src/ch12-04-testing-the-librarys-functionality.md
+++ b/src/ch12-04-testing-the-librarys-functionality.md
@@ -241,5 +241,5 @@ useful when you’re writing command line programs.
 ch10-03-lifetime-syntax.html#validating-references-with-lifetimes
 [ch11-anatomy]: ch11-01-writing-tests.html#the-anatomy-of-a-test-function
 [ch10-lifetimes]: ch10-03-lifetime-syntax.html
-[ch3-iter]: ch03-05-control-flow.html#looping-through-a-collection-with-for
+[ch3-iter]: ch03-05-control-flow.html#looping-through-a-collection-with-while
 [ch13-iterators]: ch13-02-iterators.html


### PR DESCRIPTION
Hi team, 
The section heading was [Looping Through a Collection with for](https://doc.rust-lang.org/book/ch03-05-control-flow.html#looping-through-a-collection-with-for)
and instead the explanation under it is about `while`.
Updated a link in ch12 which caused one of the job to fail