### PR TITLE
Fix more inverted uses of “shadowed”

### DIFF
--- a/src/ch19-01-all-the-places-for-patterns.md
+++ b/src/ch19-01-all-the-places-for-patterns.md
@@ -84,11 +84,11 @@ background color`.
 
 You can see that `if let` can also introduce new variables which shadow existing
 variables in the same way that `match` arms can: the line `if let Ok(age) = age`
-introduces a new shadowed `age` variable that contains the value inside the `Ok`
-variant. This means we need to place the `if age > 30` condition within that
-block: we can’t combine these two conditions into `if let Ok(age) = age && age >
-30`. The shadowed `age` we want to compare to 30 isn’t valid until the new scope
-starts with the curly bracket.
+introduces a new `age` variable that contains the value inside the `Ok` variant,
+shadowing the existing `age` variable. This means we need to place the `if age >
+30` condition within that block: we can’t combine these two conditions into `if
+let Ok(age) = age && age > 30`. The new `age` we want to compare to 30 isn’t
+valid until the new scope starts with the curly bracket.
 
 The downside of using `if let` expressions is that the compiler doesn’t check
 for exhaustiveness, whereas with `match` expressions it does. If we omitted the


### PR DESCRIPTION
Follow-on for #3773 and #4121: I missed how the rest of this paragraph also had “shadowed” inverted!