### PR TITLE
Improve explanation of `!` operator: it is bitwise NOT

### DIFF
--- a/src/appendix-02-operators.md
+++ b/src/appendix-02-operators.md
@@ -16,7 +16,7 @@ overload that operator is listed.
 | Operator                  | Example                                                 | Explanation                                                           | Overloadable?  |
 | ------------------------- | ------------------------------------------------------- | --------------------------------------------------------------------- | -------------- |
 | `!`                       | `ident!(...)`, `ident!{...}`, `ident![...]`             | Macro expansion                                                       |                |
-| `!`                       | `!expr`                                                 | Bitwise or logical complement                                         | `Not`          |
+| `!`                       | `!expr`                                                 | Bitwise NOT or logical complement                                     | `Not`          |
 | `!=`                      | `expr != expr`                                          | Nonequality comparison                                                | `PartialEq`    |
 | `%`                       | `expr % expr`                                           | Arithmetic remainder                                                  | `Rem`          |
 | `%=`                      | `var %= expr`                                           | Arithmetic remainder and assignment                                   | `RemAssign`    |


### PR DESCRIPTION
If search through page https://doc.rust-lang.org/book/appendix-02-operators.html with word "bitwise", all other operators are described clear:
* Bitwise AND
* Bitwise exclusive OR
* Bitwise OR

But `!` operator is described as just "Bitwise or logical complement".

I think it is more clear to describe it as "Bitwise NOT".

P.S.: maybe also it make sense to change "Bitwise exclusive OR" to "Bitwise exclusive OR (XOR)"