### PR TITLE
Small correction in ch13-01

### DIFF
--- a/listings/ch13-functional-features/listing-13-08/output.txt
+++ b/listings/ch13-functional-features/listing-13-08/output.txt
@@ -3,7 +3,7 @@ $ cargo run
 error[E0507]: cannot move out of `value`, a captured variable in an `FnMut` closure
   --> src/main.rs:18:30
    |
-15 |     let value = String::from("by key called");
+15 |     let value = String::from("closure called");
    |         ----- captured outer variable
 16 |
 17 |     list.sort_by_key(|r| {

--- a/listings/ch13-functional-features/listing-13-08/src/main.rs
+++ b/listings/ch13-functional-features/listing-13-08/src/main.rs
@@ -12,7 +12,7 @@ fn main() {
     ];
 
     let mut sort_operations = vec![];
-    let value = String::from("by key called");
+    let value = String::from("closure called");
 
     list.sort_by_key(|r| {
         sort_operations.push(value);

--- a/src/ch13-01-closures.md
+++ b/src/ch13-01-closures.md
@@ -382,7 +382,7 @@ compiler won’t let us use this closure with `sort_by_key`:
 `sort_by_key`</span>
 
 This is a contrived, convoluted way (that doesn’t work) to try and count the
-number of times `sort_by_key` gets called when sorting `list`. This code
+number of times `sort_by_key` calls the closure when sorting `list`. This code
 attempts to do this counting by pushing `value`—a `String` from the closure’s
 environment—into the `sort_operations` vector. The closure captures `value`
 then moves `value` out of the closure by transferring ownership of `value` to
@@ -399,7 +399,7 @@ implement `FnMut`:
 
 The error points to the line in the closure body that moves `value` out of the
 environment. To fix this, we need to change the closure body so that it doesn’t
-move values out of the environment. To count the number of times `sort_by_key`
+move values out of the environment. To count the number of times the closure
 is called, keeping a counter in the environment and incrementing its value in
 the closure body is a more straightforward way to calculate that. The closure
 in Listing 13-9 works with `sort_by_key` because it is only capturing a mutable


### PR DESCRIPTION
Fix description: the example tries to count the number of times `sort_by_key` calls the closure, not how often `sort_by_key` is called.
Also, use a clearer String value in the example code.