### PR TITLE
Update ch04-02-references-and-borrowing.md

### DIFF
--- a/src/ch04-02-references-and-borrowing.md
+++ b/src/ch04-02-references-and-borrowing.md
@@ -98,7 +98,7 @@ with just a few small tweaks that use, instead, a *mutable reference*:
 First we change `s` to be `mut`. Then we create a mutable reference with `&mut
 s` where we call the `change` function, and update the function signature to
 accept a mutable reference with `some_string: &mut String`. This makes it very
-clear that the `change` function will mutate the value it borrows.
+clear that the `change` function can mutate the value it borrows.
 
 Mutable references have one big restriction: if you have a mutable reference to
 a value, you can have no other references to that value. This code that


### PR DESCRIPTION
It is assumed that the change function will mutate the borrowed reference. It depends on the implementation of the function whether it will or will not mutate. It is more appropriate to use the word "can" instead of "will".