### PR TITLE
Update README to use --locked for installing mdbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ rust-lang/rust uses in [this file][rust-mdbook]. To get it:
 [rust-mdbook]: https://github.com/rust-lang/rust/blob/master/src/tools/rustbook/Cargo.toml
 
 ```bash
-$ cargo install mdbook --version <version_num>
+$ cargo install mdbook --locked --version <version_num>
 ```
 
 ## Building


### PR DESCRIPTION
## Issue

When installing mdbook using the README command using the version referenced 0.4.28 an error is thrown due to some of mdbooks dependencies depending on a newer toolchain (Rust 1.70.0):

```sh
$ cargo install mdbook --version 0.4.28
    Updating crates.io index
  Installing mdbook v0.4.28
error: failed to compile `mdbook v0.4.28`, intermediate artifacts can be found at `/var/folders/f7/t0k51r194wn4_2j6j9bgd2nm0000gn/T/cargo-installVwT6UO`

Caused by:
  package `clap_complete v4.4.9` cannot be built because it requires rustc 1.70.0 or newer, while the currently active rustc version is 1.67.1
  Try re-running cargo install with `--locked`
```

## Solution
Since the book is using the toolchain for Rust 1.67 and some of mdbook's dependencies are unpinned, we should include the --locked command to use the dependencies that were valid at the time of 0.4.28's publish which are compatible with Rust 1.67.

```sh
$ cargo install mdbook --locked --version 0.4.28
...
   Installed package `mdbook v0.4.28` (executable `mdbook`)
```

## Note
I'm new to Rust and this is my first PR for the book. I'm not sure if there is a better solution to this vs. using --locked. When using locked, you get some warnings about yanked packaged (which is unfortunate):

```warning: package `crossbeam-channel v0.5.6` in Cargo.lock is yanked in registry `crates-io`, consider running without --locked```

Looking at issues w/ cargo it seems it doesn't have logic yet to find the best compatible version of a package for your toolchain: https://github.com/rust-lang/cargo/issues/10903

Another option is updating the toolchain for mdbook to the latest version of rust. If that is the preferred solution I'd be glad to give that a try.