### PR TITLE
Ferris: always show, even when it’s small

### DIFF
--- a/ferris.css
+++ b/ferris.css
@@ -43,3 +43,25 @@ body.ayu .not_desired_behavior {
 .ferris-explain {
   width: 100px;
 }
+
+/*
+  A bit of a hack to make small Ferris use the existing buttons container but
+  only show/hide the buttons on hover over the `pre`. Targeting `.listing`
+  increases the specificity of this rule.
+*/
+pre > .buttons {
+  visibility: visible;
+  opacity: 1;
+  transition: none;
+}
+
+pre > .buttons button {
+  visibility: hidden;
+  opacity: 0;
+  transition: visibility 0.1s linear, opacity 0.1s linear;
+}
+
+pre:hover > .buttons button {
+  visibility: visible;
+  opacity: 1;
+}

--- a/ferris.js
+++ b/ferris.js
@@ -40,10 +40,12 @@ function attachFerrises(type) {
       continue;
     }
 
-    let lines = codeBlock.innerText.replace(/\n$/, "").split(/\n/).length;
+    let codeLines = codeBlock.innerText;
+    let extra = codeLines.endsWith("\n") ? 1 : 0;
+    let numLines = codeLines.split("\n").length - extra;
 
     /** @type {'small' | 'large'} */
-    let size = lines < 4 ? "small" : "large";
+    let size = numLines < 4 ? "small" : "large";
 
     let container = prepareFerrisContainer(codeBlock, size == "small");
     if (!container) {


### PR DESCRIPTION
Fixes #4274. Ferris always shows up now!

When not hovering over a listing:

![CleanShot 2025-03-17 at 11 49 21@2x](https://github.com/user-attachments/assets/df7da98c-2ab0-4fbe-a693-b4af7f31109c)

On hovering over a listing:

![CleanShot 2025-03-17 at 11 49 27@2x](https://github.com/user-attachments/assets/06f497c2-ff15-4740-b975-39862ede2613)
