### PR TITLE
Add `cargo init` usage suggestion to 1.3

### DIFF
--- a/src/ch01-03-hello-cargo.md
+++ b/src/ch01-03-hello-cargo.md
@@ -113,7 +113,7 @@ everything is in its place.
 If you started a project that doesn’t use Cargo, as we did with the “Hello,
 world!” project, you can convert it to a project that does use Cargo. Move the
 project code into the *src* directory and create an appropriate *Cargo.toml*
-file.
+file, or run `cargo init`.
 
 ### Building and Running a Cargo Project
 

--- a/src/ch01-03-hello-cargo.md
+++ b/src/ch01-03-hello-cargo.md
@@ -113,7 +113,8 @@ everything is in its place.
 If you started a project that doesn’t use Cargo, as we did with the “Hello,
 world!” project, you can convert it to a project that does use Cargo. Move the
 project code into the *src* directory and create an appropriate *Cargo.toml*
-file, or run `cargo init`.
+file. One easy way to get that *Cargo.toml* file is to run `cargo init`, which
+will create it for you automatically.
 
 ### Building and Running a Cargo Project
 


### PR DESCRIPTION
Reading the book I've noticed that 1.3's "Creating a Project with Cargo" part suggests readers to manually add an appropriate *Cargo.toml* file if they've already created a non-Cargo folder. I believe it's better for readers to know that this can be automatically made with just `cargo init`!