### PR TITLE
Revert "Update listings to account for `cargo new` template update"

### DIFF
--- a/listings/ch11-writing-automated-tests/listing-11-01/src/lib.rs
+++ b/listings/ch11-writing-automated-tests/listing-11-01/src/lib.rs
@@ -1,4 +1,4 @@
-pub fn add(left: u64, right: u64) -> u64 {
+pub fn add(left: usize, right: usize) -> usize {
     left + right
 }
 

--- a/listings/ch11-writing-automated-tests/listing-11-03/src/lib.rs
+++ b/listings/ch11-writing-automated-tests/listing-11-03/src/lib.rs
@@ -1,5 +1,5 @@
 // ANCHOR: here
-pub fn add(left: u64, right: u64) -> u64 {
+pub fn add(left: usize, right: usize) -> usize {
     left + right
 }
 
@@ -12,7 +12,7 @@ mod tests {
         let result = add(2, 2);
         assert_eq!(result, 4);
     }
-
+    
     #[test]
     fn another() {
         panic!("Make this test fail");

--- a/listings/ch11-writing-automated-tests/no-listing-01-changing-test-name/src/lib.rs
+++ b/listings/ch11-writing-automated-tests/no-listing-01-changing-test-name/src/lib.rs
@@ -1,4 +1,4 @@
-pub fn add(left: u64, right: u64) -> u64 {
+pub fn add(left: usize, right: usize) -> usize {
     left + right
 }
 

--- a/listings/ch14-more-about-cargo/output-only-02-add-one/add/add_one/src/lib.rs
+++ b/listings/ch14-more-about-cargo/output-only-02-add-one/add/add_one/src/lib.rs
@@ -1,4 +1,4 @@
-pub fn add(left: u64, right: u64) -> u64 {
+pub fn add(left: usize, right: usize) -> usize {
     left + right
 }
 

--- a/redirects/compiler-plugins.md
+++ b/redirects/compiler-plugins.md
@@ -2,5 +2,5 @@
 
 <small>There is a new edition of the book and this is an old link.</small>
 
-> Compiler plugins were user-provided libraries that extended the compiler's behavior in certain ways.
+> Compiler plugins were user-provided libraries that extended the compiler's behavior in certain ways. 
 > Support for them has been removed.

--- a/redirects/documentation.md
+++ b/redirects/documentation.md
@@ -3,7 +3,7 @@
 <small>There is a new edition of the book and this is an old link.</small>
 
 > Documentation comments use `///` instead of `//` and support Markdown notation for formatting the text if you’d like.
-> You place documentation comments just before the item they are documenting.
+> You place documentation comments just before the item they are documenting. 
 
 ```rust,no_run
 /// Adds one to the number given.

--- a/redirects/functions.md
+++ b/redirects/functions.md
@@ -4,7 +4,7 @@
 
 > Function definitions in Rust start with `fn` and have a set of parentheses after the function name.
 > The curly brackets tell the compiler where the function body begins and ends.
-> We can call any function we’ve defined by entering its name followed by a set of parentheses.
+> We can call any function we’ve defined by entering its name followed by a set of parentheses. 
 
 ```rust
 fn main() {


### PR DESCRIPTION
Reverts rust-lang/book#3932

This isn't in stable yet. Once this lands in a stable version, updating the Rust version as in https://github.com/rust-lang/book/blob/main/ADMIN_TASKS.md#update-the-rustc-version will pick this up.