### PR TITLE
infra: correctly support preprocessors for nostarch

### DIFF
--- a/packages/mdbook-trpl-listing/src/lib.rs
+++ b/packages/mdbook-trpl-listing/src/lib.rs
@@ -98,7 +98,7 @@ impl Preprocessor for TrplListing {
     }
 
     fn supports_renderer(&self, renderer: &str) -> bool {
-        renderer == "html"
+        renderer == "html" || renderer == "markdown"
     }
 }
 

--- a/packages/mdbook-trpl-note/src/lib.rs
+++ b/packages/mdbook-trpl-note/src/lib.rs
@@ -49,7 +49,7 @@ impl Preprocessor for TrplNote {
     }
 
     fn supports_renderer(&self, renderer: &str) -> bool {
-        renderer == "html"
+        renderer == "html" || renderer == "markdown"
     }
 }
 

--- a/tools/nostarch.sh
+++ b/tools/nostarch.sh
@@ -4,6 +4,14 @@ set -eu
 
 cargo build --release
 
+cd packages/mdbook-trpl-listing
+cargo install --locked --path .
+
+cd ../mdbook-trpl-note
+cargo install --locked --path .
+
+cd ../..
+
 mkdir -p tmp
 rm -rf tmp/*.md
 rm -rf tmp/markdown


### PR DESCRIPTION
- Update the `tools/nostarch` script to `cargo install` each of the preprocessors so they are always available to run and do not require any manual intervention.
- Add support for `"markdown"` renderer in the preprocessors.