### PR TITLE
Fix 10-03: a wrong expression of lifetime annotations

### DIFF
--- a/src/ch10-03-lifetime-syntax.md
+++ b/src/ch10-03-lifetime-syntax.md
@@ -213,7 +213,7 @@ This code should compile and produce the result we want when we use it with the
 The function signature now tells Rust that for some lifetime `'a`, the function
 takes two parameters, both of which are string slices that live at least as
 long as lifetime `'a`. The function signature also tells Rust that the string
-slice returned from the function will live at least as long as lifetime `'a`.
+slice returned from the function will live at most as long as lifetime `'a`.
 In practice, it means that the lifetime of the reference returned by the
 `longest` function is the same as the smaller of the lifetimes of the values
 referred to by the function arguments. These relationships are what we want


### PR DESCRIPTION
I think it should be `most` instead of `least` in this case:
```rust
fn longest<'a>(x: &'a str, y: &'a str) -> &'a str {
    if x.len() > y.len() {
        x
    } else {
        y
    }
}
```
The following sentence says that 

> In practice, it means that the lifetime of the reference returned by the `longest` function is the same as the smaller of the lifetimes of the values referred to by the function arguments.

That's to say, the lifetime of returned reference is less than the smaller of the lifetimes of the two arguments. So, the lifetime of returned reference should be at most as long as `'a` (<= 'a ✅), instead of at least (>= 'a ❎).