### PR TITLE
Use Rust 2021 Edition for mdBook

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -15,3 +15,6 @@ git-repository-url = "https://github.com/rust-lang/book"
 
 [preprocessor.trpl-listing]
 output-mode = "default"
+
+[rust]
+edition = "2021"


### PR DESCRIPTION
A number of examples *already* do not work correctly, and the inbound async chapter requires Rust 2021.