### PR TITLE
Mention move of individual struct fields in struct update syntax

### DIFF
--- a/src/ch05-01-defining-structs.md
+++ b/src/ch05-01-defining-structs.md
@@ -147,14 +147,18 @@ the struct’s definition.
 
 Note that the struct update syntax uses `=` like an assignment; this is because
 it moves the data, just as we saw in the [“Variables and Data Interacting with
-Move”][move]<!-- ignore --> section. In this example, we can no longer use
-`user1` as a whole after creating `user2` because the `String` in the
-`username` field of `user1` was moved into `user2`. If we had given `user2` new
-`String` values for both `email` and `username`, and thus only used the
-`active` and `sign_in_count` values from `user1`, then `user1` would still be
-valid after creating `user2`. Both `active` and `sign_in_count` are types that
-implement the `Copy` trait, so the behavior we discussed in the [“Stack-Only
-Data: Copy”][copy]<!-- ignore --> section would apply.
+Move”][move]<!-- ignore --> section. However, the fields are moved
+individually, and the original struct is not invalidated if it contains
+reference the data that wasn't moved.
+
+In Listing 5-7, we can no longer use `user1.username` because it was moved into
+`user2.username`. However, we can continue to use `user1.email` normally. If we
+had given `user2` new `String` values for both `email` and `username`, and thus
+only used the `active` and `sign_in_count` values from `user1`, then
+`user1.username` would still be valid after creating `user2`. Both `active` and
+`sign_in_count` are types that implement the `Copy` trait, so the behavior we
+discussed in the [“Stack-Only Data: Copy”][copy]<!-- ignore --> section would
+apply.
 
 ### Using Tuple Structs Without Named Fields to Create Different Types
 

--- a/src/ch05-01-defining-structs.md
+++ b/src/ch05-01-defining-structs.md
@@ -147,18 +147,14 @@ the struct’s definition.
 
 Note that the struct update syntax uses `=` like an assignment; this is because
 it moves the data, just as we saw in the [“Variables and Data Interacting with
-Move”][move]<!-- ignore --> section. However, the fields are moved
-individually, and the original struct is not invalidated if it contains
-reference the data that wasn't moved.
-
-In Listing 5-7, we can no longer use `user1.username` because it was moved into
-`user2.username`. However, we can continue to use `user1.email` normally. If we
-had given `user2` new `String` values for both `email` and `username`, and thus
-only used the `active` and `sign_in_count` values from `user1`, then
-`user1.username` would still be valid after creating `user2`. Both `active` and
-`sign_in_count` are types that implement the `Copy` trait, so the behavior we
-discussed in the [“Stack-Only Data: Copy”][copy]<!-- ignore --> section would
-apply.
+Move”][move]<!-- ignore --> section. In this example, we can no longer use
+`user1` as a whole after creating `user2` because the `String` in the
+`username` field of `user1` was moved into `user2`. If we had given `user2` new
+`String` values for both `email` and `username`, and thus only used the
+`active` and `sign_in_count` values from `user1`, then `user1` would still be
+valid after creating `user2`. Both `active` and `sign_in_count` are types that
+implement the `Copy` trait, so the behavior we discussed in the [“Stack-Only
+Data: Copy”][copy]<!-- ignore --> section would apply.
 
 ### Using Tuple Structs Without Named Fields to Create Different Types
 

--- a/src/ch05-01-defining-structs.md
+++ b/src/ch05-01-defining-structs.md
@@ -154,7 +154,8 @@ Move”][move]<!-- ignore --> section. In this example, we can no longer use
 `active` and `sign_in_count` values from `user1`, then `user1` would still be
 valid after creating `user2`. Both `active` and `sign_in_count` are types that
 implement the `Copy` trait, so the behavior we discussed in the [“Stack-Only
-Data: Copy”][copy]<!-- ignore --> section would apply.
+Data: Copy”][copy]<!-- ignore --> section would apply. We can still use
+`user1.email` in this example, since its value was _not_ moved out.
 
 ### Using Tuple Structs Without Named Fields to Create Different Types
 


### PR DESCRIPTION
I would like to propose improvements to the text under the section "Creating Instances from Other Instances with Struct Update Syntax" in Chapter 5. I would welcome any improvements to the new text that I'm proposing.

When using the struct update syntax, the original struct is *not* invalidated: only those fields that were *individually* moved into the new struct.

In the original text, watch out for the emphases that I added:

> Note that the struct update syntax uses `=` like an assignment; this is because it moves the data, just as we saw in the “Variables and Data Interacting with Move” section. In this example, **we can no longer use `user1` as a whole** after creating `user2` because the `String` in the `username` field of `user1` was moved into `user2`. If we had given `user2` new `String` values for both `email` and `username`, and thus only used the `active` and `sign_in_count` values from `user1`, **then `user1` would still be valid** after creating `user2`. Both `active` and `sign_in_count` are types that implement the `Copy` trait, so the behavior we discussed in the “Stack-Only Data: Copy” section would apply.

It reads:
- **we can no longer use `user1` as a whole**: When you say "as a whole", it reads to me like the entirety of the struct has been invalidated and cannot be used anymore, which is not true. I am not a native English speaker, so please forgive me if this is just because of my poor English communication skills.
- **then `user1` would still be valid**: which implies that `user1` is *not* valid. But it remains valid (in the sense that you can still access any fields that weren't moved), as least in the latest version of the compiler. Maybe this is a remnant from older versions?

For proof, here's a Rust program (based on the examples in the book) that compiles, and runs, and outputs as expected:

```rust
struct User {
    active: bool,
    username: String,
    email: String,
    sign_in_count: u64,
}

fn main() {
    let user1 = User {
        active: true,
        username: String::from("someusername123"),
        email: String::from("someone@example.com"),
        sign_in_count: 1,
    };

    let user2 = User {
        email: String::from("another@example.com"),
        ..user1
    };

    println!("{} active: {}", user1.email, user1.active);  // Note that I am using `user1.email` here.
    println!("{} active: {}", user2.email, user2.active);
}
```

Then, the following code will *not* compile, as expected:

```rust
struct User {
    active: bool,
    username: String,
    email: String,
    sign_in_count: u64,
}

fn main() {
    let user1 = User {
        active: true,
        username: String::from("someusername123"),
        email: String::from("someone@example.com"),
        sign_in_count: 1,
    };

    let user2 = User {
        email: String::from("another@example.com"),
        ..user1
    };

    println!("{} active: {}", user1.email, user1.active);
    println!("{} active: {}", user2.email, user2.active);

    println!("{}", user1.username); // This tries to use `user1.username`,
                                    // but it was moved into `user2`.
}
```

This is the compiler message that I'm getting with `rustc 1.81.0 (eeb90cda1 2024-09-04)`.

```
   Compiling learn_rust v0.1.0 (/Users/jpmelos/devel/learn_rust)
error[E0382]: borrow of moved value: `user1.username`
  --> src/main.rs:24:20
   |
16 |       let user2 = User {
   |  _________________-
17 | |         email: String::from("another@example.com"),
18 | |         ..user1
19 | |     };
   | |_____- value moved here
...
24 |       println!("{}", user1.username);
   |                      ^^^^^^^^^^^^^^ value borrowed here after move
   |
   = note: move occurs because `user1.username` has type `String`, which does not implement the `Copy` trait
   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0382`.
error: could not compile `learn_rust` (bin "learn_rust") due to 1 previous error
```