### PR TITLE
Update appendix-06-translation.md - new persian translation added

### DIFF
--- a/src/appendix-06-translation.md
+++ b/src/appendix-06-translation.md
@@ -21,7 +21,7 @@ For resources in languages other than English. Most are still in progress; see
 - [Esperanto](https://github.com/psychoslave/Rust-libro)
 - [ελληνική](https://github.com/TChatzigiannakis/rust-book-greek)
 - [Svenska](https://github.com/sebras/book)
-- [Persian](https://github.com/persian-rust/book) (FA)
+- [Farsi](https://github.com/RustFarsi/book), [Persian (FA)](https://github.com/persian-rust/book)
 - [Deutsch](https://github.com/rust-lang-de/rustbook-de)
 - [हिंदी](https://github.com/venkatarun95/rust-book-hindi)
 - [ไทย](https://github.com/rust-lang-th/book-th)

--- a/src/appendix-06-translation.md
+++ b/src/appendix-06-translation.md
@@ -21,7 +21,7 @@ For resources in languages other than English. Most are still in progress; see
 - [Esperanto](https://github.com/psychoslave/Rust-libro)
 - [ελληνική](https://github.com/TChatzigiannakis/rust-book-greek)
 - [Svenska](https://github.com/sebras/book)
-- [Farsi](https://github.com/RustFarsi/book)
+- [Persian](https://github.com/persian-rust/book) (FA)
 - [Deutsch](https://github.com/rust-lang-de/rustbook-de)
 - [हिंदी](https://github.com/venkatarun95/rust-book-hindi)
 - [ไทย](https://github.com/rust-lang-th/book-th)


### PR DESCRIPTION
as I mentioned in my translation issue, I have mostly completed a translation of the Rust Book into Persian (Chapters 0 to 16) and still working on the complete chapters. While a previous translation exists, it only covers the first three or four chapters and remains incomplete.