### PR TITLE
Update ch02-00-guessing-game-tutorial.md

### DIFF
--- a/src/ch02-00-guessing-game-tutorial.md
+++ b/src/ch02-00-guessing-game-tutorial.md
@@ -490,7 +490,7 @@ series, you’d have to update the *Cargo.toml* file to look like this instead:
 
 ```toml
 [dependencies]
-rand = "0.9.0"
+rand = "0.9.0-alpha.1"
 ```
 
 The next time you run `cargo build`, Cargo will update the registry of crates


### PR DESCRIPTION
Getting an error that says
```
error: failed to select a version for the requirement `rand = "^0.9.0"`
candidate versions found which didn't match: 0.9.0-alpha.1, 0.9.0-alpha.0, 0.8.5, ...
```

![image](https://github.com/rust-lang/book/assets/65181897/a65bfa18-2e5a-4533-b746-58eb9d83b97d)

After changing the rand version to `0.9.0-alpha.1` then it works
![image](https://github.com/rust-lang/book/assets/65181897/4330dea7-c206-4a89-b9c8-222548375fd2)
![image](https://github.com/rust-lang/book/assets/65181897/800296a0-21fb-426d-8ef9-d5b40c2f2bfa)
