### PR TITLE
fix: ch10-03 - misleading use of expect on .split

### DIFF
--- a/listings/ch10-generic-types-traits-and-lifetimes/listing-10-24/src/main.rs
+++ b/listings/ch10-generic-types-traits-and-lifetimes/listing-10-24/src/main.rs
@@ -4,7 +4,7 @@ struct ImportantExcerpt<'a> {
 
 fn main() {
     let novel = String::from("Call me Ishmael. Some years ago...");
-    let first_sentence = novel.split('.').next().expect("Could not find a '.'");
+    let first_sentence = novel.split('.').next().unwrap();
     let i = ImportantExcerpt {
         part: first_sentence,
     };

--- a/listings/ch10-generic-types-traits-and-lifetimes/no-listing-10-lifetimes-on-methods/src/main.rs
+++ b/listings/ch10-generic-types-traits-and-lifetimes/no-listing-10-lifetimes-on-methods/src/main.rs
@@ -21,7 +21,7 @@ impl<'a> ImportantExcerpt<'a> {
 
 fn main() {
     let novel = String::from("Call me Ishmael. Some years ago...");
-    let first_sentence = novel.split('.').next().expect("Could not find a '.'");
+    let first_sentence = novel.split('.').next().unwrap();
     let i = ImportantExcerpt {
         part: first_sentence,
     };


### PR DESCRIPTION
## Description
This pull request addresses a logical oversight in handling the split operation. Originally, the code used `expect` directly on the result of `split('.').next()` with the error message "Could not find a '.'", which could mislead into thinking it might return `None` when there is no '.' in the input string. However, `split` will always return at least one element, making `expect` logically unnecessary in this context.

## Changes
I just replaced .expect with .unwrap because I could not think of a valuable error message. I don't see how any error could happen, and it was not relevant anyway in this context.

Thank you for considering this small pull request.