### PR TITLE
ch16-05 - Add missing line in code example

### DIFF
--- a/listings/ch16-fearless-concurrency/listing-16-05/src/main.rs
+++ b/listings/ch16-fearless-concurrency/listing-16-05/src/main.rs
@@ -7,5 +7,7 @@ fn main() {
         println!("Here's a vector: {:?}", v);
     });
 
+    drop(v); // oh no!
+
     handle.join().unwrap();
 }

--- a/src/ch16-01-threads.md
+++ b/src/ch16-01-threads.md
@@ -247,7 +247,7 @@ should borrow the values. The modification to Listing 16-3 shown in Listing
 
 <span class="filename">Filename: src/main.rs</span>
 
-```rust
+```rust,ignore,does_not_compile
 {{#rustdoc_include ../listings/ch16-fearless-concurrency/listing-16-05/src/main.rs}}
 ```
 


### PR DESCRIPTION
According to the [output](https://github.com/rust-lang/book/blob/main/listings/ch16-fearless-concurrency/output-only-01-move-drop/output.txt) of the error shown in the [subsequent paragraph](https://github.com/rust-lang/book/blob/main/src/ch16-01-threads.md?plain=1#L257) the `drop` statement should still be there, while it was removed from the listing src.