### PR TITLE
Ch. 10.3: clarify language detail

### DIFF
--- a/src/ch10-03-lifetime-syntax.md
+++ b/src/ch10-03-lifetime-syntax.md
@@ -8,8 +8,8 @@ One detail we didn’t discuss in the [“References and
 Borrowing”][references-and-borrowing]<!-- ignore --> section in Chapter 4 is
 that every reference in Rust has a _lifetime_, which is the scope for which
 that reference is valid. Most of the time, lifetimes are implicit and inferred,
-just like most of the time, types are inferred. We must annotate types only
-when multiple types are possible. In a similar way, we must annotate lifetimes
+just like most of the time, types are inferred. We only have to annotate types
+when multiple types are possible. In a similar way, we have to annotate lifetimes
 when the lifetimes of references could be related in a few different ways. Rust
 requires us to annotate the relationships using generic lifetime parameters to
 ensure the actual references used at runtime will definitely be valid.


### PR DESCRIPTION
The former phrasing seemed to suggest that we _must not_ annotate types _unless_ there are multiple possibilities. In fact, we are allowed to add redundant annotations.

Cases where no annotation is needed _despite_ multiple possible types -- e.g. `let n = 8` -- are, presumably, intentionally left out here, so not touching that.