### PR TITLE
infra: modernize and improve rigor/safety of ferris.js

### DIFF
--- a/ferris.js
+++ b/ferris.js
@@ -1,4 +1,11 @@
-var ferrisTypes = [
+// @ts-check
+
+/**
+ * @typedef {{ attr: string, title: string }} FerrisType
+ */
+
+/** @type {Array<FerrisType>} */
+const FERRIS_TYPES = [
   {
     attr: 'does_not_compile',
     title: 'This code does not compile!'
@@ -14,46 +21,74 @@ var ferrisTypes = [
 ]
 
 document.addEventListener('DOMContentLoaded', () => {
-  for (var ferrisType of ferrisTypes) {
+  for (let ferrisType of FERRIS_TYPES) {
     attachFerrises(ferrisType)
   }
 })
 
+/**
+ * @param {FerrisType} type
+ */
 function attachFerrises(type) {
-  var elements = document.getElementsByClassName(type.attr)
+  let elements = document.getElementsByClassName(type.attr)
 
-  for (var codeBlock of elements) {
-    var lines = codeBlock.innerText.replace(/\n$/, '').split(/\n/).length
-    var size = 'large'
-    if (lines < 4) {
-      size = 'small'
+  for (let codeBlock of elements) {
+    // Skip SVG etc.: in principle, these should never be attached to those, but
+    // this means if someone happens to have a browser extension which *is*
+    // attaching them, it will not break the code.
+    if (!(codeBlock instanceof HTMLElement)) {
+      continue
     }
 
-    var container = prepareFerrisContainer(codeBlock, size == 'small')
+    let lines = codeBlock.innerText.replace(/\n$/, '').split(/\n/).length
+
+    /** @type {'small' | 'large'} */
+    let size = lines < 4 ? 'small' : 'large'
+
+    let container = prepareFerrisContainer(codeBlock, size == 'small')
+    if (!container) {
+      continue
+    }
+
     container.appendChild(createFerris(type, size))
   }
 }
 
+/**
+ * @param {HTMLElement} element - Code block element to attach a Ferris to.
+ * @param {boolean} useButtons - Whether to attach to existing buttons.
+ * @returns {Element | null} - The container element to use.
+ */
 function prepareFerrisContainer(element, useButtons) {
-  var foundButtons = element.parentElement.querySelector('.buttons')
+  let foundButtons = element.parentElement?.querySelector('.buttons')
   if (useButtons && foundButtons) {
     return foundButtons
   }
 
-  var div = document.createElement('div')
+  let div = document.createElement('div')
   div.classList.add('ferris-container')
+
+  if (!element.parentElement) {
+    console.error(`Could not install Ferris on ${element}, which is missing a parent`);
+    return null;
+  }
 
   element.parentElement.insertBefore(div, element)
 
   return div
 }
 
+/**
+ * @param {FerrisType} type
+ * @param {'small' | 'large'} size
+ * @returns {HTMLAnchorElement} - The generated anchor element.
+ */
 function createFerris(type, size) {
-  var a = document.createElement('a')
+  let a = document.createElement('a')
   a.setAttribute('href', 'ch00-00-introduction.html#ferris')
   a.setAttribute('target', '_blank')
 
-  var img = document.createElement('img')
+  let img = document.createElement('img')
   img.setAttribute('src', 'img/ferris/' + type.attr + '.svg')
   img.setAttribute('title', type.title)
   img.classList.add('ferris')


### PR DESCRIPTION
- Use `let` instead of `var` throughout. All modern browsers support it and have for many years, even the now-EOL IE11.[^ie]
- Add a `@ts-check` annotation so that anyone working on a TS-enabled editor will get feedback inline about cases they may otherwise miss.
- Add JSDoc-based type definitions for the script, and fix some errors that may occur at runtime. (These will be rare if they happen, but getting rid of them is still a win!)

<details><summary>screenshots to show it still works</summary>

![CleanShot 2024-05-22 at 15 48 22@2x](https://github.com/rust-lang/book/assets/2403023/e44505b0-8f6b-43f8-bf8a-e98466d64dee)
![CleanShot 2024-05-22 at 15 48 11@2x](https://github.com/rust-lang/book/assets/2403023/af0a376b-484d-47e5-84f1-0563772e3d5c)

</details>

[^ie]: IE11 did not correctly support the semantics of `let` for `for` loops, but the uses in the existing code here already used `var` in a way which would trigger the same behavior as using `let` does.