### PR TITLE
Clarify function definitions vs. expressions

### DIFF
--- a/src/ch03-03-how-functions-work.md
+++ b/src/ch03-03-how-functions-work.md
@@ -125,7 +125,8 @@ assigning a value to it with the `let` keyword is a statement. In Listing 3-1,
 </Listing>
 
 Function definitions are also statements; the entire preceding example is a
-statement in itself.
+statement in itself. (As we will see below, *calling* a function is not a
+statement.)
 
 Statements do not return values. Therefore, you can’t assign a `let` statement
 to another variable, as the following code tries to do; you’ll get an error:


### PR DESCRIPTION
Fixes #2980. @carols10cents, the downside here is that we now repeat the exact phrase 'calling a function is an expression' at two points in the text. 🤔 