### PR TITLE
Update the link to the farsi translation repository

### DIFF
--- a/src/appendix-06-translation.md
+++ b/src/appendix-06-translation.md
@@ -22,7 +22,7 @@ For resources in languages other than English. Most are still in progress; see
 - [Esperanto](https://github.com/psychoslave/Rust-libro)
 - [ελληνική](https://github.com/TChatzigiannakis/rust-book-greek)
 - [Svenska](https://github.com/sebras/book)
-- [Farsi](https://github.com/pomokhtari/rust-book-fa)
+- [Farsi](https://github.com/RustFarsi/book)
 - [Deutsch](https://github.com/rust-lang-de/rustbook-de)
 - [हिंदी](https://github.com/venkatarun95/rust-book-hindi)
 - [ไทย](https://github.com/rust-lang-th/book-th)


### PR DESCRIPTION
The farsi translation of the Rust book has moved to a Github organization. I updated the link to the new repository.