### PR TITLE
Update Strings module: Replace Russian text with Ukrainian

### DIFF
--- a/listings/ch08-common-collections/listing-08-14/src/main.rs
+++ b/listings/ch08-common-collections/listing-08-14/src/main.rs
@@ -9,9 +9,9 @@ fn main() {
     let hello = String::from("안녕하세요");
     let hello = String::from("你好");
     let hello = String::from("Olá");
-    // ANCHOR: russian
-    let hello = String::from("Здравствуйте");
-    // ANCHOR_END: russian
+    // ANCHOR: ukrainian
+    let hello = String::from("Привіт");
+    // ANCHOR_END: ukrainian
     // ANCHOR: spanish
     let hello = String::from("Hola");
     // ANCHOR_END: spanish

--- a/listings/ch08-common-collections/output-only-01-not-char-boundary/output.txt
+++ b/listings/ch08-common-collections/output-only-01-not-char-boundary/output.txt
@@ -3,5 +3,5 @@ $ cargo run
     Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.43s
      Running `target/debug/collections`
 thread 'main' panicked at src/main.rs:4:19:
-byte index 1 is not a char boundary; it is inside 'З' (bytes 0..2) of `Здравствуйте`
+byte index 1 is not a char boundary; it is inside 'П' (bytes 0..2) of `Привіт`
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/listings/ch08-common-collections/output-only-01-not-char-boundary/src/main.rs
+++ b/listings/ch08-common-collections/output-only-01-not-char-boundary/src/main.rs
@@ -1,5 +1,5 @@
 fn main() {
-    let hello = "Здравствуйте";
+    let hello = "Привіт";
 
     let s = &hello[0..1];
 }

--- a/src/ch08-02-strings.md
+++ b/src/ch08-02-strings.md
@@ -247,23 +247,23 @@ UTF-8. The following line, however, may surprise you (note that this string
 begins with the capital Cyrillic letter *Ze*, not the number 3):
 
 ```rust
-{{#rustdoc_include ../listings/ch08-common-collections/listing-08-14/src/main.rs:russian}}
+{{#rustdoc_include ../listings/ch08-common-collections/listing-08-14/src/main.rs:ukrainian}}
 ```
 
-If you were asked how long the string is, you might say 12. In fact, Rust’s
-answer is 24: that’s the number of bytes it takes to encode “Здравствуйте” in
+If you were asked how long the string is, you might say 6. In fact, Rust’s
+answer is 12: that’s the number of bytes it takes to encode “Привіт” in
 UTF-8, because each Unicode scalar value in that string takes 2 bytes of
 storage. Therefore, an index into the string’s bytes will not always correlate
 to a valid Unicode scalar value. To demonstrate, consider this invalid Rust
 code:
 
 ```rust,ignore,does_not_compile
-let hello = "Здравствуйте";
+let hello = "Привіт";
 let answer = &hello[0];
 ```
 
-You already know that `answer` will not be `З`, the first letter. When encoded
-in UTF-8, the first byte of `З` is `208` and the second is `151`, so it would
+You already know that `answer` will not be `П`, the first letter. When encoded
+in UTF-8, the first byte of `П` is `208` and the second is `159`, so it would
 seem that `answer` should in fact be `208`, but `208` is not a valid character
 on its own. Returning `208` is likely not what a user would want if they asked
 for the first letter of this string; however, that’s the only data that Rust
@@ -327,14 +327,14 @@ Rather than indexing using `[]` with a single number, you can use `[]` with a
 range to create a string slice containing particular bytes:
 
 ```rust
-let hello = "Здравствуйте";
+let hello = "Привіт";
 
 let s = &hello[0..4];
 ```
 
 Here, `s` will be a `&str` that contains the first four bytes of the string.
 Earlier, we mentioned that each of these characters was two bytes, which means
-`s` will be `Зд`.
+`s` will be `Пр`.
 
 If we were to try to slice only part of a character’s bytes with something like
 `&hello[0..1]`, Rust would panic at runtime in the same way as if an invalid
@@ -351,11 +351,11 @@ so can crash your program.
 
 The best way to operate on pieces of strings is to be explicit about whether
 you want characters or bytes. For individual Unicode scalar values, use the
-`chars` method. Calling `chars` on “Зд” separates out and returns two values of
+`chars` method. Calling `chars` on “Пр” separates out and returns two values of
 type `char`, and you can iterate over the result to access each element:
 
 ```rust
-for c in "Зд".chars() {
+for c in "Пр".chars() {
     println!("{c}");
 }
 ```
@@ -363,15 +363,15 @@ for c in "Зд".chars() {
 This code will print the following:
 
 ```text
-З
-д
+П
+р
 ```
 
 Alternatively, the `bytes` method returns each raw byte, which might be
 appropriate for your domain:
 
 ```rust
-for b in "Зд".bytes() {
+for b in "Пр".bytes() {
     println!("{b}");
 }
 ```
@@ -380,9 +380,9 @@ This code will print the four bytes that make up this string:
 
 ```text
 208
-151
-208
-180
+159
+209
+128
 ```
 
 But be sure to remember that valid Unicode scalar values may be made up of more


### PR DESCRIPTION
This pull request updates the examples in the Strings module of the Rust book to use Ukrainian language instead of russian. As a Ukrainian citizen, I believe it is important to promote and popularize the Ukrainian language, especially given the current geopolitical context.

#### Changes:
* Replaced russian text examples with equivalent Ukrainian text.
* Updated explanations and comments to reflect the changes in examples.

#### Reasoning:
* Given the ongoing war and the role of russia as an aggressor state, it is important to avoid the normalization of their language in educational materials.

#### Impact:
Thank you for considering this contribution. I look forward to your feedback and hope to see this change integrated into the Rust book.