### PR TITLE
infra: support test renderer in mdbook preprocessors

### DIFF
--- a/packages/mdbook-trpl-listing/src/lib.rs
+++ b/packages/mdbook-trpl-listing/src/lib.rs
@@ -98,7 +98,7 @@ impl Preprocessor for TrplListing {
     }
 
     fn supports_renderer(&self, renderer: &str) -> bool {
-        renderer == "html" || renderer == "markdown"
+        renderer == "html" || renderer == "markdown" || renderer == "test"
     }
 }
 

--- a/packages/mdbook-trpl-note/src/lib.rs
+++ b/packages/mdbook-trpl-note/src/lib.rs
@@ -49,7 +49,7 @@ impl Preprocessor for TrplNote {
     }
 
     fn supports_renderer(&self, renderer: &str) -> bool {
-        renderer == "html" || renderer == "markdown"
+        renderer == "html" || renderer == "markdown" || renderer == "test"
     }
 }
 


### PR DESCRIPTION
This does not change the actual behavior of `mdbook test`, but it does get rid of a warning about the test renderer being unsupported!