### PR TITLE
Chapter 19-2: Update text to `let...else`

### DIFF
--- a/listings/ch19-patterns-and-matching/listing-19-10/output.txt
+++ b/listings/ch19-patterns-and-matching/listing-19-10/output.txt
@@ -1,13 +1,13 @@
 $ cargo run
    Compiling patterns v0.1.0 (file:///projects/patterns)
-warning: irrefutable `if let` pattern
- --> src/main.rs:2:8
+warning: irrefutable `let...else` pattern
+ --> src/main.rs:2:5
   |
-2 |     if let x = 5 {
-  |        ^^^^^^^^^
+2 |     let x = 5 else {
+  |     ^^^^^^^^^
   |
-  = note: this pattern will always match, so the `if let` is useless
-  = help: consider replacing the `if let` with a `let`
+  = note: this pattern will always match, so the `else` clause is useless
+  = help: consider removing the `else` clause
   = note: `#[warn(irrefutable_let_patterns)]` on by default
 
 warning: `patterns` (bin "patterns") generated 1 warning

--- a/src/ch19-02-refutability.md
+++ b/src/ch19-02-refutability.md
@@ -50,9 +50,9 @@ pattern `Some(x)`, Rust rightfully produces a compiler error.
 
 If we have a refutable pattern where an irrefutable pattern is needed, we can
 fix it by changing the code that uses the pattern: instead of using `let`, we
-can use `if let`. Then if the pattern doesn’t match, the code will just skip
-the code in the curly brackets, giving it a way to continue validly. Listing
-19-9 shows how to fix the code in Listing 19-8.
+can use `let...else`. Then if the pattern doesn’t match, the code in the curly
+brackets will be executed, giving it a way to continue validly. Listing 19-9
+shows how to fix the code in Listing 19-8.
 
 <Listing number="19-9" caption="Using `let...else` and a block with refutable patterns instead of `let`">
 
@@ -62,12 +62,11 @@ the code in the curly brackets, giving it a way to continue validly. Listing
 
 </Listing>
 
-We’ve given the code an out! This code is perfectly valid now. However,
-if we give `if let` an irrefutable pattern (a pattern that will always
-match), such as `x`, as shown in Listing 19-10, the compiler will give a
-warning.
+We’ve given the code an out! This code is perfectly valid now. However, if we
+give `let...else` an irrefutable pattern (a pattern that will always match),
+such as `x`, as shown in Listing 19-10, the compiler will give a warning.
 
-<Listing number="19-10" caption="Attempting to use an irrefutable pattern with `if let`">
+<Listing number="19-10" caption="Attempting to use an irrefutable pattern with `let...else`">
 
 ```rust
 {{#rustdoc_include ../listings/ch19-patterns-and-matching/listing-19-10/src/main.rs:here}}
@@ -75,8 +74,8 @@ warning.
 
 </Listing>
 
-Rust complains that it doesn’t make sense to use `if let` with an irrefutable
-pattern:
+Rust complains that it doesn’t make sense to use `let...else` with an
+irrefutable pattern:
 
 ```console
 {{#include ../listings/ch19-patterns-and-matching/listing-19-10/output.txt}}


### PR DESCRIPTION
The text sometimes still refers to `if let` instead to `let...else`.
This PR updates the text accordingly.