### PR TITLE
Update title-page.md

### DIFF
--- a/src/title-page.md
+++ b/src/title-page.md
@@ -2,7 +2,7 @@
 
 *by Steve Klabnik and Carol Nichols, with contributions from the Rust Community*
 
-This version of the text assumes you’re using Rust 1.76.0 (released 2024-02-08)
+This version of the text assumes you’re using Rust 1.78.0 (released 2024-05-02)
 or later. See the [“Installation” section of Chapter 1][install]<!-- ignore -->
 to install or update Rust.
 


### PR DESCRIPTION
update the title-page.md 
i am mentioned that is the current new version of rust is 1.78.0 released in  2 may 2024 .