### PR TITLE
Clarifying language for defining the capabilities of tuples and structs to be inclusive of cases where they hold 0 or 1 value(s).

### DIFF
--- a/src/ch05-01-defining-structs.md
+++ b/src/ch05-01-defining-structs.md
@@ -1,9 +1,9 @@
 ## Defining and Instantiating Structs
 
 Structs are similar to tuples, discussed in [“The Tuple Type”][tuples]<!--
-ignore --> section, in that both hold multiple related values. Like tuples, the
+ignore --> section, in that both can hold multiple related values. Like tuples, the
 pieces of a struct can be different types. Unlike with tuples, in a struct
-you’ll name each piece of data so it’s clear what the values mean. Adding these
+you can name each piece of data so it’s clear what the values mean. Adding these
 names means that structs are more flexible than tuples: you don’t have to rely
 on the order of the data to specify or access the values of an instance.
 


### PR DESCRIPTION
The current version of this chapter reads that structs and tuples "both hold multiple related values." This language excludes those structs and tuples which happen to hold between `0`-`1` values. By inserting the word "can" into this, we can keep the emphasis on structs' and tuples' capacity for holding multiple sub-items, while still leaving room for the other cases to exist too.  

Similarly, a later sentence in this chapter currently reads "in a struct you’ll name each piece of data so it’s clear what the values mean." This language implies an obligation to name struct fields, excluding tuple structs. By replacing "you’ll" with "you can", we can be inclusive of tuple structs, while still emphasizing the power that comes with named fields. 