### PR TITLE
Correcting the OOP analogy for traits

### DIFF
--- a/src/ch10-02-traits.md
+++ b/src/ch10-02-traits.md
@@ -5,7 +5,7 @@ other types. We can use traits to define shared behavior in an abstract way. We
 can use _trait bounds_ to specify that a generic type can be any type that has
 certain behavior.
 
-> Note: Traits are similar to a feature often called _abstract clasess_ in other
+> Note: Traits are similar to a feature often called _abstract classes_ in other
 > languages, although with some differences.
 
 ### Defining a Trait

--- a/src/ch10-02-traits.md
+++ b/src/ch10-02-traits.md
@@ -5,7 +5,7 @@ other types. We can use traits to define shared behavior in an abstract way. We
 can use _trait bounds_ to specify that a generic type can be any type that has
 certain behavior.
 
-> Note: Traits are similar to a feature often called _interfaces_ in other
+> Note: Traits are similar to a feature often called _abstract clasess_ in other
 > languages, although with some differences.
 
 ### Defining a Trait


### PR DESCRIPTION
Since traits allow for a default concrete implementation of a method, the correct analogy to Object Oriented Programming would be abstract classes, since interfaces never allow concrete implementations.