### PR TITLE
Add type u8 for variable dice_roll to catch-all example in ch06-02-match

### DIFF
--- a/listings/ch06-enums-and-pattern-matching/no-listing-15-binding-catchall/src/main.rs
+++ b/listings/ch06-enums-and-pattern-matching/no-listing-15-binding-catchall/src/main.rs
@@ -1,6 +1,6 @@
 fn main() {
     // ANCHOR: here
-    let dice_roll = 9;
+    let dice_roll: u8 = 9;
     match dice_roll {
         3 => add_fancy_hat(),
         7 => remove_fancy_hat(),

--- a/listings/ch06-enums-and-pattern-matching/no-listing-16-underscore-catchall/src/main.rs
+++ b/listings/ch06-enums-and-pattern-matching/no-listing-16-underscore-catchall/src/main.rs
@@ -1,6 +1,6 @@
 fn main() {
     // ANCHOR: here
-    let dice_roll = 9;
+    let dice_roll: u8 = 9;
     match dice_roll {
         3 => add_fancy_hat(),
         7 => remove_fancy_hat(),

--- a/listings/ch06-enums-and-pattern-matching/no-listing-17-underscore-unit/src/main.rs
+++ b/listings/ch06-enums-and-pattern-matching/no-listing-17-underscore-unit/src/main.rs
@@ -1,6 +1,6 @@
 fn main() {
     // ANCHOR: here
-    let dice_roll = 9;
+    let dice_roll: u8 = 9;
     match dice_roll {
         3 => add_fancy_hat(),
         7 => remove_fancy_hat(),


### PR DESCRIPTION
I added the type annotation `u8` for the variable `dice_roll` since it is referred to in the text as such but defaults to `i32`. I also think it is neat to use `u8` for a dice since it rarely has large negative numbers.
https://github.com/rust-lang/book/blob/33cc45ceec745789e1d355dd8561b037f80ac817/src/ch06-02-match.md?plain=1#L213

