### PR TITLE
infra: ignore Nova configuration directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ book/
 target
 tmp
 
+.nova


### PR DESCRIPTION
Since I have some Nova tasks and other such config set up but don’t want it to bother other folks working on the repo!