### PR TITLE
docs: reorder functions in return value section

### DIFF
--- a/listings/ch03-common-programming-concepts/no-listing-21-function-return-values/src/main.rs
+++ b/listings/ch03-common-programming-concepts/no-listing-21-function-return-values/src/main.rs
@@ -1,9 +1,9 @@
-fn five() -> i32 {
-    5
-}
-
 fn main() {
     let x = five();
 
     println!("The value of x is: {x}");
+}
+
+fn five() -> i32 {
+    5
 }


### PR DESCRIPTION
Move `five()` function after `main()` to maintain consistent code organization with other examples in the book. This change improves readability by following the established pattern where helper functions are placed after the main function.

Related documentation: 
- [Functions with Return Values](https://doc.rust-lang.org/book/ch03-03-how-functions-work.html#functions-with-return-values)

Note: If this change is deemed unnecessary or doesn't align with the book's style guide, please feel free to close this PR. I understand that maintaining consistency with the printed version is a priority.