### PR TITLE
Ch10-03: Improve paragraph on error messages about `'static`

### DIFF
--- a/src/ch10-03-lifetime-syntax.md
+++ b/src/ch10-03-lifetime-syntax.md
@@ -570,13 +570,13 @@ let s: &'static str = "I have a static lifetime.";
 The text of this string is stored directly in the program’s binary, which is
 always available. Therefore, the lifetime of all string literals is `'static`.
 
-You might see suggestions to use the `'static` lifetime in error messages. But
-before specifying `'static` as the lifetime for a reference, think about
-whether the reference you have actually lives the entire lifetime of your
-program or not, and whether you want it to. Most of the time, an error message
-suggesting the `'static` lifetime results from attempting to create a dangling
-reference or a mismatch of the available lifetimes. In such cases, the solution
-is to fix those problems, not to specify the `'static` lifetime.
+The compiler may suggest specifying `'static` as the lifetime for a reference
+in error messages. But before doing it, think about whether the reference you
+have actually lives for the entire lifetime of your program or not. Most of the
+time, an error message suggesting the `'static` lifetime results from
+attempting to create a dangling reference or a mismatch of the available
+lifetimes. In such cases, the solution is to fix those problems, not to specify
+the `'static` lifetime.
 
 ## Generic Type Parameters, Trait Bounds, and Lifetimes Together
 


### PR DESCRIPTION
In the section "The Static Lifetime", chapter 10-03.

Before:

![2024-10-12_08-29_1](https://github.com/user-attachments/assets/4bccadb3-95a7-4f15-bd53-1a1ef10d8781)

After:

![2024-10-12_08-29](https://github.com/user-attachments/assets/0db1ea7d-eae2-4afa-9f09-408c51f14e94)

Here, I'm trying to address two things that I found weird about this paragraph:

- The introductory phrase to the paragraph is not specific enough. The first time I read it, my immediate confusion was:

  > People would suggest I mention lifetimes in error messages to the users of the software that I'm writing? Where would I see such suggestions? In other books? In blog posts? In conference talks? Is this common to suggest mentioning lifetimes in error messages to the users of our software? That's very weird.

  It never crossed my mind that this could be a suggestion coming from the compiler, because it doesn't read like it. It reads like it's talking about suggestions from other people (the default kind of suggestion). That was my first impression, at least. Then, the rest of the paragraph was very confusing as I was reading it from that perspective, and it didn't make any sense. I had to read it three times to finally realize I had misread the first phrase, and then it all made sense.

- The phrase "and whether you want it to" reads like declaring lifetimes *changes* lifetimes at the will of the programmer, since it's just a matter of "want". However, in the section "Lifetime Annotation Syntax", a few folds above, it reads:

  > Lifetime annotations don’t change how long any of the references live. Rather, they describe [...]

  ![2024-10-12_08-41](https://github.com/user-attachments/assets/c6d1ea73-d188-4a31-ab8a-31f76caaf494)

  That reads more realistic, so I'm assuming that that holds true, and not that declaring lifetimes changes lifetimes. So I would like to propose that we drop the phrasing "and whether you want it to" from this paragraph, since I can't make something live for the entire lifetime of the program just by declaring it with `'static`.