### PR TITLE
Revert #3711

### DIFF
--- a/listings/ch16-fearless-concurrency/listing-16-15/src/main.rs
+++ b/listings/ch16-fearless-concurrency/listing-16-15/src/main.rs
@@ -5,7 +5,7 @@ fn main() {
     let counter = Arc::new(Mutex::new(0));
     let mut handles = vec![];
 
-    for _ in 0..=10 {
+    for _ in 0..10 {
         let counter = Arc::clone(&counter);
         let handle = thread::spawn(move || {
             let mut num = counter.lock().unwrap();


### PR DESCRIPTION
The PR claimed that the code previously printed `Result: 9`, but it didn't. It printed `Result: 10` as intended. The PR unintentionally changed it to print `Result: 11`.

[Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=143eaec098307196adf95c111489f0f8)

`0..10` includes the numbers from 0 through 9 (inclusive); not 1 through 9.

@miketon :)