### PR TITLE
Typo in code example. Fearless concurrency chapter

### DIFF
--- a/listings/ch16-fearless-concurrency/listing-16-01/src/main.rs
+++ b/listings/ch16-fearless-concurrency/listing-16-01/src/main.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 fn main() {
     thread::spawn(|| {
-        for i in 1..10 {
+        for i in 1..5 {
             println!("hi number {} from the spawned thread!", i);
             thread::sleep(Duration::from_millis(1));
         }


### PR DESCRIPTION
As far, as book [refers](https://github.com/rust-lang/book/blob/main/src/ch16-01-threads.md#creating-a-new-thread-with-spawn) to child thread to count from one to five, it should have enumeration from 1 to 5
