### PR TITLE
Convert ch04 to `<Listing>`

### DIFF
--- a/src/ch04-01-what-is-ownership.md
+++ b/src/ch04-01-what-is-ownership.md
@@ -113,12 +113,13 @@ hardcoded into the text of our program. The variable is valid from the point at
 which it’s declared until the end of the current *scope*. Listing 4-1 shows a
 program with comments annotating where the variable `s` would be valid.
 
+<Listing number="4-1" caption="A variable and the scope in which it is valid">
+
 ```rust
 {{#rustdoc_include ../listings/ch04-understanding-ownership/listing-04-01/src/main.rs:here}}
 ```
 
-<span class="caption">Listing 4-1: A variable and the scope in which it is
-valid</span>
+</Listing>
 
 In other words, there are two important points in time here:
 
@@ -239,12 +240,13 @@ we’ve allocated on the heap. Let’s explore some of those situations now.
 Multiple variables can interact with the same data in different ways in Rust.
 Let’s look at an example using an integer in Listing 4-2.
 
+<Listing number="4-2" caption="Assigning the integer value of variable `x` to `y`">
+
 ```rust
 {{#rustdoc_include ../listings/ch04-understanding-ownership/listing-04-02/src/main.rs:here}}
 ```
 
-<span class="caption">Listing 4-2: Assigning the integer value of variable `x`
-to `y`</span>
+</Listing>
 
 We can probably guess what this is doing: “bind the value `5` to `x`; then make
 a copy of the value in `x` and bind it to `y`.” We now have two variables, `x`
@@ -429,14 +431,13 @@ assigning a value to a variable. Passing a variable to a function will move or
 copy, just as assignment does. Listing 4-3 has an example with some annotations
 showing where variables go into and out of scope.
 
-<span class="filename">Filename: src/main.rs</span>
+<Listing number="4-3" file-name="src/main.rs" caption="Functions with ownership and scope annotated">
 
 ```rust
 {{#rustdoc_include ../listings/ch04-understanding-ownership/listing-04-03/src/main.rs}}
 ```
 
-<span class="caption">Listing 4-3: Functions with ownership and scope
-annotated</span>
+</Listing>
 
 If we tried to use `s` after the call to `takes_ownership`, Rust would throw a
 compile-time error. These static checks protect us from mistakes. Try adding
@@ -449,14 +450,13 @@ Returning values can also transfer ownership. Listing 4-4 shows an example of a
 function that returns some value, with similar annotations as those in Listing
 4-3.
 
-<span class="filename">Filename: src/main.rs</span>
+<Listing number="4-4" file-name="src/main.rs" caption="Transferring ownership of return values">
 
 ```rust
 {{#rustdoc_include ../listings/ch04-understanding-ownership/listing-04-04/src/main.rs}}
 ```
 
-<span class="caption">Listing 4-4: Transferring ownership of return
-values</span>
+</Listing>
 
 The ownership of a variable follows the same pattern every time: assigning a
 value to another variable moves it. When a variable that includes data on the
@@ -471,13 +471,13 @@ from the body of the function that we might want to return as well.
 
 Rust does let us return multiple values using a tuple, as shown in Listing 4-5.
 
-<span class="filename">Filename: src/main.rs</span>
+<Listing number="4-5" file-name="src/main.rs" caption="Returning ownership of parameters">
 
 ```rust
 {{#rustdoc_include ../listings/ch04-understanding-ownership/listing-04-05/src/main.rs}}
 ```
 
-<span class="caption">Listing 4-5: Returning ownership of parameters</span>
+</Listing>
 
 But this is too much ceremony and a lot of work for a concept that should be
 common. Luckily for us, Rust has a feature for using a value without

--- a/src/ch04-01-what-is-ownership.md
+++ b/src/ch04-01-what-is-ownership.md
@@ -104,9 +104,13 @@ As a first example of ownership, we’ll look at the *scope* of some variables. 
 scope is the range within a program for which an item is valid. Take the
 following variable:
 
+<Listing>
+
 ```rust
 let s = "hello";
 ```
+
+</Listing>
 
 The variable `s` refers to a string literal, where the value of the string is
 hardcoded into the text of our program. The variable is valid from the point at
@@ -156,9 +160,13 @@ data allocated on the heap and as such is able to store an amount of text that
 is unknown to us at compile time. You can create a `String` from a string
 literal using the `from` function, like so:
 
+<Listing>
+
 ```rust
 let s = String::from("hello");
 ```
+
+</Listing>
 
 The double colon `::` operator allows us to namespace this particular `from`
 function under the `String` type rather than using some sort of name like
@@ -169,9 +177,13 @@ Module Tree”][paths-module-tree]<!-- ignore --> in Chapter 7.
 
 This kind of string *can* be mutated:
 
+<Listing>
+
 ```rust
 {{#rustdoc_include ../listings/ch04-understanding-ownership/no-listing-01-can-mutate-string/src/main.rs:here}}
 ```
+
+</Listing>
 
 So, what’s the difference here? Why can `String` be mutated but literals
 cannot? The difference is in how these two types deal with memory.
@@ -211,9 +223,13 @@ Rust takes a different path: the memory is automatically returned once the
 variable that owns it goes out of scope. Here’s a version of our scope example
 from Listing 4-1 using a `String` instead of a string literal:
 
