### PR TITLE
Take measurement inaccuracy intervals into account

### DIFF
--- a/src/ch13-04-performance.md
+++ b/src/ch13-04-performance.md
@@ -14,10 +14,10 @@ test bench_search_for  ... bench:  19,620,300 ns/iter (+/- 915,700)
 test bench_search_iter ... bench:  19,234,900 ns/iter (+/- 657,200)
 ```
 
-The iterator version was slightly faster! We won’t explain the benchmark code
-here, because the point is not to prove that the two versions are equivalent
-but to get a general sense of how these two implementations compare
-performance-wise.
+The two implementations have similar performance! We won’t explain the
+benchmark code here, because the point is not to prove that the two versions
+are equivalent but to get a general sense of how these two implementations
+compare performance-wise.
 
 For a more comprehensive benchmark, you should check using various texts of
 various sizes as the `contents`, different words and words of different lengths


### PR DESCRIPTION
Stating one version being faster while the intervals have a considerable overlap is probably not accurate.