### PR TITLE
Listing 10-19: Be consistent in creating the two strings

### DIFF
--- a/listings/ch10-generic-types-traits-and-lifetimes/listing-10-19/src/main.rs
+++ b/listings/ch10-generic-types-traits-and-lifetimes/listing-10-19/src/main.rs
@@ -1,7 +1,7 @@
 fn main() {
     let string1 = String::from("abcd");
-    let string2 = "xyz";
+    let string2 = String::from("xyz");
 
-    let result = longest(string1.as_str(), string2);
+    let result = longest(string1.as_str(), string2.as_str());
     println!("The longest string is {result}");
 }


### PR DESCRIPTION
The variables `string1` and `string2` are created and passed to `longest` in different ways for no apparent reason. I've made a small change to make Listing 10-19 consistent with the rest of the examples in Section 10.3.