### PR TITLE
Update text to reflect the change from '&str' to 'char' in example

### DIFF
--- a/src/ch06-01-defining-an-enum.md
+++ b/src/ch06-01-defining-an-enum.md
@@ -249,7 +249,7 @@ For now, all you need to know is that `<T>` means that the `Some` variant of
 the `Option` enum can hold one piece of data of any type, and that each
 concrete type that gets used in place of `T` makes the overall `Option<T>` type
 a different type. Here are some examples of using `Option` values to hold
-number types and string types:
+number types and char types:
 
 ```rust
 {{#rustdoc_include ../listings/ch06-enums-and-pattern-matching/no-listing-06-option-examples/src/main.rs:here}}


### PR DESCRIPTION
I noticed a small mistake when reading Chapter 6 – seems like this was left behind when the example was changed in c76f1b4d