### PR TITLE
Appendix B, Operators: Replace “member access” with “field access” and “method call”.

### DIFF
--- a/src/appendix-02-operators.md
+++ b/src/appendix-02-operators.md
@@ -37,7 +37,9 @@ overload that operator is listed.
 | `-`                       | `expr - expr`                                           | Arithmetic subtraction                                                | `Sub`          |
 | `-=`                      | `var -= expr`                                           | Arithmetic subtraction and assignment                                 | `SubAssign`    |
 | `->`                      | `fn(...) -> type`, <code>&vert;...&vert; -> type</code> | Function and closure return type                                      |                |
-| `.`                       | `expr.ident`                                            | Member access                                                         |                |
+| `.`                       | `expr.ident`                                            | Field access                                                          |                |
+| `.`                       | `expr.ident(expr, ...)`                                 | Method call                                                           |                |
+| `(`                       | `expr(expr, ...)`                                       | Function call                                                         |                |
 | `..`                      | `..`, `expr..`, `..expr`, `expr..expr`                  | Right-exclusive range literal                                         | `PartialOrd`   |
 | `..=`                     | `..=expr`, `expr..=expr`                                | Right-inclusive range literal                                         | `PartialOrd`   |
 | `..`                      | `..expr`                                                | Struct literal update syntax                                          |                |


### PR DESCRIPTION
Rust doesn’t really have a single “member access” operator, but two different operators both using the “`.`” token as syntax. Using the same terminology as the Rust Reference will help reduce confusion. The book does not use the phrase “member access” elsewhere, so this should not be adding any inconsistency.

I also added a row for the function call operator since it would be odd to have method calls but not function calls in the table. Function calls are technically also mentioned in the “Tuples” table, but that’s an odd place to look for them. I don’t consider this a necessary part of this PR, though.