### PR TITLE
Fix a typo: remove an extra 's' from ch. 18.01

### DIFF
--- a/src/ch08-01-vectors.md
+++ b/src/ch08-01-vectors.md
@@ -202,7 +202,7 @@ some of the columns in the row contain integers, some floating-point numbers,
 and some strings. We can define an enum whose variants will hold the different
 value types, and all the enum variants will be considered the same type: that
 of the enum. Then we can create a vector to hold that enum and so, ultimately,
-holds different types. We’ve demonstrated this in Listing 8-9.
+hold different types. We’ve demonstrated this in Listing 8-9.
 
 ```rust
 {{#rustdoc_include ../listings/ch08-common-collections/listing-08-09/src/main.rs:here}}


### PR DESCRIPTION
Fixes #3561. Closes #3696 (because it supersedes it with a simpler fix).