### PR TITLE
Switch back from `eprintln!` to `println!` in listing 17-12

### DIFF
--- a/listings/ch17-async-await/listing-17-12/src/main.rs
+++ b/listings/ch17-async-await/listing-17-12/src/main.rs
@@ -23,7 +23,7 @@ fn main() {
 
         let rx_fut = async {
             while let Some(value) = rx.recv().await {
-                eprintln!("received '{value}'");
+                println!("received '{value}'");
             }
         };
 


### PR DESCRIPTION
Looks like the `eprintln!()` macro was added by mistake, this PR changes it back to `println!()`, as in the previous listings.