### PR TITLE
infra: more workspace cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = ["packages/tools"]
-# default-members = ["packages/tools"]
+default-members = ["packages/tools"]
 resolver = "2"
 exclude = [
     "linkchecker", # linkchecker is part of the CI workflow
@@ -18,11 +18,7 @@ exclude = [
 [workspace.dependencies]
 walkdir = "2.3.1"
 docopt = "1.1.0"
-mdbook = "0.4.37"
-pulldown-cmark = { version = "0.10.3", features = ["simd"] }
-pulldown-cmark-to-cmark = "13.0.0"
 serde = "1.0"
-serde_json = "1.0"
 regex = "1.3.3"
 lazy_static = "1.4.0"
 flate2 = "1.0.13"


### PR DESCRIPTION
- Turn back on `default-members`.
- Remove deps from root only used by mdbook preprocessors, since they are managed by themselves now.