### PR TITLE
Ch. 21.3: remove error ferris from working code

### DIFF
--- a/src/ch21-03-graceful-shutdown-and-cleanup.md
+++ b/src/ch21-03-graceful-shutdown-and-cleanup.md
@@ -74,7 +74,7 @@ So we need to update the `ThreadPool` `drop` implementation like this:
 
 <Listing file-name="src/lib.rs">
 
-```rust,ignore,does_not_compile
+```rust,ignore
 {{#rustdoc_include ../listings/ch21-web-server/no-listing-04-update-drop-definition/src/lib.rs:here}}
 ```
 

--- a/src/ch21-03-graceful-shutdown-and-cleanup.md
+++ b/src/ch21-03-graceful-shutdown-and-cleanup.md
@@ -74,7 +74,7 @@ So we need to update the `ThreadPool` `drop` implementation like this:
 
 <Listing file-name="src/lib.rs">
 
-```rust,ignore
+```rust
 {{#rustdoc_include ../listings/ch21-web-server/no-listing-04-update-drop-definition/src/lib.rs:here}}
 ```
 


### PR DESCRIPTION
This removes the compile error ferris icon from working code (the fix for listing 21-22)

![2024-12-30-204856_hyprshot](https://github.com/user-attachments/assets/1966dbe5-252c-475b-9190-21f50e8637f8)
