### PR TITLE
Ch. 15.5: account for improved error message

### DIFF
--- a/src/ch15-05-interior-mutability.md
+++ b/src/ch15-05-interior-mutability.md
@@ -189,9 +189,10 @@ However, there’s one problem with this test, as shown here:
 
 We can’t modify the `MockMessenger` to keep track of the messages, because the
 `send` method takes an immutable reference to `self`. We also can’t take the
-suggestion from the error text to use `&mut self` instead, because then the
-signature of `send` wouldn’t match the signature in the `Messenger` trait
-definition (feel free to try and see what error message you get).
+suggestion from the error text to use `&mut self` in both the `impl` method and
+the `trait` definition. We do not want to change the `Messenger` trait solely
+for the sake of testing. Instead, we need to find a way to make our test code
+work correctly with our existing design.
 
 This is a situation in which interior mutability can help! We’ll store the
 `sent_messages` within a `RefCell<T>`, and then the `send` method will be


### PR DESCRIPTION
Previously, the error message from the compiler only suggested changing the `impl` to use `&mut self`, but a (very helpful!) update to the error message suggests changing both the `impl` and the `trait` definitions, which is much better in the general case since changing one without the other will just produce a new error message: a point the original text points to with its suggestion to try and see what happens.

Account for the new error message by keeping the framing of the reason as avoiding breaking the trait contract, but now explicitly in terms of good testing habits.

Fixes #4140