### PR TITLE
Mention scope of bound variables in `match` and `if let`

### DIFF
--- a/src/ch06-02-match.md
+++ b/src/ch06-02-match.md
@@ -101,7 +101,9 @@ would be `Coin::Quarter(UsState::Alaska)`. When we compare that value with each
 of the match arms, none of them match until we reach `Coin::Quarter(state)`. At
 that point, the binding for `state` will be the value `UsState::Alaska`. We can
 then use that binding in the `println!` expression, thus getting the inner
-state value out of the `Coin` enum variant for `Quarter`.
+state value out of the `Coin` enum variant for `Quarter`. The binding is only
+valid for the scope defined by the right side of the arm, and cannot be
+used once that scope is over.
 
 ### Matching with `Option<T>`
 

--- a/src/ch06-03-if-let.md
+++ b/src/ch06-03-if-let.md
@@ -31,8 +31,10 @@ sign. It works the same way as a `match`, where the expression is given to the
 `match` and the pattern is its first arm. In this case, the pattern is
 `Some(max)`, and the `max` binds to the value inside the `Some`. We can then
 use `max` in the body of the `if let` block in the same way we used `max` in
-the corresponding `match` arm. The code in the `if let` block isn’t run if the
-value doesn’t match the pattern.
+the corresponding `match` arm. Much like `match`, the binding is only valid for
+the duration of the scope defined by the `if let`, and cannot be used later.
+The code in the `if let` block isn’t run if the value doesn’t match the
+pattern.
 
 Using `if let` means less typing, less indentation, and less boilerplate code.
 However, you lose the exhaustive checking that `match` enforces. Choosing


### PR DESCRIPTION
I would like to propose that we mention the scope of bound variables in `match` and `if let` arms.

If I try this:

```rust
fn main() {
    let non_null: Option<u8> = Some(1);

    match non_null {
        Some(number) => {
            println!("A number: {number}.");
        }
        None => {
            println!("Nothing.");
        }
    }

    println!("And print the number again: {number}.");
}

fn another() {
    let non_null: Option<u8> = Some(1);

    if let Some(number) = non_null {
        println!("A number: {number}.");
    }

    println!("And print the number again: {number}.");
}
```

I get this error:

```
error[E0425]: cannot find value `number` in this scope
  --> src/main.rs:13:44
   |
13 |     println!("And print the number again: {number}.");
   |                                            ^^^^^^ not found in this scope

error[E0425]: cannot find value `number` in this scope
  --> src/main.rs:23:44
   |
23 |     println!("And print the number again: {number}.");
   |                                            ^^^^^^ not found in this scope

For more information about this error, try `rustc --explain E0425`.
```

I'm sure this is pretty obvious for experienced Rust programmers, but it can be surprising for programmers coming from other languages. For example, in Python:

```python
x = 2
number = None

match x:
    case 1:
        print("hey")
    case number:
        print("ola")

print(number)  # <-- `number` will still be bound here!
```

Yields:

```
ola
2
```