### PR TITLE
clarify in section 3.4 that rust supports block comments with /* */

### DIFF
--- a/src/ch03-04-comments.md
+++ b/src/ch03-04-comments.md
@@ -21,6 +21,18 @@ single line, you’ll need to include `//` on each line, like this:
 // explain what's going on.
 ```
 
+Rust also supports Block comments:
+
+```rust
+/*
+This is a block comment
+it can span multiple lines
+block comments can be useful in certain situations
+*/
+```
+
+While block comments are valid in Rust, they are less commonly used compared to // comments. One reason is that block comments cannot be nested, which can sometimes make debugging trickier. That said, they can be helpful for temporarily commenting out large sections of code during development.
+
 Comments can also be placed at the end of lines containing code:
 
 <span class="filename">Filename: src/main.rs</span>


### PR DESCRIPTION
Currently the book section 3.4 on comments, makes no mention of block comments /* */. as a new user of the language, i assumed rust simply didn't support it, until i spoke with a colleague about the issue. This PR adds the missing information about block comments to provide clearer guidance for new users