### PR TITLE
Fix: unnecessary use of italics

### DIFF
--- a/src/ch15-01-box.md
+++ b/src/ch15-01-box.md
@@ -98,9 +98,9 @@ which is an invalid or absent value.
 
 The cons list isn’t a commonly used data structure in Rust. Most of the time
 when you have a list of items in Rust, `Vec<T>` is a better choice to use.
-Other, more complex recursive data types *are* useful in various situations,
-but by starting with the cons list in this chapter, we can explore how boxes
-let us define a recursive data type without much distraction.
+Other, more complex recursive data types are useful in various situations, but
+by starting with the cons list in this chapter, we can explore how boxes let
+us define a recursive data type without much distraction.
 
 Listing 15-2 contains an enum definition for a cons list. Note that this code
 won’t compile yet because the `List` type doesn’t have a known size, which


### PR DESCRIPTION
Is there any specific reason for making the term `are` italic? If not, I have provided the fix and obeyed 79 characters in a row standard after its removal.
