### PR TITLE
infra: disable mdBook default-features for mdBook preprocessors

### DIFF
--- a/packages/mdbook-trpl-listing/Cargo.toml
+++ b/packages/mdbook-trpl-listing/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-mdbook = { version = "0.4", features = [] }                # only need the library
+mdbook = { version = "0.4", default-features = false }     # only need the library
 pulldown-cmark = { version = "0.10", features = ["simd"] }
 pulldown-cmark-to-cmark = "13"
 serde_json = "1"

--- a/packages/mdbook-trpl-note/Cargo.toml
+++ b/packages/mdbook-trpl-note/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-mdbook = { version = "0.4", features = [] }                # only need the library
+mdbook = { version = "0.4", default-features = false }     # only need the library
 pulldown-cmark = { version = "0.10", features = ["simd"] }
 pulldown-cmark-to-cmark = "13"
 serde_json = "1"


### PR DESCRIPTION
This prevents us from pulling in `notify` accidentally, which is causing a `tidy check` issue in `rust-lang/rust` because of the CC0 license on `notify`. I had intended to address this in efd315a3, but forgot that `features = []` does not imply `default-features = false`.