### PR TITLE
Ch. 2: intentionally use `{}` at first

### DIFF
--- a/listings/ch02-guessing-game-tutorial/listing-02-01/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/listing-02-01/src/main.rs
@@ -25,7 +25,7 @@ fn main() {
     // ANCHOR_END: expect
 
     // ANCHOR: print_guess
-    println!("You guessed: {guess}");
+    println!("You guessed: {}", guess);
     // ANCHOR_END: print_guess
 }
 // ANCHOR: all


### PR DESCRIPTION
This supports the prose in the guessing game tutorial, which uses this as a way of teaching where you can do `{foo}` and where you cannot.

(Follow-on from #3385, where this got mistakenly changed because neither the author nor I realized there was the prose connection there.)

Between this and Carol’s changes for the last print revision, this supersedes and closes #3898.