### PR TITLE
Appendix A: don't create separate lists for future use keywords

### DIFF
--- a/src/appendix-01-keywords.md
+++ b/src/appendix-01-keywords.md
@@ -69,9 +69,7 @@ Rust for potential future use.
 - `box`
 - `do`
 - `final`
-
-* `gen`
-
+- `gen`
 - `macro`
 - `override`
 - `priv`


### PR DESCRIPTION
This was a bad merge after applying dprint. Fixed up now. Follow-on to #4202 (thanks to @ehuss for [catching it](https://github.com/rust-lang/book/pull/4202#pullrequestreview-2552974418)!).