### PR TITLE
Make Listing 10-14 easier to understand

### DIFF
--- a/listings/ch10-generic-types-traits-and-lifetimes/listing-10-14/src/lib.rs
+++ b/listings/ch10-generic-types-traits-and-lifetimes/listing-10-14/src/lib.rs
@@ -4,7 +4,6 @@ pub trait Summary {
         String::from("(Read more...)")
     }
 }
-// ANCHOR_END: here
 
 pub struct NewsArticle {
     pub headline: String,
@@ -27,3 +26,4 @@ impl Summary for Tweet {
         format!("{}: {}", self.username, self.content)
     }
 }
+// ANCHOR_END: here


### PR DESCRIPTION
I believe that fully expanding Listing 10-14 would make it more comprehensible for readers. Compared to before, fully expanding Listing 10-14 could help readers compare "Implementing a Trait on a Type" with "Default Implementations" thereby deepening their understanding.

```rust
// Implementing a Trait on a Type
impl Summary for NewsArticle {}

// Default Implementations
impl Summary for Tweet {
    fn summarize(&self) -> String {
        format!("{}: {}", self.username, self.content)
    }
}
```

Additionally, it better corresponds to the later section that uses `impl Summary for NewsArticle {}` to demonstrate Default Implementations.