### PR TITLE
remove pub qualifier

### DIFF
--- a/listings/ch07-managing-growing-projects/quick-reference-example/src/main.rs
+++ b/listings/ch07-managing-growing-projects/quick-reference-example/src/main.rs
@@ -1,6 +1,6 @@
 use crate::garden::vegetables::Asparagus;
 
-pub mod garden;
+mod garden;
 
 fn main() {
     let plant = Asparagus {};

--- a/src/ch07-02-defining-modules-to-control-scope-and-privacy.md
+++ b/src/ch07-02-defining-modules-to-control-scope-and-privacy.md
@@ -71,7 +71,7 @@ The crate root file in this case is *src/main.rs*, and it contains:
 
 </Listing>
 
-The `pub mod garden;` line tells the compiler to include the code it finds in
+The `mod garden;` line tells the compiler to include the code it finds in
 *src/garden.rs*, which is:
 
 <Listing file-name="src/garden.rs">


### PR DESCRIPTION
I'm new to Rust, so forgive me if I'm wrong here, but from what I'm being told on the Discord server, the `pub` qualifier is unnecessary in the `crate` module when declaring the `garden` module because a parent module has access to a child module it declares, and the `pub` qualifier is only necessary for the parent to access elements within the child module, not to access the module itself. This was a source of confusion for me because the code compiled without `pub`, but the example gives the impression that it's required.