### PR TITLE
Swap assert_eq! parameters

### DIFF
--- a/listings/ch11-writing-automated-tests/output-only-01-show-output/output.txt
+++ b/listings/ch11-writing-automated-tests/output-only-01-show-output/output.txt
@@ -22,8 +22,8 @@ failures:
 I got the value 8
 thread 'tests::this_test_will_fail' panicked at src/lib.rs:19:9:
 assertion `left == right` failed
-  left: 5
- right: 10
+  left: 10
+ right: 5
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
 

--- a/listings/ch11-writing-automated-tests/output-only-01-show-output/src/lib.rs
+++ b/listings/ch11-writing-automated-tests/output-only-01-show-output/src/lib.rs
@@ -10,12 +10,12 @@ mod tests {
     #[test]
     fn this_test_will_pass() {
         let value = prints_and_returns_10(4);
-        assert_eq!(10, value);
+        assert_eq!(value, 10);
     }
 
     #[test]
     fn this_test_will_fail() {
         let value = prints_and_returns_10(8);
-        assert_eq!(5, value);
+        assert_eq!(value, 5);
     }
 }


### PR DESCRIPTION
Swap assert_eq! parameters to make the error message consistent to the description in the book.