### PR TITLE
Clarify slice ownership by mentioning borrowing in Rust explanation

### DIFF
--- a/src/ch04-03-slices.md
+++ b/src/ch04-03-slices.md
@@ -2,7 +2,7 @@
 
 _Slices_ let you reference a contiguous sequence of elements in a
 [collection](ch08-00-common-collections.md) rather than the whole collection. A
-slice is a kind of reference, so it does not have ownership.
+slice is a kind of reference, and like all references, it does not have ownership but borrows data.
 
 Here’s a small programming problem: write a function that takes a string of
 words separated by spaces and returns the first word it finds in that string.


### PR DESCRIPTION
Adjusted the explanation of slices in the Rust documentation to make it clearer by emphasizing that slices are references and borrow data rather than owning it. This change aims to improve understanding of Rust’s ownership and borrowing model for newcomers.