### PR TITLE
Fix incorrect source in 16.05

### DIFF
--- a/listings/ch16-fearless-concurrency/listing-16-05/src/main.rs
+++ b/listings/ch16-fearless-concurrency/listing-16-05/src/main.rs
@@ -3,9 +3,11 @@ use std::thread;
 fn main() {
     let v = vec![1, 2, 3];
 
-    let handle = thread::spawn(move || {
+    let handle = thread::spawn(|| {
         println!("Here's a vector: {:?}", v);
     });
+
+    drop(v); // oh no!
 
     handle.join().unwrap();
 }

--- a/nostarch/chapter16.md
+++ b/nostarch/chapter16.md
@@ -389,9 +389,11 @@ use std::thread;
 fn main() {
     let v = vec![1, 2, 3];
 
-    let handle = thread::spawn(move || {
+    let handle = thread::spawn(|| {
         println!("Here's a vector: {:?}", v);
     });
+
+    drop(v); // oh no!
 
     handle.join().unwrap();
 }

--- a/src/ch16-01-threads.md
+++ b/src/ch16-01-threads.md
@@ -247,7 +247,7 @@ should borrow the values. The modification to Listing 16-3 shown in Listing
 
 <span class="filename">Filename: src/main.rs</span>
 
-```rust
+```rust,ignore,does_not_compile
 {{#rustdoc_include ../listings/ch16-fearless-concurrency/listing-16-05/src/main.rs}}
 ```
 


### PR DESCRIPTION
```
10 | drop(v); // oh no!
   | ^ value used here after move
```

In the book, I should get a compilation error, but the source now passes compilation.

![image](https://github.com/rust-lang/book/assets/9567723/5e859d5e-2bd4-4cd5-a141-41c677ef29c4)


This pull request modifies the example source to produce compilation errors consistent with the book.

<img width="677" alt="image" src="https://github.com/rust-lang/book/assets/9567723/49c15cc7-0f57-46f2-b1e8-eb7dbce8d34e">



-----

(This image captures that part.)

<img width="579" alt="image" src="https://github.com/rust-lang/book/assets/9567723/1c5441ab-09c3-418b-a7eb-7a11b93a36da">
