### PR TITLE
Refactor: Discard unused next return value and update documentation in Chapter 13

### DIFF
--- a/listings/ch13-functional-features/listing-13-20/src/lib.rs
+++ b/listings/ch13-functional-features/listing-13-20/src/lib.rs
@@ -13,7 +13,7 @@ impl Config {
     pub fn build(
         mut args: impl Iterator<Item = String>,
     ) -> Result<Config, &'static str> {
-        args.next();
+        let _ = args.next();
 
         let query = match args.next() {
             Some(arg) => arg,

--- a/src/ch13-03-improving-our-io-project.md
+++ b/src/ch13-03-improving-our-io-project.md
@@ -110,7 +110,7 @@ updates the code from Listing 12-23 to use the `next` method:
 
 Remember that the first value in the return value of `env::args` is the name of
 the program. We want to ignore that and get to the next value, so first we call
-`next` and do nothing with the return value. Second, we call `next` to get the
+`next` and discard the return value. Second, we call `next` to get the
 value we want to put in the `query` field of `Config`. If `next` returns a
 `Some`, we use a `match` to extract the value. If it returns `None`, it means
 not enough arguments were given and we return early with an `Err` value. We do


### PR DESCRIPTION
This update refactors the build method in Listing 13-20 to explicitly discard the unused return value of the first use of args.next() in Chapter 13. To make it more clear the return value is not used. 