+<Listing>
+
 ```rust
 {{#rustdoc_include ../listings/ch04-understanding-ownership/no-listing-02-string-scope/src/main.rs:here}}
 ```
+
+</Listing>
 
 There is a natural point at which we can return the memory our `String` needs
 to the allocator: when `s` goes out of scope. When a variable goes out of
@@ -256,9 +272,13 @@ onto the stack.
 
 Now let’s look at the `String` version:
 
+<Listing>
+
 ```rust
 {{#rustdoc_include ../listings/ch04-understanding-ownership/no-listing-03-string-move/src/main.rs:here}}
 ```
+
+</Listing>
 
 This looks very similar, so we might assume that the way it works would be the
 same: that is, the second line would make a copy of the value in `s1` and bind
@@ -322,16 +342,24 @@ no longer valid. Therefore, Rust doesn’t need to free anything when `s1` goes
 out of scope. Check out what happens when you try to use `s1` after `s2` is
 created; it won’t work:
 
+<Listing>
+
 ```rust,ignore,does_not_compile
 {{#rustdoc_include ../listings/ch04-understanding-ownership/no-listing-04-cant-use-after-move/src/main.rs:here}}
 ```
 
+</Listing>
+
 You’ll get an error like this because Rust prevents you from using the
 invalidated reference:
+
+<Listing>
 
 ```console
 {{#include ../listings/ch04-understanding-ownership/no-listing-04-cant-use-after-move/output.txt}}
 ```
+
+</Listing>
 
 If you’ve heard the terms *shallow copy* and *deep copy* while working with
 other languages, the concept of copying the pointer, length, and capacity
@@ -368,9 +396,13 @@ programming languages, you’ve probably seen them before.
 
 Here’s an example of the `clone` method in action:
 
+<Listing>
+
 ```rust
 {{#rustdoc_include ../listings/ch04-understanding-ownership/no-listing-05-clone/src/main.rs:here}}
 ```
+
+</Listing>
 
 This works just fine and explicitly produces the behavior shown in Figure 4-3,
 where the heap data *does* get copied.
@@ -384,9 +416,13 @@ different is going on.
 There’s another wrinkle we haven’t talked about yet. This code using
 integers—part of which was shown in Listing 4-2—works and is valid:
 
+<Listing>
+
 ```rust
 {{#rustdoc_include ../listings/ch04-understanding-ownership/no-listing-06-copy/src/main.rs:here}}
 ```
+
+</Listing>
 
 But this code seems to contradict what we just learned: we don’t have a call to
 `clone`, but `x` is still valid and wasn’t moved into `y`.

--- a/src/ch04-01-what-is-ownership.md
+++ b/src/ch04-01-what-is-ownership.md
@@ -104,13 +104,9 @@ As a first example of ownership, we’ll look at the *scope* of some variables. 
 scope is the range within a program for which an item is valid. Take the
 following variable:
 
-<Listing>
-
 ```rust
 let s = "hello";
 ```
-
-</Listing>
 
 The variable `s` refers to a string literal, where the value of the string is
 hardcoded into the text of our program. The variable is valid from the point at
@@ -160,13 +156,9 @@ data allocated on the heap and as such is able to store an amount of text that
 is unknown to us at compile time. You can create a `String` from a string
 literal using the `from` function, like so:
 
-<Listing>
-
 ```rust
 let s = String::from("hello");
 ```
-
-</Listing>
 
 The double colon `::` operator allows us to namespace this particular `from`
 function under the `String` type rather than using some sort of name like
@@ -177,13 +169,9 @@ Module Tree”][paths-module-tree]<!-- ignore --> in Chapter 7.
 
 This kind of string *can* be mutated:
 
-<Listing>
-
 ```rust
 {{#rustdoc_include ../listings/ch04-understanding-ownership/no-listing-01-can-mutate-string/src/main.rs:here}}
 ```
-
-</Listing>
 
 So, what’s the difference here? Why can `String` be mutated but literals
 cannot? The difference is in how these two types deal with memory.
@@ -223,13 +211,9 @@ Rust takes a different path: the memory is automatically returned once the
 variable that owns it goes out of scope. Here’s a version of our scope example
 from Listing 4-1 using a `String` instead of a string literal:
 
-<Listing>
-
 ```rust
 {{#rustdoc_include ../listings/ch04-understanding-ownership/no-listing-02-string-scope/src/main.rs:here}}
 ```
-
-</Listing>
 
 There is a natural point at which we can return the memory our `String` needs
 to the allocator: when `s` goes out of scope. When a variable goes out of
@@ -272,13 +256,9 @@ onto the stack.
 
 Now let’s look at the `String` version:
 
-<Listing>
-
 ```rust
 {{#rustdoc_include ../listings/ch04-understanding-ownership/no-listing-03-string-move/src/main.rs:here}}
 ```
-
-</Listing>
 
 This looks very similar, so we might assume that the way it works would be the
 same: that is, the second line would make a copy of the value in `s1` and bind
@@ -342,24 +322,16 @@ no longer valid. Therefore, Rust doesn’t need to free anything when `s1` goes
 out of scope. Check out what happens when you try to use `s1` after `s2` is
 created; it won’t work:
 
-<Listing>
-
 ```rust,ignore,does_not_compile
 {{#rustdoc_include ../listings/ch04-understanding-ownership/no-listing-04-cant-use-after-move/src/main.rs:here}}
 ```
 
