### PR TITLE
Ch. 17 fixes: correct a bad link in the 2018 edition pages

### DIFF
--- a/2018-edition/src/ch17-03-oo-design-patterns.md
+++ b/2018-edition/src/ch17-03-oo-design-patterns.md
@@ -3,7 +3,7 @@
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch19-03-oo-design-patterns.html) instead.
+version of the book](../ch18-03-oo-design-patterns.html) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust


### PR DESCRIPTION
Looks like I basically accidentally did the find-and-replace operation twice on this one. Whoops!

Contributes to rust-lang/rust#131859—this *should* be one of the last things to fix before that goes ✅!