### PR TITLE
🔗 link fix: better link

### DIFF
--- a/src/ch02-00-guessing-game-tutorial.md
+++ b/src/ch02-00-guessing-game-tutorial.md
@@ -917,7 +917,7 @@ types, and functions, and shows how to use them in Rust. Chapter 4 explores
 ownership, a feature that makes Rust different from other languages. Chapter 5
 discusses structs and method syntax, and Chapter 6 explains how enums work.
 
-[prelude]: ../std/prelude/index.html
+[prelude]: ../std/index.html
 [variables-and-mutability]: ch03-01-variables-and-mutability.html#variables-and-mutability
 [comments]: ch03-04-comments.html
 [string]: ../std/string/struct.String.html


### PR DESCRIPTION
Mentioning the prelude link is not conventional, as its mentioned "in the standard library documentation"

changes i made