### PR TITLE
fix: fix a garden-path expression that can be confusing.

### DIFF
--- a/src/ch21-01-single-threaded.md
+++ b/src/ch21-01-single-threaded.md
@@ -141,7 +141,7 @@ connection, we now call the new `handle_connection` function and pass the
 `stream` to it.
 
 In the `handle_connection` function, we create a new `BufReader` instance that
-wraps a reference to the `stream`. And `BufReader` adds buffering by managing calls
+wraps a reference to the `stream`. The `BufReader` adds buffering by managing calls
 to the `std::io::Read` trait methods for us.
 
 We create a variable named `http_request` to collect the lines of the request

--- a/src/ch21-01-single-threaded.md
+++ b/src/ch21-01-single-threaded.md
@@ -141,7 +141,7 @@ connection, we now call the new `handle_connection` function and pass the
 `stream` to it.
 
 In the `handle_connection` function, we create a new `BufReader` instance that
-wraps a reference to the `stream`. `BufReader` adds buffering by managing calls
+wraps a reference to the `stream`. And `BufReader` adds buffering by managing calls
 to the `std::io::Read` trait methods for us.
 
 We create a variable named `http_request` to collect the lines of the request


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/8dac40d8-7f1e-4093-974e-29644e0dba68)

Fix a garden-path expression that can be confusing for those who are familiar with referring to packages using dots, especially when English is a second language for the reader.