### PR TITLE
Anchors on listings

### DIFF
--- a/packages/mdbook-trpl/src/listing/mod.rs
+++ b/packages/mdbook-trpl/src/listing/mod.rs
@@ -221,7 +221,13 @@ struct Listing {
 
 impl Listing {
     fn opening_html(&self) -> String {
-        let figure = String::from("<figure class=\"listing\">\n");
+        let id_attribute = self
+            .number
+            .as_ref()
+            .map(|number| format!(" id=\"listing-{number}\""))
+            .unwrap_or_default();
+
+        let figure = format!("<figure class=\"listing\"{id_attribute}>\n");
 
         match self.file_name.as_ref() {
             Some(file_name) => format!(

--- a/packages/mdbook-trpl/src/listing/mod.rs
+++ b/packages/mdbook-trpl/src/listing/mod.rs
@@ -239,16 +239,21 @@ impl Listing {
 
     fn closing_html(&self, trailing: &str) -> String {
         match (&self.number, &self.caption) {
-            (Some(number), Some(caption)) => format!(
-                r#"<figcaption>Listing {number}: {caption}</figcaption>
+            (Some(number), caption) => {
+                let caption_text = caption
+                    .as_ref()
+                    .map(|caption| format!(": {}", caption))
+                    .unwrap_or_default();
+                let listing_a_tag = format!(
+                    "<a href=\"#listing-{number}\">Listing {number}</a>"
+                );
+                format!(
+                    r#"<figcaption>{listing_a_tag}{caption_text}</figcaption>
 </figure>{trailing}"#
-            ),
+                )
+            }
             (None, Some(caption)) => format!(
                 r#"<figcaption>{caption}</figcaption>
-</figure>{trailing}"#
-            ),
-            (Some(number), None) => format!(
-                r#"<figcaption>Listing {number}</figcaption>
 </figure>{trailing}"#
             ),
             (None, None) => format!("</figure>{trailing}"),

--- a/packages/mdbook-trpl/src/listing/tests.rs
+++ b/packages/mdbook-trpl/src/listing/tests.rs
@@ -18,15 +18,15 @@ fn main() {}
 
     assert_eq!(
         &result.unwrap(),
-        r#"<figure class="listing" id="listing-1-2">
+        r##"<figure class="listing" id="listing-1-2">
 <span class="file-name">Filename: src/main.rs</span>
 
 ````rust
 fn main() {}
 ````
 
-<figcaption>Listing 1-2: A write-up which <em>might</em> include inline Markdown like <code>code</code> etc.</figcaption>
-</figure>"#
+<figcaption><a href="#listing-1-2">Listing 1-2</a>: A write-up which <em>might</em> include inline Markdown like <code>code</code> etc.</figcaption>
+</figure>"##
     );
 }
 
@@ -80,7 +80,7 @@ fn get_a_box_of<T>(t: T) -> Box<T> {
 
     assert_eq!(
         &result.unwrap(),
-        r#"<figure class="listing" id="listing-34-5">
+        r##"<figure class="listing" id="listing-34-5">
 
 ````rust
 fn get_a_box_of<T>(t: T) -> Box<T> {
@@ -88,8 +88,8 @@ fn get_a_box_of<T>(t: T) -> Box<T> {
 }
 ````
 
-<figcaption>Listing 34-5: This has a <code>Box&lt;T&gt;</code> in it.</figcaption>
-</figure>"#
+<figcaption><a href="#listing-34-5">Listing 34-5</a>: This has a <code>Box&lt;T&gt;</code> in it.</figcaption>
+</figure>"##
     );
 }
 
@@ -115,7 +115,7 @@ Save the file and go back to your terminal window"#,
     assert!(result.is_ok());
     assert_eq!(
         result.unwrap(),
-        r#"Now open the *main.rs* file you just created and enter the code in Listing 1-1.
+        r##"Now open the *main.rs* file you just created and enter the code in Listing 1-1.
 
 <figure class="listing" id="listing-1-1">
 <span class="file-name">Filename: main.rs</span>
@@ -126,10 +126,10 @@ fn main() {
 }
 ````
 
-<figcaption>Listing 1-1: A program that prints <code>Hello, world!</code></figcaption>
+<figcaption><a href="#listing-1-1">Listing 1-1</a>: A program that prints <code>Hello, world!</code></figcaption>
 </figure>
 
-Save the file and go back to your terminal window"#
+Save the file and go back to your terminal window"##
     );
 }
 
@@ -153,7 +153,7 @@ This is the closing."#,
     assert!(result.is_ok());
     assert_eq!(
         result.unwrap(),
-        r#"This is the opening.
+        r##"This is the opening.
 
 <figure class="listing" id="listing-1-1">
 
@@ -161,10 +161,10 @@ This is the closing."#,
 fn main() {}
 ````
 
-<figcaption>Listing 1-1: This is the caption</figcaption>
+<figcaption><a href="#listing-1-1">Listing 1-1</a>: This is the caption</figcaption>
 </figure>
 
-This is the closing."#
+This is the closing."##
     );
 }
 

--- a/packages/mdbook-trpl/src/listing/tests.rs
+++ b/packages/mdbook-trpl/src/listing/tests.rs
@@ -18,7 +18,7 @@ fn main() {}
 
     assert_eq!(
         &result.unwrap(),
-        r#"<figure class="listing">
+        r#"<figure class="listing" id="listing-1-2">
 <span class="file-name">Filename: src/main.rs</span>
 
 ````rust
@@ -80,7 +80,7 @@ fn get_a_box_of<T>(t: T) -> Box<T> {
 
     assert_eq!(
         &result.unwrap(),
-        r#"<figure class="listing">
+        r#"<figure class="listing" id="listing-34-5">
 
 ````rust
 fn get_a_box_of<T>(t: T) -> Box<T> {
@@ -117,7 +117,7 @@ Save the file and go back to your terminal window"#,
         result.unwrap(),
         r#"Now open the *main.rs* file you just created and enter the code in Listing 1-1.
 
-<figure class="listing">
+<figure class="listing" id="listing-1-1">
 <span class="file-name">Filename: main.rs</span>
 
 ````rust
@@ -155,7 +155,7 @@ This is the closing."#,
         result.unwrap(),
         r#"This is the opening.
 
-<figure class="listing">
+<figure class="listing" id="listing-1-1">
 
 ````rust
 fn main() {}


### PR DESCRIPTION
I think I made it by the following four main steps, as the first four commits said:

1. [add id to Listing with number attribute for cross reference](https://github.com/rust-lang/book/commit/9a04d81031d1e76d7056536ed56ee97fa4d0d1fb)
Finally make my change in listing mod into effect by `cargo install --locked --path packages/mdbook-trpl` after mod updated. 
Now each rendered snippet automatically has an `id` attribute like `id="listing-16-6"` for referencing.

2. [change listing reference from text to link](https://github.com/rust-lang/book/commit/89ad502b50dc36a089896f49ead26330de95bdbe)
Replace `Listing[ \n](\d+[\d-]+)` to `[Listing $1](#listing-$1)`. Change 672 results in 72 files.

3. [fix: prefix the actual file name if referenced listing is in another ch.md](https://github.com/rust-lang/book/commit/265e26f30cc30329ef72f1fc8c7481b16fceaacb)
Using script generated by such prompt:
> i have a folder of .md files, could you please give me a python script to achieve this:
> 1. find out all lines containing such pattern 1 `#listing-([\d-]+)`. the matched part in parentheses will be used as $1 in the next step. 
> 2. in the preceding lines, test if the same file contain pattern 2 `number="$1"`. if not, find the actual file name which contains pattern 2, alias as $a, and change pattern 1 to pattern 3 `$a#listing-$1`, apply the change to file.

4. [fix those grouped reference starts with Listings](https://github.com/rust-lang/book/commit/89fe9cb1890e99c620a087ef5f81afcd74383fdc)
Manually, fix 3 results in 2 files.

Another two commits to fix linting and package tests:

5. [fix lint errors](https://github.com/rust-lang/book/commit/2480600418969f3cb59c437075e79bdde04233fc)
Which is caused by omissions in step 3.

6. [update tests after new attribute id added](https://github.com/rust-lang/book/commit/f375619a34de08b72a1b72b566c9de88aaddabac)


Let me know if anything should get improved. @chriskrycho #921 