### PR TITLE
infra: add robots.txt for GH Pages previews

### DIFF
--- a/ADMIN_TASKS.md
+++ b/ADMIN_TASKS.md
@@ -133,3 +133,13 @@ $ dot dot/trpl04-01.dot -Tsvg > src/img/trpl04-01.svg
 In the generated SVG, remove the width and the height attributes from the `svg`
 element and set the `viewBox` attribute to `0.00 0.00 1000.00 1000.00` or other
 values that don't cut off the image.
+
+## Publish a preview to GitHub Pages
+
+We sometimes publish to GitHub Pages for in-progress previews. The recommended
+flow for publishing is:
+
+- Install the `ghp-import` tool by running `pip install ghp-import` (or `pipx install ghp-import`, using [pipx][pipx]).
+- In the root, run `tools/generate-preview.sh`
+
+[pipx]: https://pipx.pypa.io/stable/#install-pipx

--- a/tools/generate-preview.sh
+++ b/tools/generate-preview.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+mdbook build
+cp ./tools/preview-robots.txt ./book/robots.txt

--- a/tools/preview-robots.txt
+++ b/tools/preview-robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
Block *everything*. We do not want any of this to be indexed, because we *only* use it for previews, and do not want its content to be cached or (especially!) surfaced to readers, since it may have a variety of issues ranging from pedagogical missteps to outright errors!