### PR TITLE
Add info about handling editions in book.toml to ADMIN.md

### DIFF
--- a/ADMIN_TASKS.md
+++ b/ADMIN_TASKS.md
@@ -23,6 +23,11 @@ occasional maintenance tasks.
 To update the `edition = "[year]"` metadata in all the listings' `Cargo.toml`s,
 run the `./tools/update-editions.sh` script and commit the changes.
 
+## Update the `edition` in mdBook config
+
+Open `book.toml` and `nostarch/book.toml` and set the `edition` value in the
+`[rust]` table to the new edition.
+
 ## Release a new version of the listings
 
 We now make `.tar` files of complete projects containing every listing

--- a/nostarch/book.toml
+++ b/nostarch/book.toml
@@ -13,3 +13,6 @@ build-dir = "../tmp"
 
 [preprocessor.trpl-listing]
 output-mode = "simple"
+
+[rust]
+edition = "2021"


### PR DESCRIPTION
This will make sure we do not end up with extraneous warnings in the output when running samples via the playground (as noted in #3970)!