### PR TITLE
infra: change how packages are opted out of workspaces

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,14 +6,6 @@ exclude = [
     "linkchecker", # linkchecker is part of the CI workflow
     "listings",    # these are intentionally distinct from the workspace
     "tmp",         # listings are built here when updating output via tools/update-rustc.sh
-    "packages/trpl",        # manages its own dependencies as a standalone crate
-
-    # These are used as path dependencies in `rust-lang/rust` (since we are not
-    # publishing them to crates.io), so they cannot be part of this workspace,
-    # because path dependencies do not get built as a crate within the hosting
-    # workspace.
-    "packages/mdbook-trpl-listing",
-    "packages/mdbook-trpl-note",
 ]
 
 [workspace.dependencies]

--- a/packages/mdbook-trpl-listing/Cargo.toml
+++ b/packages/mdbook-trpl-listing/Cargo.toml
@@ -17,3 +17,8 @@ toml = "0.8.12"
 
 [dev-dependencies]
 assert_cmd = "2"
+
+# This package is used as a path dependency in `rust-lang/rust`, not published
+# to crates.io, so it cannot be part of the `rust-lang/book` workspace, because
+# path dependencies do not get built as a crate within the hosting workspace.
+[workspace]

--- a/packages/mdbook-trpl-note/Cargo.toml
+++ b/packages/mdbook-trpl-note/Cargo.toml
@@ -14,3 +14,8 @@ serde_json = "1"
 
 [dev-dependencies]
 assert_cmd = "2"
+
+# This package is used as a path dependency in `rust-lang/rust`, not published
+# to crates.io, so it cannot be part of the `rust-lang/book` workspace, because
+# path dependencies do not get built as a crate within the hosting workspace.
+[workspace]

--- a/packages/trpl/Cargo.toml
+++ b/packages/trpl/Cargo.toml
@@ -21,3 +21,8 @@ tokio = { version = "1", default-features = false, features = [
     "time",
 ] }
 tokio-stream = "0.1"
+
+# This package is built as a standalone package to publish to crates.io, and is
+# also built as a path dependency for distribution with Rust, so it must not be
+# built as part of the `rust-lang/book` or `rust-lang/rust` workspaces.
+[workspace]


### PR DESCRIPTION
The `trpl`, `mdbook-trpl-note`, and `mdbook-trpl-listing` crates should *never* be part of a host workspace: neither in `rust-lang/book` nor in `rust-lang/rust`. They are always built as independent packages, so they do not end up depending implicitly on the host’s workspace dependencies.

Accordingly, opt out by setting an empty `[workspace]` key in each of the packages' `Cargo.toml` files so that they do not have to be configured in both places they might be used.

Helps unblock rust-lang/rust#131859