### PR TITLE
Ch. 2: tweak a phrase to avoid derailing some readers

### DIFF
--- a/src/ch02-00-guessing-game-tutorial.md
+++ b/src/ch02-00-guessing-game-tutorial.md
@@ -684,8 +684,8 @@ often used when you want to convert a value from one type to another type.
 We bind this new variable to the expression `guess.trim().parse()`. The `guess`
 in the expression refers to the original `guess` variable that contained the
 input as a string. The `trim` method on a `String` instance will eliminate any
-whitespace at the beginning and end, which we must do to be able to compare the
-string to the `u32`, which can only contain numerical data. The user must press
+whitespace at the beginning and end, which we must do before we can convert the
+string to a `u32`, which can only contain numerical data. The user must press
 <kbd>enter</kbd> to satisfy `read_line` and input their guess, which adds a
 newline character to the string. For example, if the user types <kbd>5</kbd> and
 presses <kbd>enter</kbd>, `guess` looks like this: `5\n`. The `\n` represents


### PR DESCRIPTION
Multiple people have filed or commented on issues over the past few years (at least #3782, #4101, #4090, and #3921; and possibly others I have not found) because seeing “compare” here led them to jump ahead to the conversion (in the next paragraph). The text was technically correct as it stood, but since it kept derailing/hijacking people’s train of thought, tweaking it seems helpful.