### PR TITLE
Add HTML-based redirects for previous chapter numbering

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -10,6 +10,26 @@ additional-css = ["ferris.css", "theme/2018-edition.css", "theme/semantic-notes.
 additional-js = ["ferris.js"]
 git-repository-url = "https://github.com/rust-lang/book"
 
+[output.html.redirect]
+"ch17-00-oop.html" = "ch18-00-oop.html"
+"ch17-01-what-is-oo.html" = "ch18-01-what-is-oo.html"
+"ch17-02-trait-objects.html" = "ch18-02-trait-objects.html"
+"ch17-03-oo-design-patterns.html" = "ch18-03-oo-design-patterns.html"
+"ch18-00-patterns.html" = "ch19-00-patterns.html"
+"ch18-01-all-the-places-for-patterns.html" = "ch19-01-all-the-places-for-patterns.html"
+"ch18-02-refutability.html" = "ch19-02-refutability.html"
+"ch18-03-pattern-syntax.html" = "ch19-03-pattern-syntax.html"
+"ch19-00-advanced-features.html" = "ch20-00-advanced-features.html"
+"ch19-01-unsafe-rust.html" = "ch20-01-unsafe-rust.html"
+"ch19-03-advanced-traits.html" = "ch20-03-advanced-traits.html"
+"ch19-04-advanced-types.html" = "ch20-04-advanced-types.html"
+"ch19-05-advanced-functions-and-closures.html" = "ch20-05-advanced-functions-and-closures.html"
+"ch19-06-macros.html" = "ch20-06-macros.html"
+"ch20-00-final-project-a-web-server.html" = "ch21-00-final-project-a-web-server.html"
+"ch20-01-single-threaded.html" = "ch21-01-single-threaded.html"
+"ch20-02-multithreaded.html" = "ch21-02-multithreaded.html"
+"ch20-03-graceful-shutdown-and-cleanup.html" = "ch21-03-graceful-shutdown-and-cleanup.html"
+
 # Do not sync this preprocessor; it is for the HTML renderer only.
 [preprocessor.trpl-note]
 


### PR DESCRIPTION
Unlike the redirects we have in place for the previous editions, this simply performs an in-place redirect, using the built-in mechanism for this in mdbook. As an alternative, we could hand-craft HTML pages to do what the redirect pages for the first and second edition do: present a page and let the user click through proactively. What we cannot do, unfortunately, is have those pages present *without showing up in the sidebar nav* (see rust-lang/mdBook#702 and rust-lang/mdBook#830), which we distinctly do not want.