### PR TITLE
Ch13: Clarify closure capture types

### DIFF
--- a/src/ch13-01-closures.md
+++ b/src/ch13-01-closures.md
@@ -384,14 +384,14 @@ compiler won’t let us use this closure with `sort_by_key`:
 This is a contrived, convoluted way (that doesn’t work) to try and count the
 number of times `sort_by_key` calls the closure when sorting `list`. This code
 attempts to do this counting by pushing `value`—a `String` from the closure’s
-environment—into the `sort_operations` vector. The closure captures `value`
-then moves `value` out of the closure by transferring ownership of `value` to
-the `sort_operations` vector. This closure can be called once; trying to call
-it a second time wouldn’t work because `value` would no longer be in the
-environment to be pushed into `sort_operations` again! Therefore, this closure
-only implements `FnOnce`. When we try to compile this code, we get this error
-that `value` can’t be moved out of the closure because the closure must
-implement `FnMut`:
+environment—into the `sort_operations` vector. The closure captures ownership
+of `value` then moves `value` out of the closure by transferring ownership of
+`value` to the `sort_operations` vector. This closure can be called once;
+trying to call it a second time wouldn’t work because `value` would no longer
+be in the environment to be pushed into `sort_operations` again! Therefore,
+this closure only implements `FnOnce`. When we try to compile this code, we get
+this error that `value` can’t be moved out of the closure because the closure
+must implement `FnMut`:
 
 ```console
 {{#include ../listings/ch13-functional-features/listing-13-08/output.txt}}

--- a/src/ch13-02-iterators.md
+++ b/src/ch13-02-iterators.md
@@ -219,10 +219,10 @@ that takes ownership of the vector. Then we call `filter` to adapt that
 iterator into a new iterator that only contains elements for which the closure
 returns `true`.
 
-The closure captures the `shoe_size` parameter from the environment and
-compares the value with each shoe’s size, keeping only shoes of the size
-specified. Finally, calling `collect` gathers the values returned by the
-adapted iterator into a vector that’s returned by the function.
+The closure captures an immutable reference to the `shoe_size` parameter from
+the environment and compares the value with each shoe’s size, keeping only
+shoes of the size specified. Finally, calling `collect` gathers the values
+returned by the adapted iterator into a vector that’s returned by the function.
 
 The test shows that when we call `shoes_in_size`, we get back only shoes
 that have the same size as the value we specified.


### PR DESCRIPTION
Most places in this chapter are explicit about what type of capture is occurring ((im)mutable reference or ownership), and this change updates two more places to follow that standard. I've left the type of capture unspecified in the description of listing 13-16 because it is just a brief overview, and the capture type is now in the full breakdown immediately after the listing.