### PR TITLE
tools: fix nostarch build reference to mdbook-trpl

### DIFF
--- a/tools/nostarch.sh
+++ b/tools/nostarch.sh
@@ -4,7 +4,7 @@ set -eu
 
 cargo build --release
 
-cargo install --locked --path ./packages/mdbook_trpl --offline
+cargo install --locked --path ./packages/mdbook-trpl --offline
 
 mkdir -p tmp
 rm -rf tmp/*.md


### PR DESCRIPTION
Note that this is not urgent to land upstream because the script in question is one only we run.