### PR TITLE
Use non deprecated functions in Chapter 2. Programming a Guessing Game

### DIFF
--- a/listings/ch02-guessing-game-tutorial/listing-02-03/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/listing-02-03/src/main.rs
@@ -8,7 +8,7 @@ fn main() {
     println!("Guess the number!");
 
     // ANCHOR: ch07-04
-    let secret_number = rand::thread_rng().gen_range(1..=100);
+    let secret_number = rand::rng().random_range(1..=100);
     // ANCHOR_END: ch07-04
 
     println!("The secret number is: {secret_number}");

--- a/listings/ch02-guessing-game-tutorial/listing-02-04/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/listing-02-04/src/main.rs
@@ -8,7 +8,7 @@ fn main() {
     // ANCHOR_END: here
     println!("Guess the number!");
 
-    let secret_number = rand::thread_rng().gen_range(1..=100);
+    let secret_number = rand::rng().random_range(1..=100);
 
     println!("The secret number is: {secret_number}");
 

--- a/listings/ch02-guessing-game-tutorial/listing-02-05/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/listing-02-05/src/main.rs
@@ -5,7 +5,7 @@ use std::io;
 fn main() {
     println!("Guess the number!");
 
-    let secret_number = rand::thread_rng().gen_range(1..=100);
+    let secret_number = rand::rng().random_range(1..=100);
 
     println!("The secret number is: {secret_number}");
 

--- a/listings/ch02-guessing-game-tutorial/listing-02-06/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/listing-02-06/src/main.rs
@@ -5,7 +5,7 @@ use std::io;
 fn main() {
     println!("Guess the number!");
 
-    let secret_number = rand::thread_rng().gen_range(1..=100);
+    let secret_number = rand::rng().random_range(1..=100);
 
     loop {
         println!("Please input your guess.");

--- a/listings/ch02-guessing-game-tutorial/no-listing-03-convert-string-to-number/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/no-listing-03-convert-string-to-number/src/main.rs
@@ -5,7 +5,7 @@ use std::io;
 fn main() {
     println!("Guess the number!");
 
-    let secret_number = rand::thread_rng().gen_range(1..=100);
+    let secret_number = rand::rng().random_range(1..=100);
 
     println!("The secret number is: {secret_number}");
 

--- a/listings/ch02-guessing-game-tutorial/no-listing-04-looping/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/no-listing-04-looping/src/main.rs
@@ -5,7 +5,7 @@ use std::io;
 fn main() {
     println!("Guess the number!");
 
-    let secret_number = rand::thread_rng().gen_range(1..=100);
+    let secret_number = rand::rng().random_range(1..=100);
 
     // ANCHOR: here
     // --snip--

--- a/listings/ch02-guessing-game-tutorial/no-listing-05-quitting/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/no-listing-05-quitting/src/main.rs
@@ -5,7 +5,7 @@ use std::io;
 fn main() {
     println!("Guess the number!");
 
-    let secret_number = rand::thread_rng().gen_range(1..=100);
+    let secret_number = rand::rng().random_range(1..=100);
 
     println!("The secret number is: {secret_number}");
 

--- a/listings/ch07-managing-growing-projects/listing-07-18/src/main.rs
+++ b/listings/ch07-managing-growing-projects/listing-07-18/src/main.rs
@@ -8,7 +8,7 @@ use std::{cmp::Ordering, io};
 fn main() {
     println!("Guess the number!");
 
-    let secret_number = rand::thread_rng().gen_range(1..=100);
+    let secret_number = rand::rng().random_range(1..=100);
 
     println!("The secret number is: {secret_number}");
 

--- a/listings/ch07-managing-growing-projects/no-listing-01-use-std-unnested/src/main.rs
+++ b/listings/ch07-managing-growing-projects/no-listing-01-use-std-unnested/src/main.rs
@@ -9,7 +9,7 @@ use std::io;
 fn main() {
     println!("Guess the number!");
 
-    let secret_number = rand::thread_rng().gen_range(1..=100);
+    let secret_number = rand::rng().random_range(1..=100);
 
     println!("The secret number is: {secret_number}");
 

--- a/listings/ch09-error-handling/listing-09-13/src/main.rs
+++ b/listings/ch09-error-handling/listing-09-13/src/main.rs
@@ -6,7 +6,7 @@ use std::io;
 fn main() {
     println!("Guess the number!");
 
-    let secret_number = rand::thread_rng().gen_range(1..=100);
+    let secret_number = rand::rng().random_range(1..=100);
 
     loop {
         println!("Please input your guess.");

--- a/listings/ch09-error-handling/no-listing-09-guess-out-of-range/src/main.rs
+++ b/listings/ch09-error-handling/no-listing-09-guess-out-of-range/src/main.rs
@@ -5,7 +5,7 @@ use std::io;
 fn main() {
     println!("Guess the number!");
 
-    let secret_number = rand::thread_rng().gen_range(1..=100);
+    let secret_number = rand::rng().random_range(1..=100);
 
     // ANCHOR: here
     loop {

--- a/src/ch02-00-guessing-game-tutorial.md
+++ b/src/ch02-00-guessing-game-tutorial.md
@@ -7,7 +7,67 @@ functions, external crates, and more! In the following chapters, we’ll explore
 these ideas in more detail. In this chapter, you’ll just practice the
 fundamentals.
 
-We’ll implement a classic beginner programming problem: a guessing game. Here’s
+We’ll implement a classic beginner progdoc.rust-lang.org/book/
+Topics
+rust book mdbook rust-programming-language
+Resources
+ Readme
+License
+ Apache-2.0, MIT licenses found
+Security policy
+ Security policy
+ Activity
+ Custom properties
+Stars
+ 15.6k stars
+Watchers
+ 226 watching
+Forks
+ 3.5k forks
+Report repository
+Releases 3
+Add async chapter
+Latest
+on Nov 7, 2024
++ 2 releases
+Packages
+No packages published
+Contributors
+647
+￼
+￼
+￼
+￼
+￼
+￼
+￼
+￼
+￼
+￼
+￼
+￼
+￼
+￼
++ 633 contributors
+Deployments
+337
+ github-pages 3 months ago
++ 336 deployments
+Languages
+Rust
+89.7%
+ 
+XSLT
+4.4%
+ 
+Shell
+2.6%
+ 
+HTML
+2.1%
+ 
+Other
+1.2%ramming problem: a guessing game. Here’s
 how it works: the program will generate a random integer between 1 and 100. It
 will then prompt the player to enter a guess. After a guess is entered, the
 program will indicate whether the guess is too low or too high. If the guess is
@@ -528,12 +588,12 @@ random number generators implement, and this trait must be in scope for us to
 use those methods. Chapter 10 will cover traits in detail.
 
 Next, we’re adding two lines in the middle. In the first line, we call the
-`rand::thread_rng` function that gives us the particular random number
+`rand::rng` function that gives us the particular random number
 generator we’re going to use: one that is local to the current thread of
-execution and is seeded by the operating system. Then we call the `gen_range`
+execution and is seeded by the operating system. Then we call the `random_range`
 method on the random number generator. This method is defined by the `Rng`
 trait that we brought into scope with the `use rand::Rng;` statement. The
-`gen_range` method takes a range expression as an argument and generates a
+`random_range` method takes a range expression as an argument and generates a
 random number in the range. The kind of range expression we’re using here takes
 the form `start..=end` and is inclusive on the lower and upper bounds, so we
 need to specify `1..=100` to request a number between 1 and 100.

--- a/src/ch02-00-guessing-game-tutorial.md
+++ b/src/ch02-00-guessing-game-tutorial.md
@@ -7,67 +7,7 @@ functions, external crates, and more! In the following chapters, we’ll explore
 these ideas in more detail. In this chapter, you’ll just practice the
 fundamentals.
 
-We’ll implement a classic beginner progdoc.rust-lang.org/book/
-Topics
-rust book mdbook rust-programming-language
-Resources
- Readme
-License
- Apache-2.0, MIT licenses found
-Security policy
- Security policy
- Activity
- Custom properties
-Stars
- 15.6k stars
-Watchers
- 226 watching
-Forks
- 3.5k forks
-Report repository
-Releases 3
-Add async chapter
-Latest
-on Nov 7, 2024
-+ 2 releases
-Packages
-No packages published
-Contributors
-647
-￼
-￼
-￼
-￼
-￼
-￼
-￼
-￼
-￼
-￼
-￼
-￼
-￼
-￼
-+ 633 contributors
-Deployments
-337
- github-pages 3 months ago
-+ 336 deployments
-Languages
-Rust
-89.7%
- 
-XSLT
-4.4%
- 
-Shell
-2.6%
- 
-HTML
-2.1%
- 
-Other
-1.2%ramming problem: a guessing game. Here’s
+We’ll implement a classic beginner programming problem: a guessing game. Here’s
 how it works: the program will generate a random integer between 1 and 100. It
 will then prompt the player to enter a guess. After a guess is entered, the
 program will indicate whether the guess is too low or too high. If the guess is


### PR DESCRIPTION
[Chapter 2. Programming a Guessing Game](https://doc.rust-lang.org/book/ch02-00-guessing-game-tutorial.html) uses `thread_rng()` and `gen_range()`, which are deprecated. 
I replaced every `thread_rng()` with `rng()`, and every `gen_range()` with `random_range()`

The function is also referenced in a few other areas, of which I updated.