### PR TITLE
infra: don’t emit `Filename: ` in mdbook-trpl-listing output

### DIFF
--- a/packages/mdbook-trpl/src/listing/mod.rs
+++ b/packages/mdbook-trpl/src/listing/mod.rs
@@ -252,7 +252,7 @@ impl Listing {
     fn opening_text(&self) -> String {
         self.file_name
             .as_ref()
-            .map(|file_name| format!("Filename: {file_name}\n"))
+            .map(|file_name| format!("{file_name}\n"))
             .unwrap_or_default()
     }
 

--- a/packages/mdbook-trpl/src/listing/tests.rs
+++ b/packages/mdbook-trpl/src/listing/tests.rs
@@ -51,7 +51,7 @@ Trailing text."#,
         &result.unwrap(),
         r#"Leading text.
 
-Filename: src/main.rs
+src/main.rs
 
 ```rust
 fn main() {}


### PR DESCRIPTION
Noted by the NoStarch folks when working on edits for Ch. 17.