### PR TITLE
Reframe null value errors ch06-02-match.md

### DIFF
--- a/src/ch06-02-match.md
+++ b/src/ch06-02-match.md
@@ -191,7 +191,7 @@ pattern we forgot! Matches in Rust are _exhaustive_: we must exhaust every last
 possibility in order for the code to be valid. Especially in the case of
 `Option<T>`, when Rust prevents us from forgetting to explicitly handle the
 `None` case, it protects us from assuming that we have a value when we might
-have null, thus making the billion-dollar mistake discussed earlier impossible.
+have null, thus avoiding a major trap set by the billion-dollar mistake discussed earlier.
 
 ### Catch-all Patterns and the `_` Placeholder
 


### PR DESCRIPTION
This may be pedantic, but so is Rust!

As written, the prose conflates null value errors with Hoare's "billion dollar mistake". But as quoted earlier, that phrase applies to the creation of null values. What is described here is just one trap that his "mistake" enabled.

I have tried to re-phrase more accurately, but my interest is in correctness rather than my word choices.