### PR TITLE
Add  maintenance time section in  appendix-07-nightly-rust.md 

### DIFF
--- a/src/appendix-07-nightly-rust.md
+++ b/src/appendix-07-nightly-rust.md
@@ -114,6 +114,12 @@ work as expected, you can report it to the team and get it fixed before the
 next stable release happens! Breakage in a beta release is relatively rare, but
 `rustc` is still a piece of software, and bugs do exist.
 
+### Maintenance time
+
+The Rust project only supports the most recent stable version, which means the 
+maintenance time of a stable version is six weeks. When a new stable version 
+released, the old version reaches its EOL(end-of-life). 
+
 ### Unstable Features
 
 There’s one more catch with this release model: unstable features. Rust uses a

--- a/src/appendix-07-nightly-rust.md
+++ b/src/appendix-07-nightly-rust.md
@@ -116,9 +116,9 @@ next stable release happens! Breakage in a beta release is relatively rare, but
 
 ### Maintenance time
 
-The Rust project only supports the most recent stable version, which means the 
-maintenance time of a stable version is six weeks. When a new stable version 
-released, the old version reaches its EOL(end-of-life). 
+The Rust project supports the most recent stable version. When a new stable
+version is released, the old version reaches its end of life (EOL). This means
+each version is supported for six weeks.
 
 ### Unstable Features
 


### PR DESCRIPTION
Rust stable version has a six-week maintenance time that corresponds to the release interval， and only supports the most recent stable version. But it doesn't seem to be explicitly pointed out in the documentation. This PR adds a `maintenance time` section to supplement it.