### PR TITLE
Chapter 1: fix 'four things' now that spacing is not emphasized

### DIFF
--- a/src/ch01-02-hello-world.md
+++ b/src/ch01-02-hello-world.md
@@ -119,7 +119,7 @@ println!("Hello, world!");
 ```
 
 This line does all the work in this little program: it prints text to the
-screen. There are four important details to notice here.
+screen. There are three important details to notice here.
 
 First, `println!` calls a Rust macro. If it had called a function instead, it
 would be entered as `println` (without the `!`). We’ll discuss Rust macros in


### PR DESCRIPTION
I updated most of the text here in #4150 but as [a commenter there pointed out](https://github.com/rust-lang/book/pull/4150#pullrequestreview-2636735879) (thanks @zankia!), and indeed as I had noticed while working on porting our revisions over to the print copy, I failed to get this wording fixed!