### PR TITLE
Ch. 02: Consistent ordering of `use` statements

### DIFF
--- a/listings/ch02-guessing-game-tutorial/listing-02-03/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/listing-02-03/src/main.rs
@@ -1,5 +1,6 @@
 // ANCHOR: all
 use std::io;
+
 // ANCHOR: ch07-04
 use rand::Rng;
 

--- a/listings/ch02-guessing-game-tutorial/listing-02-04/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/listing-02-04/src/main.rs
@@ -1,7 +1,8 @@
 // ANCHOR: here
-use rand::Rng;
 use std::cmp::Ordering;
 use std::io;
+
+use rand::Rng;
 
 fn main() {
     // --snip--

--- a/listings/ch02-guessing-game-tutorial/listing-02-05/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/listing-02-05/src/main.rs
@@ -1,6 +1,7 @@
-use rand::Rng;
 use std::cmp::Ordering;
 use std::io;
+
+use rand::Rng;
 
 fn main() {
     println!("Guess the number!");

--- a/listings/ch02-guessing-game-tutorial/listing-02-06/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/listing-02-06/src/main.rs
@@ -1,6 +1,7 @@
-use rand::Rng;
 use std::cmp::Ordering;
 use std::io;
+
+use rand::Rng;
 
 fn main() {
     println!("Guess the number!");

--- a/listings/ch02-guessing-game-tutorial/no-listing-03-convert-string-to-number/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/no-listing-03-convert-string-to-number/src/main.rs
@@ -1,6 +1,7 @@
-use rand::Rng;
 use std::cmp::Ordering;
 use std::io;
+
+use rand::Rng;
 
 fn main() {
     println!("Guess the number!");

--- a/listings/ch02-guessing-game-tutorial/no-listing-04-looping/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/no-listing-04-looping/src/main.rs
@@ -1,6 +1,7 @@
-use rand::Rng;
 use std::cmp::Ordering;
 use std::io;
+
+use rand::Rng;
 
 fn main() {
     println!("Guess the number!");

--- a/listings/ch02-guessing-game-tutorial/no-listing-05-quitting/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/no-listing-05-quitting/src/main.rs
@@ -1,6 +1,7 @@
-use rand::Rng;
 use std::cmp::Ordering;
 use std::io;
+
+use rand::Rng;
 
 fn main() {
     println!("Guess the number!");


### PR DESCRIPTION
Adopt the idiomatic pattern of separating `std` from third-party `use` statements, with the result that we get the ordering we want for Ch. 07 for “free”.

Fixes #3121