### PR TITLE
Fix typo in Chapter 15 Section 05. 

### DIFF
--- a/src/ch15-05-interior-mutability.md
+++ b/src/ch15-05-interior-mutability.md
@@ -61,7 +61,7 @@ multithreaded program in Chapter 16.
 Here is a recap of the reasons to choose `Box<T>`, `Rc<T>`, or `RefCell<T>`:
 
 * `Rc<T>` enables multiple owners of the same data; `Box<T>` and `RefCell<T>`
-  have single owners.
+  have single owner.
 * `Box<T>` allows immutable or mutable borrows checked at compile time; `Rc<T>`
   allows only immutable borrows checked at compile time; `RefCell<T>` allows
   immutable or mutable borrows checked at runtime.


### PR DESCRIPTION
Fix typo in Chapter 15 Section 05. changing:
"`Rc<T>` enables multiple owners of the same data; `Box<T>` and `RefCell<T>` have single owners ." 
to
"`Rc<T>` enables multiple owners of the same data; `Box<T>` and `RefCell<T>` have single owner."