### PR TITLE
Improve ch03-05-control-flow collection looping wording

### DIFF
--- a/src/ch03-05-control-flow.md
+++ b/src/ch03-05-control-flow.md
@@ -297,7 +297,7 @@ evaluates to `true`, the code runs; otherwise, it exits the loop.
 
 #### Looping Through a Collection with `for`
 
-You could choose to use the `while` construct to loop over the elements of a
+You can also use the `while` construct to loop over the elements of a
 collection, such as an array. For example, the loop in Listing 3-4 prints each
 element in the array `a`.
 

--- a/src/ch03-05-control-flow.md
+++ b/src/ch03-05-control-flow.md
@@ -297,7 +297,7 @@ evaluates to `true`, the code runs; otherwise, it exits the loop.
 
 #### Looping Through a Collection with `for`
 
-You can choose to use the `while` construct to loop over the elements of a
+You could choose to use the `while` construct to loop over the elements of a
 collection, such as an array. For example, the loop in Listing 3-4 prints each
 element in the array `a`.
 


### PR DESCRIPTION
This makes it clearer, that you COULD use a `while` loop to loop a collection, but a `for` loop is the preferred way

When reading the section "Looping Through a Collection with `for`" for the first time this morning I was confused it starts with "You can choose to use the `while` construct to loop over the elements of a collection..."
For me it cleared up when reading further.

But also #3757 was created by @Atabic today who also got confused by this. So I think the wording may be improved by using "could" instead of "can".