### PR TITLE
Fix workspace behavior by excluding `listings`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,10 @@
 members = ["packages/*"]
 default-members = ["packages/*"]
 resolver = "2"
-exclude = ["linkchecker"]        # part of the CI workflow
+exclude = [
+    "linkchecker", # linkchecker is part of the CI workflow
+    "listings",    # these are intentionally distinct from the workspace
+]
 
 [workspace.dependencies]
 walkdir = "2.3.1"


### PR DESCRIPTION
At some point we may want to include these in the workspace, but for now they need to be excluded so `cargo build` and `rust-analyzer` work correctly with the workspace layout.