### PR TITLE
Fix incorrect source in 16.1

### DIFF
--- a/listings/ch16-fearless-concurrency/listing-16-05/src/main.rs
+++ b/listings/ch16-fearless-concurrency/listing-16-05/src/main.rs
@@ -3,9 +3,11 @@ use std::thread;
 fn main() {
     let v = vec![1, 2, 3];
 
-    let handle = thread::spawn(move || {
+    let handle = thread::spawn(|| {
         println!("Here's a vector: {:?}", v);
     });
+
+    drop(v); // oh no!
 
     handle.join().unwrap();
 }

--- a/nostarch/chapter16.md
+++ b/nostarch/chapter16.md
@@ -389,9 +389,11 @@ use std::thread;
 fn main() {
     let v = vec![1, 2, 3];
 
-    let handle = thread::spawn(move || {
+    let handle = thread::spawn(|| {
         println!("Here's a vector: {:?}", v);
     });
+
+    drop(v); // oh no!
 
     handle.join().unwrap();
 }


### PR DESCRIPTION
```
10 | drop(v); // oh no!
   | ^ value used here after move
```

In the book, I should get a compilation error, but the source now passes compilation.

![image](https://github.com/rust-lang/book/assets/9567723/5e859d5e-2bd4-4cd5-a141-41c677ef29c4)


Create a pull request that modifies the source as in the book.

<img width="677" alt="image" src="https://github.com/rust-lang/book/assets/9567723/49c15cc7-0f57-46f2-b1e8-eb7dbce8d34e">
