### PR TITLE
Prepare for removal of compiler plugin support.

### DIFF
--- a/redirects/compiler-plugins.md
+++ b/redirects/compiler-plugins.md
@@ -2,12 +2,5 @@
 
 <small>There is a new edition of the book and this is an old link.</small>
 
-> Compiler plugins are user-provided libraries that extend the compiler's behavior with new syntax extensions, lint checks, etc.
-
----
-
-This particular chapter has moved to [the Unstable Book][2].
-
-* **[In the Unstable Rust Book: `plugin`][2]**
-
-[2]: ../unstable-book/language-features/plugin.html
+> Compiler plugins were user-provided libraries that extended the compiler's behavior in certain ways. 
+> Support for them has been removed.


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/116412 will remove support for compiler plugins from rustc, which includes the entry in The Rust Unstable Book. This commit removes a link to that entry so it won't be broken when that PR merges.