### PR TITLE
Drop a pedantry-triggering sentence about IEEE-754

### DIFF
--- a/src/ch03-02-data-types.md
+++ b/src/ch03-02-data-types.md
@@ -141,8 +141,7 @@ Here’s an example that shows floating-point numbers in action:
 {{#rustdoc_include ../listings/ch03-common-programming-concepts/no-listing-06-floating-point/src/main.rs}}
 ```
 
-Floating-point numbers are represented according to the IEEE-754 standard. The
-`f32` type is a single-precision float, and `f64` has double precision.
+Floating-point numbers are represented according to the IEEE-754 standard.
 
 #### Numeric Operations
 


### PR DESCRIPTION
The pedantry is accurate (!), but since we can just drop this entirely, it will cut the potential distraction for readers who might get hung up on it otherwise!

Fixes #3818