-</Listing>
-
 You’ll get an error like this because Rust prevents you from using the
 invalidated reference:
-
-<Listing>
 
 ```console
 {{#include ../listings/ch04-understanding-ownership/no-listing-04-cant-use-after-move/output.txt}}
 ```
-
-</Listing>
 
 If you’ve heard the terms *shallow copy* and *deep copy* while working with
 other languages, the concept of copying the pointer, length, and capacity
@@ -396,13 +368,9 @@ programming languages, you’ve probably seen them before.
 
 Here’s an example of the `clone` method in action:
 
-<Listing>
-
 ```rust
 {{#rustdoc_include ../listings/ch04-understanding-ownership/no-listing-05-clone/src/main.rs:here}}
 ```
-
-</Listing>
 
 This works just fine and explicitly produces the behavior shown in Figure 4-3,
 where the heap data *does* get copied.
@@ -416,13 +384,9 @@ different is going on.
 There’s another wrinkle we haven’t talked about yet. This code using
 integers—part of which was shown in Listing 4-2—works and is valid:
 
-<Listing>
-
 ```rust
 {{#rustdoc_include ../listings/ch04-understanding-ownership/no-listing-06-copy/src/main.rs:here}}
 ```
-
-</Listing>
 
 But this code seems to contradict what we just learned: we don’t have a call to
 `clone`, but `x` is still valid and wasn’t moved into `y`.

