### PR TITLE
Add missing semicolon in listing 19-15 and 19-16

### DIFF
--- a/listings/ch19-patterns-and-matching/listing-19-15/src/main.rs
+++ b/listings/ch19-patterns-and-matching/listing-19-15/src/main.rs
@@ -19,7 +19,7 @@ fn main() {
             println!("Text message: {text}");
         }
         Message::ChangeColor(r, g, b) => {
-            println!("Change the color to red {r}, green {g}, and blue {b}")
+            println!("Change the color to red {r}, green {g}, and blue {b}");
         }
     }
 }

--- a/listings/ch19-patterns-and-matching/listing-19-16/src/main.rs
+++ b/listings/ch19-patterns-and-matching/listing-19-16/src/main.rs
@@ -18,7 +18,7 @@ fn main() {
             println!("Change color to red {r}, green {g}, and blue {b}");
         }
         Message::ChangeColor(Color::Hsv(h, s, v)) => {
-            println!("Change color to hue {h}, saturation {s}, value {v}")
+            println!("Change color to hue {h}, saturation {s}, value {v}");
         }
         _ => (),
     }


### PR DESCRIPTION
The code in 19.15 and 19.16 are correct and the compiler will not complain, however, every other arms `println!` have a semicolon but it is missing from the last one. Added it for consistency.