### PR TITLE
Correct the explanation of what `::<path>` means

### DIFF
--- a/src/appendix-02-operators.md
+++ b/src/appendix-02-operators.md
@@ -102,7 +102,7 @@ hierarchy to an item.
 | Symbol | Explanation |
 |--------|-------------|
 | `ident::ident` | Namespace path |
-| `::path` | Path relative to the crate root (i.e., an explicitly absolute path) |
+| `::path` | Path relative to the extern prelude, where all other crates are rooted (i.e., an explicitly absolute path including crate name) |
 | `self::path` | Path relative to the current module (i.e., an explicitly relative path). |
 | `super::path` | Path relative to the parent of the current module |
 | `type::ident`, `<type as trait>::ident` | Associated constants, functions, and types |


### PR DESCRIPTION
This changed in the 2018 Edition (thank goodness: paths were *bad* back then, and now they’re much less bad!)

Fixes #3841

> [!NOTE]
> I do not love this phrasing, even in an appendix: “extern prelude” is *so* in the weeds. If we can come up with a better one, I am all in favor!