### PR TITLE
Revise sentence to not refer to two subjects as it

### DIFF
--- a/listings/ch04-understanding-ownership/no-listing-08-reference-with-annotations/src/main.rs
+++ b/listings/ch04-understanding-ownership/no-listing-08-reference-with-annotations/src/main.rs
@@ -9,6 +9,6 @@ fn main() {
 // ANCHOR: here
 fn calculate_length(s: &String) -> usize { // s is a reference to a String
     s.len()
-} // Here, s goes out of scope. But because it does not have ownership of what
-  // it refers to, it is not dropped.
+} // Here, s goes out of scope. But because s does not have ownership of what
+  // it refers to, the value is not dropped.
 // ANCHOR_END: here

--- a/src/ch04-02-references-and-borrowing.md
+++ b/src/ch04-02-references-and-borrowing.md
@@ -45,8 +45,8 @@ Let’s take a closer look at the function call here:
 ```
 
 The `&s1` syntax lets us create a reference that _refers_ to the value of `s1`
-but does not own it. Because it does not own it, the value it points to will
-not be dropped when the reference stops being used.
+but does not own it. Because the reference does not own it, the value it points
+to will not be dropped when the reference stops being used.
 
 Likewise, the signature of the function uses `&` to indicate that the type of
 the parameter `s` is a reference. Let’s add some explanatory annotations:


### PR DESCRIPTION
While reading the book I noticed "it" referring to the reference and the value in the same sentence.