### PR TITLE
Revert "Chapter 15-05: Fix incorrect interpretation of compiler error"

### DIFF
--- a/src/ch15-05-interior-mutability.md
+++ b/src/ch15-05-interior-mutability.md
@@ -191,10 +191,9 @@ However, there’s one problem with this test, as shown here:
 
 We can’t modify the `MockMessenger` to keep track of the messages, because the
 `send` method takes an immutable reference to `self`. We also can’t take the
-suggestion from the error text to use `&mut self` instead, because we are
-testing an API and it's not a good idea to modify the API for the sole purpose
-of testing. Usually, the test engineers do not have permission to modify the
-API they're testing. Feel free to try and see what error message you get.
+suggestion from the error text to use `&mut self` instead, because then the
+signature of `send` wouldn’t match the signature in the `Messenger` trait
+definition (feel free to try and see what error message you get).
 
 This is a situation in which interior mutability can help! We’ll store the
 `sent_messages` within a `RefCell<T>`, and then the `send` method will be


### PR DESCRIPTION
Reverts rust-lang/book#3501. GitHub's button layout… 😠 