### PR TITLE
Persist printing error, NOT ErrorKind

### DIFF
--- a/listings/ch09-error-handling/listing-09-05/src/main.rs
+++ b/listings/ch09-error-handling/listing-09-05/src/main.rs
@@ -11,8 +11,8 @@ fn main() {
                 Ok(fc) => fc,
                 Err(e) => panic!("Problem creating the file: {e:?}"),
             },
-            other_error => {
-                panic!("Problem opening the file: {other_error:?}");
+            _ => {
+                panic!("Problem opening the file: {error:?}");
             }
         },
     };


### PR DESCRIPTION
Reading through the Rust Book, I found this code that appears to be trying to take different actions based on the error type. Looking closer, I realized that the author changed the code (I believe, unintentionally) to log only the error type instead of the whole error when certain conditions are met.

This is a simple fix - the wildcard match for `other_error` is removed, and replaced with a non-binding wildcard, and the panic is changed to consuming the base error. This is better because it changes the minimal amount of functionality in the example code and it refamiliarizes readers with the non-binding wildcard matching system.