### PR TITLE
Fix two typos in 04-03 and 07-03

### DIFF
--- a/src/ch04-03-slices.md
+++ b/src/ch04-03-slices.md
@@ -266,7 +266,7 @@ a string slice for the type of the `s` parameter</span>
 
 If we have a string slice, we can pass that directly. If we have a `String`, we
 can pass a slice of the `String` or a reference to the `String`. This
-flexibility takes advantage of *deref coercions*, a feature we will cover in
+flexibility takes advantage of *deref coercions*, a feature we will cover in the
 [“Implicit Deref Coercions with Functions and
 Methods”][deref-coercions]<!--ignore--> section of Chapter 15.
 

--- a/src/ch07-03-paths-for-referring-to-an-item-in-the-module-tree.md
+++ b/src/ch07-03-paths-for-referring-to-an-item-in-the-module-tree.md
@@ -185,7 +185,7 @@ interested in this topic, see [The Rust API Guidelines][api-guidelines].
 > package name by default. Typically, packages with this pattern of containing
 > both a library and a binary crate will have just enough code in the binary
 > crate to start an executable that calls code with the library crate. This
-> lets other projects benefit from the most functionality that the package
+> lets other projects benefit from most of the functionality that the package
 > provides, because the library crate’s code can be shared.
 >
 > The module tree should be defined in *src/lib.rs*. Then, any public items can


### PR DESCRIPTION
References to other sections follow the `the <section_name> section` format