--- a/src/ch04-02-references-and-borrowing.md
+++ b/src/ch04-02-references-and-borrowing.md
@@ -40,13 +40,9 @@ s1`</span>
 
 Let’s take a closer look at the function call here:
 
-<Listing>
-
 ```rust
 {{#rustdoc_include ../listings/ch04-understanding-ownership/no-listing-07-reference/src/main.rs:here}}
 ```
-
-</Listing>
 
 The `&s1` syntax lets us create a reference that *refers* to the value of `s1`
 but does not own it. Because it does not own it, the value it points to will
@@ -55,13 +51,9 @@ not be dropped when the reference stops being used.
 Likewise, the signature of the function uses `&` to indicate that the type of
 the parameter `s` is a reference. Let’s add some explanatory annotations:
 
-<Listing>
-
 ```rust
 {{#rustdoc_include ../listings/ch04-understanding-ownership/no-listing-08-reference-with-annotations/src/main.rs:here}}
 ```
-
-</Listing>
 
 The scope in which the variable `s` is valid is the same as any function
 parameter’s scope, but the value pointed to by the reference is not dropped
@@ -87,13 +79,9 @@ Listing 4-6. Spoiler alert: it doesn’t work!
 
 Here’s the error:
 
-<Listing>
-
 ```console
 {{#include ../listings/ch04-understanding-ownership/listing-04-06/output.txt}}
 ```
-
-</Listing>
 
 Just as variables are immutable by default, so are references. We’re not
 allowed to modify something we have a reference to.
@@ -130,13 +118,9 @@ attempts to create two mutable references to `s` will fail:
 
 Here’s the error:
 
-<Listing>
-
 ```console
 {{#include ../listings/ch04-understanding-ownership/no-listing-10-multiple-mut-not-allowed/output.txt}}
 ```
-
-</Listing>
 
 This error says that this code is invalid because we cannot borrow `s` as
 mutable more than once at a time. The first mutable borrow is in `r1` and must
@@ -162,34 +146,22 @@ refusing to compile code with data races!
 As always, we can use curly brackets to create a new scope, allowing for
 multiple mutable references, just not *simultaneous* ones:
 
-<Listing>
-
 ```rust
 {{#rustdoc_include ../listings/ch04-understanding-ownership/no-listing-11-muts-in-separate-scopes/src/main.rs:here}}
 ```
 
-</Listing>
-
 Rust enforces a similar rule for combining mutable and immutable references.
 This code results in an error:
-
-<Listing>
 
 ```rust,ignore,does_not_compile
 {{#rustdoc_include ../listings/ch04-understanding-ownership/no-listing-12-immutable-and-mutable-not-allowed/src/main.rs:here}}
 ```
 
-</Listing>
-
 Here’s the error:
-
-<Listing>
 
 ```console
 {{#include ../listings/ch04-understanding-ownership/no-listing-12-immutable-and-mutable-not-allowed/output.txt}}
 ```
-
-</Listing>
 
 Whew! We *also* cannot have a mutable reference while we have an immutable one
 to the same value.
@@ -204,13 +176,9 @@ through the last time that reference is used. For instance, this code will
 compile because the last usage of the immutable references, the `println!`,
 occurs before the mutable reference is introduced:
 
-<Listing>
-
 ```rust,edition2021
 {{#rustdoc_include ../listings/ch04-understanding-ownership/no-listing-13-reference-scope-ends/src/main.rs:here}}
 ```
-
-</Listing>
 
 The scopes of the immutable references `r1` and `r2` end after the `println!`
 where they are last used, which is before the mutable reference `r3` is
@@ -246,26 +214,18 @@ compile-time error:
 
 Here’s the error:
 
-<Listing>
-
 ```console
 {{#include ../listings/ch04-understanding-ownership/no-listing-14-dangling-reference/output.txt}}
 ```
-
-</Listing>
 
 This error message refers to a feature we haven’t covered yet: lifetimes. We’ll
 discuss lifetimes in detail in Chapter 10. But, if you disregard the parts
 about lifetimes, the message does contain the key to why this code is a problem:
 
-<Listing>
-
 ```text
 this function's return type contains a borrowed value, but there is no value
 for it to be borrowed from
 ```
-
-</Listing>
 
 Let’s take a closer look at exactly what’s happening at each stage of our
 `dangle` code:
@@ -285,13 +245,9 @@ won’t let us do this.
 
 The solution here is to return the `String` directly:
 
-<Listing>
-
 ```rust
 {{#rustdoc_include ../listings/ch04-understanding-ownership/no-listing-16-no-dangle/src/main.rs:here}}
 ```
-
-</Listing>
 
 This works without any problems. Ownership is moved out, and nothing is
 deallocated.

--- a/src/ch04-02-references-and-borrowing.md
+++ b/src/ch04-02-references-and-borrowing.md
@@ -67,13 +67,13 @@ to give it back. You don’t own it.
 So, what happens if we try to modify something we’re borrowing? Try the code in
 Listing 4-6. Spoiler alert: it doesn’t work!
 
-<span class="filename">Filename: src/main.rs</span>
+<Listing number="4-6" file-name="src/main.rs" caption="Attempting to modify a borrowed value">
 
 ```rust,ignore,does_not_compile
 {{#rustdoc_include ../listings/ch04-understanding-ownership/listing-04-06/src/main.rs}}
 ```
 
-<span class="caption">Listing 4-6: Attempting to modify a borrowed value</span>
+</Listing>
 
 Here’s the error:
 

--- a/src/ch04-02-references-and-borrowing.md
+++ b/src/ch04-02-references-and-borrowing.md
@@ -12,11 +12,13 @@ particular type for the life of that reference.
 Here is how you would define and use a `calculate_length` function that has a
 reference to an object as a parameter instead of taking ownership of the value:
 
-<span class="filename">Filename: src/main.rs</span>
+<Listing file-name="src/main.rs">
 
 ```rust
 {{#rustdoc_include ../listings/ch04-understanding-ownership/no-listing-07-reference/src/main.rs:all}}
 ```
+
+</Listing>
 
 First, notice that all the tuple code in the variable declaration and the
 function return value is gone. Second, note that we pass `&s1` into
@@ -89,11 +91,13 @@ allowed to modify something we have a reference to.
 We can fix the code from Listing 4-6 to allow us to modify a borrowed value
 with just a few small tweaks that use, instead, a *mutable reference*:
 
-<span class="filename">Filename: src/main.rs</span>
+<Listing file-name="src/main.rs">
 
 ```rust
 {{#rustdoc_include ../listings/ch04-understanding-ownership/no-listing-09-fixes-listing-04-06/src/main.rs}}
 ```
+
+</Listing>
 
 First we change `s` to be `mut`. Then we create a mutable reference with `&mut
 s` where we call the `change` function, and update the function signature to
@@ -104,11 +108,13 @@ Mutable references have one big restriction: if you have a mutable reference to
 a value, you can have no other references to that value. This code that
 attempts to create two mutable references to `s` will fail:
 
-<span class="filename">Filename: src/main.rs</span>
+<Listing file-name="src/main.rs">
 
 ```rust,ignore,does_not_compile
 {{#rustdoc_include ../listings/ch04-understanding-ownership/no-listing-10-multiple-mut-not-allowed/src/main.rs:here}}
 ```
+
+</Listing>
 
 Here’s the error:
 
@@ -198,11 +204,13 @@ reference to the data does.
 Let’s try to create a dangling reference to see how Rust prevents them with a
 compile-time error:
 
-<span class="filename">Filename: src/main.rs</span>
+<Listing file-name="src/main.rs">
 
 ```rust,ignore,does_not_compile
 {{#rustdoc_include ../listings/ch04-understanding-ownership/no-listing-14-dangling-reference/src/main.rs}}
 ```
+
+</Listing>
 
 Here’s the error:
 
@@ -222,11 +230,13 @@ for it to be borrowed from
 Let’s take a closer look at exactly what’s happening at each stage of our
 `dangle` code:
 
-<span class="filename">Filename: src/main.rs</span>
+<Listing file-name="src/main.rs">
 
 ```rust,ignore,does_not_compile
 {{#rustdoc_include ../listings/ch04-understanding-ownership/no-listing-15-dangling-reference-annotated/src/main.rs:here}}
 ```
+
+</Listing>
 
 Because `s` is created inside `dangle`, when the code of `dangle` is finished,
 `s` will be deallocated. But we tried to return a reference to it. That means

--- a/src/ch04-02-references-and-borrowing.md
+++ b/src/ch04-02-references-and-borrowing.md
@@ -40,9 +40,13 @@ s1`</span>
 
 Let’s take a closer look at the function call here:
 
+<Listing>
+
 ```rust
 {{#rustdoc_include ../listings/ch04-understanding-ownership/no-listing-07-reference/src/main.rs:here}}
 ```
+
+</Listing>
 
 The `&s1` syntax lets us create a reference that *refers* to the value of `s1`
 but does not own it. Because it does not own it, the value it points to will
@@ -51,9 +55,13 @@ not be dropped when the reference stops being used.
 Likewise, the signature of the function uses `&` to indicate that the type of
 the parameter `s` is a reference. Let’s add some explanatory annotations:
 
+<Listing>
+
 ```rust
 {{#rustdoc_include ../listings/ch04-understanding-ownership/no-listing-08-reference-with-annotations/src/main.rs:here}}
 ```
+
+</Listing>
 
 The scope in which the variable `s` is valid is the same as any function
 parameter’s scope, but the value pointed to by the reference is not dropped
@@ -79,9 +87,13 @@ Listing 4-6. Spoiler alert: it doesn’t work!
 
 Here’s the error:
 
+<Listing>
+
 ```console
 {{#include ../listings/ch04-understanding-ownership/listing-04-06/output.txt}}
 ```
+
+</Listing>
 
 Just as variables are immutable by default, so are references. We’re not
 allowed to modify something we have a reference to.
@@ -118,9 +130,13 @@ attempts to create two mutable references to `s` will fail:
 
 Here’s the error:
 
+<Listing>
+
 ```console
 {{#include ../listings/ch04-understanding-ownership/no-listing-10-multiple-mut-not-allowed/output.txt}}
 ```
+
+</Listing>
 
 This error says that this code is invalid because we cannot borrow `s` as
 mutable more than once at a time. The first mutable borrow is in `r1` and must
@@ -146,22 +162,34 @@ refusing to compile code with data races!
 As always, we can use curly brackets to create a new scope, allowing for
 multiple mutable references, just not *simultaneous* ones:
 
+<Listing>
+
 ```rust
 {{#rustdoc_include ../listings/ch04-understanding-ownership/no-listing-11-muts-in-separate-scopes/src/main.rs:here}}
 ```
 
+</Listing>
+
 Rust enforces a similar rule for combining mutable and immutable references.
 This code results in an error:
+
+<Listing>
 
 ```rust,ignore,does_not_compile
 {{#rustdoc_include ../listings/ch04-understanding-ownership/no-listing-12-immutable-and-mutable-not-allowed/src/main.rs:here}}
 ```
 
+</Listing>
+
 Here’s the error:
+
+<Listing>
 
 ```console
 {{#include ../listings/ch04-understanding-ownership/no-listing-12-immutable-and-mutable-not-allowed/output.txt}}
 ```
+
+</Listing>
 
 Whew! We *also* cannot have a mutable reference while we have an immutable one
 to the same value.
@@ -176,9 +204,13 @@ through the last time that reference is used. For instance, this code will
 compile because the last usage of the immutable references, the `println!`,
 occurs before the mutable reference is introduced:
 
+<Listing>
+
 ```rust,edition2021
 {{#rustdoc_include ../listings/ch04-understanding-ownership/no-listing-13-reference-scope-ends/src/main.rs:here}}
 ```
+
+</Listing>
 
 The scopes of the immutable references `r1` and `r2` end after the `println!`
 where they are last used, which is before the mutable reference `r3` is
@@ -214,18 +246,26 @@ compile-time error:
 
 Here’s the error:
 
+<Listing>
+
 ```console
 {{#include ../listings/ch04-understanding-ownership/no-listing-14-dangling-reference/output.txt}}
 ```
+
+</Listing>
 
 This error message refers to a feature we haven’t covered yet: lifetimes. We’ll
 discuss lifetimes in detail in Chapter 10. But, if you disregard the parts
 about lifetimes, the message does contain the key to why this code is a problem:
 
+<Listing>
+
 ```text
 this function's return type contains a borrowed value, but there is no value
 for it to be borrowed from
 ```
+
+</Listing>
 
 Let’s take a closer look at exactly what’s happening at each stage of our
 `dangle` code:
@@ -245,9 +285,13 @@ won’t let us do this.
 
 The solution here is to return the `String` directly:
 
+<Listing>
+
 ```rust
 {{#rustdoc_include ../listings/ch04-understanding-ownership/no-listing-16-no-dangle/src/main.rs:here}}
 ```
+
+</Listing>
 
 This works without any problems. Ownership is moved out, and nothing is
 deallocated.

--- a/src/ch04-03-slices.md
+++ b/src/ch04-03-slices.md
@@ -21,14 +21,13 @@ ownership, so this is fine. But what should we return? We don’t really have a
 way to talk about *part* of a string. However, we could return the index of the
 end of the word, indicated by a space. Let’s try that, as shown in Listing 4-7.
 
-<span class="filename">Filename: src/main.rs</span>
+<Listing number="4-7" file-name="src/main.rs" caption="The `first_word` function that returns a byte index value into the `String` parameter">
 
 ```rust
 {{#rustdoc_include ../listings/ch04-understanding-ownership/listing-04-07/src/main.rs:here}}
 ```
 
-<span class="caption">Listing 4-7: The `first_word` function that returns a
-byte index value into the `String` parameter</span>
+</Listing>
 
 Because we need to go through the `String` element by element and check whether
 a value is a space, we’ll convert our `String` to an array of bytes using the
@@ -73,14 +72,13 @@ because it’s a separate value from the `String`, there’s no guarantee that i
 will still be valid in the future. Consider the program in Listing 4-8 that
 uses the `first_word` function from Listing 4-7.
 
-<span class="filename">Filename: src/main.rs</span>
+<Listing number="4-8" file-name="src/main.rs" caption="Storing the result from calling the `first_word` function and then changing the `String` contents">
 
 ```rust
 {{#rustdoc_include ../listings/ch04-understanding-ownership/listing-04-08/src/main.rs:here}}
 ```
 
-<span class="caption">Listing 4-8: Storing the result from calling the
-`first_word` function and then changing the `String` contents</span>
+</Listing>
 
 This program compiles without any errors and would also do so if we used `word`
 after calling `s.clear()`. Because `word` isn’t connected to the state of `s`
@@ -257,12 +255,13 @@ A more experienced Rustacean would write the signature shown in Listing 4-9
 instead because it allows us to use the same function on both `&String` values
 and `&str` values.
 
+<Listing number="4-9" caption="Improving the `first_word` function by using a string slice for the type of the `s` parameter">
+
 ```rust,ignore
 {{#rustdoc_include ../listings/ch04-understanding-ownership/listing-04-09/src/main.rs:here}}
 ```
 
-<span class="caption">Listing 4-9: Improving the `first_word` function by using
-a string slice for the type of the `s` parameter</span>
+</Listing>
 
 If we have a string slice, we can pass that directly. If we have a `String`, we
 can pass a slice of the `String` or a reference to the `String`. This

--- a/src/ch04-03-slices.md
+++ b/src/ch04-03-slices.md
@@ -12,13 +12,9 @@ one word, so the entire string should be returned.
 Let’s work through how we’d write the signature of this function without using
 slices, to understand the problem that slices will solve:
 
-<Listing>
-
 ```rust,ignore
 fn first_word(s: &String) -> ?
 ```
-
-</Listing>
 
 The `first_word` function has a `&String` as a parameter. We don’t want
 ownership, so this is fine. But what should we return? We don’t really have a
@@ -37,23 +33,15 @@ Because we need to go through the `String` element by element and check whether
 a value is a space, we’ll convert our `String` to an array of bytes using the
 `as_bytes` method.
 
-<Listing>
-
 ```rust,ignore
 {{#rustdoc_include ../listings/ch04-understanding-ownership/listing-04-07/src/main.rs:as_bytes}}
 ```
 
-</Listing>
-
 Next, we create an iterator over the array of bytes using the `iter` method:
-
-<Listing>
 
 ```rust,ignore
 {{#rustdoc_include ../listings/ch04-understanding-ownership/listing-04-07/src/main.rs:iter}}
 ```
-
-</Listing>
 
 We’ll discuss iterators in more detail in [Chapter 13][ch13]<!-- ignore -->.
 For now, know that `iter` is a method that returns each element in a collection
@@ -73,13 +61,9 @@ Inside the `for` loop, we search for the byte that represents the space by
 using the byte literal syntax. If we find a space, we return the position.
 Otherwise, we return the length of the string by using `s.len()`.
 
-<Listing>
-
 ```rust,ignore
 {{#rustdoc_include ../listings/ch04-understanding-ownership/listing-04-07/src/main.rs:inside_for}}
 ```
-
-</Listing>
 
 We now have a way to find out the index of the end of the first word in the
 string, but there’s a problem. We’re returning a `usize` on its own, but it’s
@@ -106,13 +90,9 @@ Having to worry about the index in `word` getting out of sync with the data in
 `s` is tedious and error prone! Managing these indices is even more brittle if
 we write a `second_word` function. Its signature would have to look like this:
 
-<Listing>
-
 ```rust,ignore
 fn second_word(s: &String) -> (usize, usize) {
 ```
-
-</Listing>
 
 Now we’re tracking a starting *and* an ending index, and we have even more
 values that were calculated from data in a particular state but aren’t tied to
@@ -125,13 +105,9 @@ Luckily, Rust has a solution to this problem: string slices.
 
 A *string slice* is a reference to part of a `String`, and it looks like this:
 
-<Listing>
-
 ```rust
 {{#rustdoc_include ../listings/ch04-understanding-ownership/no-listing-17-slice/src/main.rs:here}}
 ```
-
-</Listing>
 
 Rather than a reference to the entire `String`, `hello` is a reference to a
 portion of the `String`, specified in the extra `[0..5]` bit. We create slices
@@ -157,8 +133,6 @@ src="img/trpl04-06.svg" class="center" style="width: 50%;" />
 With Rust’s `..` range syntax, if you want to start at index 0, you can drop
 the value before the two periods. In other words, these are equal:
 
-<Listing>
-
 ```rust
 let s = String::from("hello");
 
@@ -166,12 +140,8 @@ let slice = &s[0..2];
 let slice = &s[..2];
 ```
 
-</Listing>
-
 By the same token, if your slice includes the last byte of the `String`, you
 can drop the trailing number. That means these are equal:
-
-<Listing>
 
 ```rust
 let s = String::from("hello");
@@ -182,12 +152,8 @@ let slice = &s[3..len];
 let slice = &s[3..];
 ```
 
-</Listing>
-
 You can also drop both values to take a slice of the entire string. So these
 are equal:
-
-<Listing>
 
 ```rust
 let s = String::from("hello");
@@ -197,8 +163,6 @@ let len = s.len();
 let slice = &s[0..len];
 let slice = &s[..];
 ```
-
-</Listing>
 
 > Note: String slice range indices must occur at valid UTF-8 character
 > boundaries. If you attempt to create a string slice in the middle of a
@@ -229,13 +193,9 @@ the slice and the number of elements in the slice.
 
 Returning a slice would also work for a `second_word` function:
 
-<Listing>
-
 ```rust,ignore
 fn second_word(s: &String) -> &str {
 ```
-
-</Listing>
 
 We now have a straightforward API that’s much harder to mess up because the
 compiler will ensure the references into the `String` remain valid. Remember
@@ -257,13 +217,9 @@ compile-time error:
 
 Here’s the compiler error:
 
-<Listing>
-
 ```console
 {{#include ../listings/ch04-understanding-ownership/no-listing-19-slice-error/output.txt}}
 ```
-
-</Listing>
 
 Recall from the borrowing rules that if we have an immutable reference to
 something, we cannot also take a mutable reference. Because `clear` needs to
@@ -282,13 +238,9 @@ but it has also eliminated an entire class of errors at compile time!
 Recall that we talked about string literals being stored inside the binary. Now
 that we know about slices, we can properly understand string literals:
 
-<Listing>
-
 ```rust
 let s = "Hello, world!";
 ```
-
-</Listing>
 
 The type of `s` here is `&str`: it’s a slice pointing to that specific point of
 the binary. This is also why string literals are immutable; `&str` is an
@@ -299,13 +251,9 @@ immutable reference.
 Knowing that you can take slices of literals and `String` values leads us to
 one more improvement on `first_word`, and that’s its signature:
 
-<Listing>
-
 ```rust,ignore
 fn first_word(s: &String) -> &str {
 ```
-
-</Listing>
 
 A more experienced Rustacean would write the signature shown in Listing 4-9
 instead because it allows us to use the same function on both `&String` values
@@ -341,18 +289,12 @@ makes our API more general and useful without losing any functionality:
 String slices, as you might imagine, are specific to strings. But there’s a
 more general slice type too. Consider this array:
 
-<Listing>
-
 ```rust
 let a = [1, 2, 3, 4, 5];
 ```
 
-</Listing>
-
 Just as we might want to refer to part of a string, we might want to refer to
 part of an array. We’d do so like this:
-
-<Listing>
 
 ```rust
 let a = [1, 2, 3, 4, 5];
@@ -361,8 +303,6 @@ let slice = &a[1..3];
 
 assert_eq!(slice, &[2, 3]);
 ```
-
-</Listing>
 
 This slice has the type `&[i32]`. It works the same way as string slices do, by
 storing a reference to the first element and a length. You’ll use this kind of

--- a/src/ch04-03-slices.md
+++ b/src/ch04-03-slices.md
@@ -174,11 +174,13 @@ let slice = &s[..];
 With all this information in mind, let’s rewrite `first_word` to return a
 slice. The type that signifies “string slice” is written as `&str`:
 
-<span class="filename">Filename: src/main.rs</span>
+<Listing file-name="src/main.rs">
 
 ```rust
 {{#rustdoc_include ../listings/ch04-understanding-ownership/no-listing-18-first-word-slice/src/main.rs:here}}
 ```
+
+</Listing>
 
 We get the index for the end of the word the same way we did in Listing 4-7, by
 looking for the first occurrence of a space. When we find a space, we return a
@@ -205,11 +207,13 @@ string. Slices make this bug impossible and let us know we have a problem with
 our code much sooner. Using the slice version of `first_word` will throw a
 compile-time error:
 
-<span class="filename">Filename: src/main.rs</span>
+<Listing file-name="src/main.rs">
 
 ```rust,ignore,does_not_compile
 {{#rustdoc_include ../listings/ch04-understanding-ownership/no-listing-19-slice-error/src/main.rs:here}}
 ```
+
+</Listing>
 
 Here’s the compiler error:
 
@@ -272,11 +276,13 @@ Methods”][deref-coercions]<!--ignore--> section of Chapter 15.
 Defining a function to take a string slice instead of a reference to a `String`
 makes our API more general and useful without losing any functionality:
 
-<span class="filename">Filename: src/main.rs</span>
+<Listing file-name="src/main.rs">
 
 ```rust
 {{#rustdoc_include ../listings/ch04-understanding-ownership/listing-04-09/src/main.rs:usage}}
 ```
+
+</Listing>
 
 ### Other Slices
 

--- a/src/ch04-03-slices.md
+++ b/src/ch04-03-slices.md
@@ -12,9 +12,13 @@ one word, so the entire string should be returned.
 Let’s work through how we’d write the signature of this function without using
 slices, to understand the problem that slices will solve:
 
+<Listing>
+
 ```rust,ignore
 fn first_word(s: &String) -> ?
 ```
+
+</Listing>
 
 The `first_word` function has a `&String` as a parameter. We don’t want
 ownership, so this is fine. But what should we return? We don’t really have a
@@ -33,15 +37,23 @@ Because we need to go through the `String` element by element and check whether
 a value is a space, we’ll convert our `String` to an array of bytes using the
 `as_bytes` method.
 
+<Listing>
+
 ```rust,ignore
 {{#rustdoc_include ../listings/ch04-understanding-ownership/listing-04-07/src/main.rs:as_bytes}}
 ```
 
+</Listing>
+
 Next, we create an iterator over the array of bytes using the `iter` method:
+
+<Listing>
 
 ```rust,ignore
 {{#rustdoc_include ../listings/ch04-understanding-ownership/listing-04-07/src/main.rs:iter}}
 ```
+
+</Listing>
 
 We’ll discuss iterators in more detail in [Chapter 13][ch13]<!-- ignore -->.
 For now, know that `iter` is a method that returns each element in a collection
@@ -61,9 +73,13 @@ Inside the `for` loop, we search for the byte that represents the space by
 using the byte literal syntax. If we find a space, we return the position.
 Otherwise, we return the length of the string by using `s.len()`.
 
+<Listing>
+
 ```rust,ignore
 {{#rustdoc_include ../listings/ch04-understanding-ownership/listing-04-07/src/main.rs:inside_for}}
 ```
+
+</Listing>
 
 We now have a way to find out the index of the end of the first word in the
 string, but there’s a problem. We’re returning a `usize` on its own, but it’s
@@ -90,9 +106,13 @@ Having to worry about the index in `word` getting out of sync with the data in
 `s` is tedious and error prone! Managing these indices is even more brittle if
 we write a `second_word` function. Its signature would have to look like this:
 
+<Listing>
+
 ```rust,ignore
 fn second_word(s: &String) -> (usize, usize) {
 ```
+
+</Listing>
 
 Now we’re tracking a starting *and* an ending index, and we have even more
 values that were calculated from data in a particular state but aren’t tied to
@@ -105,9 +125,13 @@ Luckily, Rust has a solution to this problem: string slices.
 
 A *string slice* is a reference to part of a `String`, and it looks like this:
 
+<Listing>
+
 ```rust
 {{#rustdoc_include ../listings/ch04-understanding-ownership/no-listing-17-slice/src/main.rs:here}}
 ```
+
+</Listing>
 
 Rather than a reference to the entire `String`, `hello` is a reference to a
 portion of the `String`, specified in the extra `[0..5]` bit. We create slices
@@ -133,6 +157,8 @@ src="img/trpl04-06.svg" class="center" style="width: 50%;" />
 With Rust’s `..` range syntax, if you want to start at index 0, you can drop
 the value before the two periods. In other words, these are equal:
 
+<Listing>
+
 ```rust
 let s = String::from("hello");
 
@@ -140,8 +166,12 @@ let slice = &s[0..2];
 let slice = &s[..2];
 ```
 
+</Listing>
+
 By the same token, if your slice includes the last byte of the `String`, you
 can drop the trailing number. That means these are equal:
+
+<Listing>
 
 ```rust
 let s = String::from("hello");
@@ -152,8 +182,12 @@ let slice = &s[3..len];
 let slice = &s[3..];
 ```
 
+</Listing>
+
 You can also drop both values to take a slice of the entire string. So these
 are equal:
+
+<Listing>
 
 ```rust
 let s = String::from("hello");
@@ -163,6 +197,8 @@ let len = s.len();
 let slice = &s[0..len];
 let slice = &s[..];
 ```
+
+</Listing>
 
 > Note: String slice range indices must occur at valid UTF-8 character
 > boundaries. If you attempt to create a string slice in the middle of a
@@ -193,9 +229,13 @@ the slice and the number of elements in the slice.
 
 Returning a slice would also work for a `second_word` function:
 
+<Listing>
+
 ```rust,ignore
 fn second_word(s: &String) -> &str {
 ```
+
+</Listing>
 
 We now have a straightforward API that’s much harder to mess up because the
 compiler will ensure the references into the `String` remain valid. Remember
@@ -217,9 +257,13 @@ compile-time error:
 
 Here’s the compiler error:
 
+<Listing>
+
 ```console
 {{#include ../listings/ch04-understanding-ownership/no-listing-19-slice-error/output.txt}}
 ```
+
+</Listing>
 
 Recall from the borrowing rules that if we have an immutable reference to
 something, we cannot also take a mutable reference. Because `clear` needs to
@@ -238,9 +282,13 @@ but it has also eliminated an entire class of errors at compile time!
 Recall that we talked about string literals being stored inside the binary. Now
 that we know about slices, we can properly understand string literals:
 
+<Listing>
+
 ```rust
 let s = "Hello, world!";
 ```
+
+</Listing>
 
 The type of `s` here is `&str`: it’s a slice pointing to that specific point of
 the binary. This is also why string literals are immutable; `&str` is an
@@ -251,9 +299,13 @@ immutable reference.
 Knowing that you can take slices of literals and `String` values leads us to
 one more improvement on `first_word`, and that’s its signature:
 
+<Listing>
+
 ```rust,ignore
 fn first_word(s: &String) -> &str {
 ```
+
+</Listing>
 
 A more experienced Rustacean would write the signature shown in Listing 4-9
 instead because it allows us to use the same function on both `&String` values
@@ -289,12 +341,18 @@ makes our API more general and useful without losing any functionality:
 String slices, as you might imagine, are specific to strings. But there’s a
 more general slice type too. Consider this array:
 
+<Listing>
+
 ```rust
 let a = [1, 2, 3, 4, 5];
 ```
 
+</Listing>
+
 Just as we might want to refer to part of a string, we might want to refer to
 part of an array. We’d do so like this:
+
+<Listing>
 
 ```rust
 let a = [1, 2, 3, 4, 5];
@@ -303,6 +361,8 @@ let slice = &a[1..3];
 
 assert_eq!(slice, &[2, 3]);
 ```
+
+</Listing>
 
 This slice has the type `&[i32]`. It works the same way as string slices do, by
 storing a reference to the first element and a length. You’ll use this kind of


### PR DESCRIPTION
Reference: https://github.com/rust-lang/book/issues/3919

Convert ch04 to `<Listing>`.