### PR TITLE
[blocked] infra: update dependencies for mdbook preprocessors

### DIFF
--- a/packages/mdbook-trpl-listing/Cargo.lock
+++ b/packages/mdbook-trpl-listing/Cargo.lock
@@ -481,7 +481,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "opener",
- "pulldown-cmark",
+ "pulldown-cmark 0.10.3",
  "regex",
  "serde",
  "serde_json",
@@ -499,7 +499,7 @@ dependencies = [
  "clap",
  "html_parser",
  "mdbook",
- "pulldown-cmark",
+ "pulldown-cmark 0.11.0",
  "pulldown-cmark-to-cmark",
  "serde_json",
  "thiserror",
@@ -642,9 +642,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76979bea66e7875e7509c4ec5300112b316af87fa7a252ca91c448b32dfe3993"
 dependencies = [
  "bitflags",
+ "memchr",
+ "pulldown-cmark-escape 0.10.1",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8746739f11d39ce5ad5c2520a9b75285310dbfe78c541ccf832d38615765aec0"
+dependencies = [
+ "bitflags",
  "getopts",
  "memchr",
- "pulldown-cmark-escape",
+ "pulldown-cmark-escape 0.11.0",
  "unicase",
 ]
 
@@ -655,12 +667,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd348ff538bc9caeda7ee8cad2d1d48236a1f443c1fa3913c6a02fe0043b1dd3"
 
 [[package]]
-name = "pulldown-cmark-to-cmark"
-version = "13.0.0"
+name = "pulldown-cmark-escape"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f609795c8d835f79dcfcf768415b9fb57ef1b74891e99f86e73f43a7a257163b"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
+
+[[package]]
+name = "pulldown-cmark-to-cmark"
+version = "15.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9c77db841443d89a57ae94f22d29c022f6d9f41b00bddbf1f4024dbaf4bdce1"
 dependencies = [
- "pulldown-cmark",
+ "pulldown-cmark 0.11.0",
 ]
 
 [[package]]

--- a/packages/mdbook-trpl-listing/Cargo.toml
+++ b/packages/mdbook-trpl-listing/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2021"
 clap = { version = "4", features = ["derive"] }
 html_parser = "0.7.0"
 mdbook = { version = "0.4", default-features = false }     # only need the library
-pulldown-cmark = { version = "0.10", features = ["simd"] }
-pulldown-cmark-to-cmark = "13"
+pulldown-cmark = { version = "0.11", features = ["simd"] }
+pulldown-cmark-to-cmark = "15"
 serde_json = "1"
 thiserror = "1.0.60"
 toml = "0.8.12"

--- a/packages/mdbook-trpl-note/Cargo.toml
+++ b/packages/mdbook-trpl-note/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 mdbook = { version = "0.4", default-features = false }     # only need the library
-pulldown-cmark = { version = "0.10", features = ["simd"] }
-pulldown-cmark-to-cmark = "13"
+pulldown-cmark = { version = "0.11", features = ["simd"] }
+pulldown-cmark-to-cmark = "15"
 serde_json = "1"
 
 [dev-dependencies]


### PR DESCRIPTION
Needs https://github.com/rust-lang/mdBook/pull/2401 to land before it can be landed, because mdbook requires pulldown-cmark 0.10, so there is a type mismatch on `Event`:

```
error[E0271]: expected `Parser<'_>` to be an iterator that yields `Event<'_>`, but it yields `Event<'_>`
   --> src/lib.rs:372:39
    |
372 |             html::push_html(&mut buf, events);
    |             ---------------           ^^^^^^ expected `Event<'_>`, found `pulldown_cmark::Event<'_>`
    |             |
    |             required by a bound introduced by this call
    |
    = note: `pulldown_cmark::Event<'_>` and `Event<'_>` have similar names, but are actually distinct types
note: `pulldown_cmark::Event<'_>` is defined in crate `pulldown_cmark`
   --> /Users/chris/.cargo/registry/src/index.crates.io-6f17d22bba15001f/pulldown-cmark-0.10.3/src/lib.rs:354:1
    |
354 | pub enum Event<'a> {
    | ^^^^^^^^^^^^^^^^^^
note: `Event<'_>` is defined in crate `pulldown_cmark`
   --> /Users/chris/.cargo/registry/src/index.crates.io-6f17d22bba15001f/pulldown-cmark-0.11.0/src/lib.rs:366:1
    |
366 | pub enum Event<'a> {
    | ^^^^^^^^^^^^^^^^^^
    = note: perhaps two different versions of crate `pulldown_cmark` are being used?
```