### PR TITLE
Ch. 17: mention `use std::pin::{Pin, pin};` on introduction

### DIFF
--- a/listings/ch17-async-await/listing-17-17/src/main.rs
+++ b/listings/ch17-async-await/listing-17-17/src/main.rs
@@ -1,6 +1,6 @@
 extern crate trpl; // required for mdbook test
 
-use std::{future::Future, time::Duration};
+use std::time::Duration;
 
 fn main() {
     trpl::run(async {

--- a/listings/ch17-async-await/listing-17-18/src/main.rs
+++ b/listings/ch17-async-await/listing-17-18/src/main.rs
@@ -1,17 +1,19 @@
 extern crate trpl; // required for mdbook test
 
-use std::{
-    future::Future,
-    pin::{Pin, pin},
-    time::Duration,
-};
+// ANCHOR: here
+use std::pin::Pin;
+
+// -- snip --
+
+// ANCHOR_END: here
+use std::time::Duration;
 
 fn main() {
     trpl::run(async {
         let (tx, mut rx) = trpl::channel();
 
         let tx1 = tx.clone();
-        let tx1_fut = pin!(async move {
+        let tx1_fut = async move {
             let vals = vec![
                 String::from("hi"),
                 String::from("from"),
@@ -23,15 +25,15 @@ fn main() {
                 tx1.send(val).unwrap();
                 trpl::sleep(Duration::from_secs(1)).await;
             }
-        });
+        };
 
-        let rx_fut = pin!(async {
+        let rx_fut = async {
             while let Some(value) = rx.recv().await {
                 println!("received '{value}'");
             }
-        });
+        };
 
-        let tx_fut = pin!(async move {
+        let tx_fut = async move {
             let vals = vec![
                 String::from("more"),
                 String::from("messages"),
@@ -43,7 +45,7 @@ fn main() {
                 tx.send(val).unwrap();
                 trpl::sleep(Duration::from_secs(1)).await;
             }
-        });
+        };
 
         // ANCHOR: here
         let futures: Vec<Pin<Box<dyn Future<Output = ()>>>> =

--- a/listings/ch17-async-await/listing-17-19/src/main.rs
+++ b/listings/ch17-async-await/listing-17-19/src/main.rs
@@ -1,10 +1,12 @@
 extern crate trpl; // required for mdbook test
 
-use std::{
-    future::Future,
-    pin::{Pin, pin},
-    time::Duration,
-};
+// ANCHOR: here
+use std::pin::{Pin, pin};
+
+// -- snip --
+
+// ANCHOR_END: here
+use std::time::Duration;
 
 fn main() {
     trpl::run(async {

--- a/listings/ch17-async-await/listing-17-28/src/main.rs
+++ b/listings/ch17-async-await/listing-17-28/src/main.rs
@@ -1,6 +1,6 @@
 extern crate trpl; // required for mdbook test
 
-use std::{future::Future, time::Duration};
+use std::time::Duration;
 
 fn main() {
     trpl::run(async {

--- a/listings/ch17-async-await/listing-17-29/src/main.rs
+++ b/listings/ch17-async-await/listing-17-29/src/main.rs
@@ -1,6 +1,6 @@
 extern crate trpl; // required for mdbook test
 
-use std::{future::Future, time::Duration};
+use std::time::Duration;
 
 // ANCHOR: implementation
 use trpl::Either;

--- a/src/ch17-03-more-futures.md
+++ b/src/ch17-03-more-futures.md
@@ -196,9 +196,9 @@ tell us that the first async block (`src/main.rs:8:23: 20:10`) does not
 implement the `Unpin` trait and suggests using `pin!` or `Box::pin` to resolve
 it. Later in the chapter, we’ll dig into a few more details about `Pin` and
 `Unpin`. For the moment, though, we can just follow the compiler’s advice to get
-unstuck. In Listing 17-18, we start by updating the type annotation for
-`futures`, with a `Pin` wrapping each `Box`. Second, we use `Box::pin` to pin
-the futures themselves.
+unstuck. In Listing 17-18, we start by importing `Pin` from `std::pin`. Next we
+update the type annotation for `futures`, with a `Pin` wrapping each `Box`.
+Finally, we use `Box::pin` to pin the futures themselves.
 
 <Listing number="17-18" caption="Using `Pin` and `Box::pin` to make the `Vec` type check" file-name="src/main.rs">
 
@@ -238,9 +238,10 @@ future, using the `std::pin::pin` macro.
 
 However, we must still be explicit about the type of the pinned reference;
 otherwise, Rust will still not know to interpret these as dynamic trait objects,
-which is what we need them to be in the `Vec`. We therefore `pin!` each future
-when we define it, and define `futures` as a `Vec` containing pinned mutable
-references to the dynamic future type, as in Listing 17-19.
+which is what we need them to be in the `Vec`. We therefore add `pin` to our
+list of imports from `std::pin`. Then we can `pin!` each future when we define
+it and define `futures` as a `Vec` containing pinned mutable references to the
+dynamic future type, as in Listing 17-19.
 
 <Listing number="17-19" caption="Using `Pin` directly with the `pin!` macro to avoid unnecessary heap allocations" file-name="src/main.rs">
 


### PR DESCRIPTION
Bonus: drop now-unnecessary `use std::future::Future` bits given it is now part of the prelude as of the 2024 edition!

Fixes #4275