### PR TITLE
Update in Ch4-01 Both tuple and array can implement copy (Only tuple was mentioned)

### DIFF
--- a/src/ch04-01-what-is-ownership.md
+++ b/src/ch04-01-what-is-ownership.md
@@ -454,7 +454,7 @@ implement `Copy`:
 - The Boolean type, `bool`, with values `true` and `false`.
 - All the floating-point types, such as `f64`.
 - The character type, `char`.
-- Tuples, if they only contain types that also implement `Copy`. For example,
+- Tuples and Arrays, if they only contain types that also implement `Copy`. For example,
   `(i32, i32)` implements `Copy`, but `(i32, String)` does not.
 
 ### Ownership and Functions


### PR DESCRIPTION
Both tuple and array can implement copy (Only tuple was mentioned)