### PR TITLE
Fix lifetime description in a function signature

### DIFF
--- a/src/ch10-03-lifetime-syntax.md
+++ b/src/ch10-03-lifetime-syntax.md
@@ -211,7 +211,7 @@ This code should compile and produce the result we want when we use it with the
 The function signature now tells Rust that for some lifetime `'a`, the function
 takes two parameters, both of which are string slices that live at least as
 long as lifetime `'a`. The function signature also tells Rust that the string
-slice returned from the function will live at least as long as lifetime `'a`.
+slice returned from the function will live at most as long as lifetime `'a`.
 In practice, it means that the lifetime of the reference returned by the
 `longest` function is the same as the smaller of the lifetimes of the values
 referred to by the function arguments. These relationships are what we want


### PR DESCRIPTION
I think that what the author meant here is that the returned reference can't outlive lifetime `'a` (i.e will live at **most** as long as lifetime `'a` and not at **least** as long as lifetime `'a`).  
