### PR TITLE
Ch. 17: fix tiny example consistency issue

### DIFF
--- a/listings/ch17-async-await/listing-17-24/src/main.rs
+++ b/listings/ch17-async-await/listing-17-24/src/main.rs
@@ -26,7 +26,7 @@ fn main() {
             trpl::sleep(one_ms).await;
             slow("b", 15);
             trpl::sleep(one_ms).await;
-            slow("b", 35);
+            slow("b", 350);
             trpl::sleep(one_ms).await;
             println!("'b' finished.");
         };

--- a/listings/ch17-async-await/listing-17-25/src/main.rs
+++ b/listings/ch17-async-await/listing-17-25/src/main.rs
@@ -24,7 +24,7 @@ fn main() {
             trpl::yield_now().await;
             slow("b", 15);
             trpl::yield_now().await;
-            slow("b", 35);
+            slow("b", 350);
             trpl::yield_now().await;
             println!("'b' finished.");
         };


### PR DESCRIPTION
This is the world's smallest consistency issue: Listing 17-23 introduces a set of wait times, and the future listings keep all the same times except for this one time which changed from `350` to `35`. Might as well make it consistent? Or not, it doesn't matter.