### PR TITLE
Fix typo in Chapter 2 - Programming a Guessing Game

### DIFF
--- a/src/ch02-00-guessing-game-tutorial.md
+++ b/src/ch02-00-guessing-game-tutorial.md
@@ -680,7 +680,7 @@ often used when you want to convert a value from one type to another type.
 We bind this new variable to the expression `guess.trim().parse()`. The `guess`
 in the expression refers to the original `guess` variable that contained the
 input as a string. The `trim` method on a `String` instance will eliminate any
-whitespace at the beginning and end, which we must do to be able to compare the
+whitespace at the beginning and end, which we must do to be able to convert the
 string to the `u32`, which can only contain numerical data. The user must press
 <span class="keystroke">enter</span> to satisfy `read_line` and input their
 guess, which adds a newline character to the string. For example, if the user


### PR DESCRIPTION
The word compare should be replaced with convert, as it refers to the reason for trimming whitespace.