### PR TITLE
Remove shell prompt from rustup install console block

### DIFF
--- a/src/ch01-01-installation.md
+++ b/src/ch01-01-installation.md
@@ -28,7 +28,7 @@ these steps should work as expected with the content of this book.
 If you’re using Linux or macOS, open a terminal and enter the following command:
 
 ```console
-$ curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | sh
+curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | sh
 ```
 
 The command downloads a script and starts the installation of the `rustup`


### PR DESCRIPTION
The `$` shell prompt in the console block for the rustup install page is included in the clipboard when copying the block for shell execution which means the user has to delete is before execution.

I notice this is the case for all of the console blocks I have seen so far...comment here if you would like me to make this change globally and I'll update this PR. thx