### PR TITLE
Fixed dead links present in every /second-edition/src file

### DIFF
--- a/second-edition/src/appendix-00.md
+++ b/second-edition/src/appendix-00.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../appendix-00.html) instead.
+version of the book](/src/appendix-00.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/appendix-01-keywords.md
+++ b/second-edition/src/appendix-01-keywords.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../appendix-01-keywords.html) instead.
+version of the book](/src/appendix-01-keywords.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/appendix-02-operators.md
+++ b/second-edition/src/appendix-02-operators.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../appendix-02-operators.html) instead.
+version of the book](/src/appendix-02-operators.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/appendix-03-derivable-traits.md
+++ b/second-edition/src/appendix-03-derivable-traits.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../appendix-03-derivable-traits.html) instead.
+version of the book](/src/appendix-03-derivable-traits.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/appendix-04-macros.md
+++ b/second-edition/src/appendix-04-macros.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch20-05-macros.html) instead.
+version of the book](/src/ch20-05-macros.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/appendix-05-translation.md
+++ b/second-edition/src/appendix-05-translation.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../appendix-06-translation.html) instead.
+version of the book](/src/appendix-06-translation.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/appendix-06-newest-features.md
+++ b/second-edition/src/appendix-06-newest-features.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](/src/index.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/appendix-07-nightly-rust.md
+++ b/second-edition/src/appendix-07-nightly-rust.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../appendix-07-nightly-rust.html) instead.
+version of the book](/src/appendix-07-nightly-rust.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch00-00-introduction.md
+++ b/second-edition/src/ch00-00-introduction.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch00-00-introduction.html) instead.
+version of the book](/src/ch00-00-introduction.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch01-00-getting-started.md
+++ b/second-edition/src/ch01-00-getting-started.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch01-00-getting-started.html) instead.
+version of the book](/src/ch01-00-getting-started.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch01-01-installation.md
+++ b/second-edition/src/ch01-01-installation.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch01-01-installation.html) instead.
+version of the book](/src/ch01-01-installation.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch01-02-hello-world.md
+++ b/second-edition/src/ch01-02-hello-world.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch01-02-hello-world.html) instead.
+version of the book](/src/ch01-02-hello-world.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch01-03-hello-cargo.md
+++ b/second-edition/src/ch01-03-hello-cargo.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch01-03-hello-cargo.html) instead.
+version of the book](/src/ch01-03-hello-cargo.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch02-00-guessing-game-tutorial.md
+++ b/second-edition/src/ch02-00-guessing-game-tutorial.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch02-00-guessing-game-tutorial.html) instead.
+version of the book](/src/ch02-00-guessing-game-tutorial.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch03-00-common-programming-concepts.md
+++ b/second-edition/src/ch03-00-common-programming-concepts.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch03-00-common-programming-concepts.html) instead.
+version of the book](/src/ch03-00-common-programming-concepts.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch03-01-variables-and-mutability.md
+++ b/second-edition/src/ch03-01-variables-and-mutability.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch03-01-variables-and-mutability.html) instead.
+version of the book](/src/ch03-01-variables-and-mutability.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch03-02-data-types.md
+++ b/second-edition/src/ch03-02-data-types.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch03-02-data-types.html) instead.
+version of the book](/src/ch03-02-data-types.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch03-03-how-functions-work.md
+++ b/second-edition/src/ch03-03-how-functions-work.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch03-03-how-functions-work.html) instead.
+version of the book](/src/ch03-03-how-functions-work.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch03-04-comments.md
+++ b/second-edition/src/ch03-04-comments.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch03-04-comments.html) instead.
+version of the book](/src/ch03-04-comments.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch03-05-control-flow.md
+++ b/second-edition/src/ch03-05-control-flow.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch03-05-control-flow.html) instead.
+version of the book](/src/ch03-05-control-flow.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch04-00-understanding-ownership.md
+++ b/second-edition/src/ch04-00-understanding-ownership.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch04-00-understanding-ownership.html) instead.
+version of the book](/src/ch04-00-understanding-ownership.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch04-01-what-is-ownership.md
+++ b/second-edition/src/ch04-01-what-is-ownership.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch04-01-what-is-ownership.html) instead.
+version of the book](/src/ch04-01-what-is-ownership.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch04-02-references-and-borrowing.md
+++ b/second-edition/src/ch04-02-references-and-borrowing.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch04-02-references-and-borrowing.html) instead.
+version of the book](/src/ch04-02-references-and-borrowing.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch04-03-slices.md
+++ b/second-edition/src/ch04-03-slices.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch04-03-slices.html) instead.
+version of the book](/src/ch04-03-slices.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch05-00-structs.md
+++ b/second-edition/src/ch05-00-structs.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch05-00-structs.html) instead.
+version of the book](/src/ch05-00-structs.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch05-01-defining-structs.md
+++ b/second-edition/src/ch05-01-defining-structs.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch05-01-defining-structs.html) instead.
+version of the book](/src/ch05-01-defining-structs.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch05-02-example-structs.md
+++ b/second-edition/src/ch05-02-example-structs.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch05-02-example-structs.html) instead.
+version of the book](/src/ch05-02-example-structs.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch05-03-method-syntax.md
+++ b/second-edition/src/ch05-03-method-syntax.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch05-03-method-syntax.html) instead.
+version of the book](/src/ch05-03-method-syntax.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch06-00-enums.md
+++ b/second-edition/src/ch06-00-enums.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch06-00-enums.html) instead.
+version of the book](/src/ch06-00-enums.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch06-01-defining-an-enum.md
+++ b/second-edition/src/ch06-01-defining-an-enum.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch06-01-defining-an-enum.html) instead.
+version of the book](/src/ch06-01-defining-an-enum.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch06-02-match.md
+++ b/second-edition/src/ch06-02-match.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch06-02-match.html) instead.
+version of the book](/src/ch06-02-match.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch06-03-if-let.md
+++ b/second-edition/src/ch06-03-if-let.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch06-03-if-let.html) instead.
+version of the book](/src/ch06-03-if-let.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch07-00-modules.md
+++ b/second-edition/src/ch07-00-modules.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch07-02-defining-modules-to-control-scope-and-privacy.html) instead.
+version of the book](/src/ch07-02-defining-modules-to-control-scope-and-privacy.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch07-01-mod-and-the-filesystem.md
+++ b/second-edition/src/ch07-01-mod-and-the-filesystem.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch07-02-defining-modules-to-control-scope-and-privacy.html) instead.
+version of the book](/src/ch07-02-defining-modules-to-control-scope-and-privacy.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch07-02-controlling-visibility-with-pub.md
+++ b/second-edition/src/ch07-02-controlling-visibility-with-pub.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch07-02-defining-modules-to-control-scope-and-privacy.html) instead.
+version of the book](/src/ch07-02-defining-modules-to-control-scope-and-privacy.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch07-03-importing-names-with-use.md
+++ b/second-edition/src/ch07-03-importing-names-with-use.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch07-04-bringing-paths-into-scope-with-the-use-keyword.html) instead.
+version of the book](/src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch08-00-common-collections.md
+++ b/second-edition/src/ch08-00-common-collections.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch08-00-common-collections.html) instead.
+version of the book](/src/ch08-00-common-collections.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch08-01-vectors.md
+++ b/second-edition/src/ch08-01-vectors.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch08-01-vectors.html) instead.
+version of the book](/src/ch08-01-vectors.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch08-02-strings.md
+++ b/second-edition/src/ch08-02-strings.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch08-02-strings.html) instead.
+version of the book](/src/ch08-02-strings.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch08-03-hash-maps.md
+++ b/second-edition/src/ch08-03-hash-maps.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch08-03-hash-maps.html) instead.
+version of the book](/src/ch08-03-hash-maps.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch09-00-error-handling.md
+++ b/second-edition/src/ch09-00-error-handling.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch09-00-error-handling.html) instead.
+version of the book](/src/ch09-00-error-handling.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch09-01-unrecoverable-errors-with-panic.md
+++ b/second-edition/src/ch09-01-unrecoverable-errors-with-panic.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch09-01-unrecoverable-errors-with-panic.html) instead.
+version of the book](/src/ch09-01-unrecoverable-errors-with-panic.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch09-02-recoverable-errors-with-result.md
+++ b/second-edition/src/ch09-02-recoverable-errors-with-result.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch09-02-recoverable-errors-with-result.html) instead.
+version of the book](/src/ch09-02-recoverable-errors-with-result.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch09-03-to-panic-or-not-to-panic.md
+++ b/second-edition/src/ch09-03-to-panic-or-not-to-panic.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch09-03-to-panic-or-not-to-panic.html) instead.
+version of the book](/src/ch09-03-to-panic-or-not-to-panic.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch10-00-generics.md
+++ b/second-edition/src/ch10-00-generics.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch10-00-generics.html) instead.
+version of the book](/src/ch10-00-generics.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch10-01-syntax.md
+++ b/second-edition/src/ch10-01-syntax.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch10-01-syntax.html) instead.
+version of the book](/src/ch10-01-syntax.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch10-02-traits.md
+++ b/second-edition/src/ch10-02-traits.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch10-02-traits.html) instead.
+version of the book](/src/ch10-02-traits.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch10-03-lifetime-syntax.md
+++ b/second-edition/src/ch10-03-lifetime-syntax.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch10-03-lifetime-syntax.html) instead.
+version of the book](/src/ch10-03-lifetime-syntax.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch11-00-testing.md
+++ b/second-edition/src/ch11-00-testing.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch11-00-testing.html) instead.
+version of the book](/src/ch11-00-testing.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch11-01-writing-tests.md
+++ b/second-edition/src/ch11-01-writing-tests.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch11-01-writing-tests.html) instead.
+version of the book](/src/ch11-01-writing-tests.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch11-02-running-tests.md
+++ b/second-edition/src/ch11-02-running-tests.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch11-02-running-tests.html) instead.
+version of the book](/src/ch11-02-running-tests.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch11-03-test-organization.md
+++ b/second-edition/src/ch11-03-test-organization.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch11-03-test-organization.html) instead.
+version of the book](/src/ch11-03-test-organization.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch12-00-an-io-project.md
+++ b/second-edition/src/ch12-00-an-io-project.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch12-00-an-io-project.html) instead.
+version of the book](/src/ch12-00-an-io-project.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch12-01-accepting-command-line-arguments.md
+++ b/second-edition/src/ch12-01-accepting-command-line-arguments.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch12-01-accepting-command-line-arguments.html) instead.
+version of the book](/src/ch12-01-accepting-command-line-arguments.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch12-02-reading-a-file.md
+++ b/second-edition/src/ch12-02-reading-a-file.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch12-02-reading-a-file.html) instead.
+version of the book](/src/ch12-02-reading-a-file.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch12-03-improving-error-handling-and-modularity.md
+++ b/second-edition/src/ch12-03-improving-error-handling-and-modularity.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch12-03-improving-error-handling-and-modularity.html) instead.
+version of the book](/src/ch12-03-improving-error-handling-and-modularity.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch12-04-testing-the-librarys-functionality.md
+++ b/second-edition/src/ch12-04-testing-the-librarys-functionality.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch12-04-testing-the-librarys-functionality.html) instead.
+version of the book](/src/ch12-04-testing-the-librarys-functionality.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch12-05-working-with-environment-variables.md
+++ b/second-edition/src/ch12-05-working-with-environment-variables.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch12-05-working-with-environment-variables.html) instead.
+version of the book](/src/ch12-05-working-with-environment-variables.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch12-06-writing-to-stderr-instead-of-stdout.md
+++ b/second-edition/src/ch12-06-writing-to-stderr-instead-of-stdout.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch12-06-writing-to-stderr-instead-of-stdout.html) instead.
+version of the book](/src/ch12-06-writing-to-stderr-instead-of-stdout.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch13-00-functional-features.md
+++ b/second-edition/src/ch13-00-functional-features.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch13-00-functional-features.html) instead.
+version of the book](/src/ch13-00-functional-features.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch13-01-closures.md
+++ b/second-edition/src/ch13-01-closures.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch13-01-closures.html) instead.
+version of the book](/src/ch13-01-closures.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch13-02-iterators.md
+++ b/second-edition/src/ch13-02-iterators.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch13-02-iterators.html) instead.
+version of the book](/src/ch13-02-iterators.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch13-03-improving-our-io-project.md
+++ b/second-edition/src/ch13-03-improving-our-io-project.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch13-03-improving-our-io-project.html) instead.
+version of the book](/src/ch13-03-improving-our-io-project.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch13-04-performance.md
+++ b/second-edition/src/ch13-04-performance.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch13-04-performance.html) instead.
+version of the book](/src/ch13-04-performance.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch14-00-more-about-cargo.md
+++ b/second-edition/src/ch14-00-more-about-cargo.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch14-00-more-about-cargo.html) instead.
+version of the book](/src/ch14-00-more-about-cargo.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch14-01-release-profiles.md
+++ b/second-edition/src/ch14-01-release-profiles.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch14-01-release-profiles.html) instead.
+version of the book](/src/ch14-01-release-profiles.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch14-02-publishing-to-crates-io.md
+++ b/second-edition/src/ch14-02-publishing-to-crates-io.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch14-02-publishing-to-crates-io.html) instead.
+version of the book](/src/ch14-02-publishing-to-crates-io.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch14-03-cargo-workspaces.md
+++ b/second-edition/src/ch14-03-cargo-workspaces.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch14-03-cargo-workspaces.html) instead.
+version of the book](/src/ch14-03-cargo-workspaces.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch14-04-installing-binaries.md
+++ b/second-edition/src/ch14-04-installing-binaries.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch14-04-installing-binaries.html) instead.
+version of the book](/src/ch14-04-installing-binaries.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch14-05-extending-cargo.md
+++ b/second-edition/src/ch14-05-extending-cargo.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch14-05-extending-cargo.html) instead.
+version of the book](/src/ch14-05-extending-cargo.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch15-00-smart-pointers.md
+++ b/second-edition/src/ch15-00-smart-pointers.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch15-00-smart-pointers.html) instead.
+version of the book](/src/ch15-00-smart-pointers.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch15-01-box.md
+++ b/second-edition/src/ch15-01-box.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch15-01-box.html) instead.
+version of the book](/src/ch15-01-box.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch15-02-deref.md
+++ b/second-edition/src/ch15-02-deref.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch15-02-deref.html) instead.
+version of the book](/src/ch15-02-deref.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch15-03-drop.md
+++ b/second-edition/src/ch15-03-drop.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch15-03-drop.html) instead.
+version of the book](/src/ch15-03-drop.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch15-04-rc.md
+++ b/second-edition/src/ch15-04-rc.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch15-04-rc.html) instead.
+version of the book](/src/ch15-04-rc.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch15-05-interior-mutability.md
+++ b/second-edition/src/ch15-05-interior-mutability.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch15-05-interior-mutability.html) instead.
+version of the book](/src/ch15-05-interior-mutability.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch15-06-reference-cycles.md
+++ b/second-edition/src/ch15-06-reference-cycles.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch15-06-reference-cycles.html) instead.
+version of the book](/src/ch15-06-reference-cycles.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch16-00-concurrency.md
+++ b/second-edition/src/ch16-00-concurrency.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch16-00-concurrency.html) instead.
+version of the book](/src/ch16-00-concurrency.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch16-01-threads.md
+++ b/second-edition/src/ch16-01-threads.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch16-01-threads.html) instead.
+version of the book](/src/ch16-01-threads.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch16-02-message-passing.md
+++ b/second-edition/src/ch16-02-message-passing.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch16-02-message-passing.html) instead.
+version of the book](/src/ch16-02-message-passing.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch16-03-shared-state.md
+++ b/second-edition/src/ch16-03-shared-state.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch16-03-shared-state.html) instead.
+version of the book](/src/ch16-03-shared-state.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch16-04-extensible-concurrency-sync-and-send.md
+++ b/second-edition/src/ch16-04-extensible-concurrency-sync-and-send.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch16-04-extensible-concurrency-sync-and-send.html) instead.
+version of the book](/src/ch16-04-extensible-concurrency-sync-and-send.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch17-00-oop.md
+++ b/second-edition/src/ch17-00-oop.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch18-00-oop.html) instead.
+version of the book](/src/ch18-00-oop.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch17-01-what-is-oo.md
+++ b/second-edition/src/ch17-01-what-is-oo.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch18-01-what-is-oo.html) instead.
+version of the book](/src/ch18-01-what-is-oo.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch17-02-trait-objects.md
+++ b/second-edition/src/ch17-02-trait-objects.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch18-02-trait-objects.html) instead.
+version of the book](/src/ch18-02-trait-objects.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch17-03-oo-design-patterns.md
+++ b/second-edition/src/ch17-03-oo-design-patterns.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch18-03-oo-design-patterns.html) instead.
+version of the book](/src/ch18-03-oo-design-patterns.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch18-00-patterns.md
+++ b/second-edition/src/ch18-00-patterns.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch19-00-patterns.html) instead.
+version of the book](/src/ch19-00-patterns.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch18-01-all-the-places-for-patterns.md
+++ b/second-edition/src/ch18-01-all-the-places-for-patterns.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch19-01-all-the-places-for-patterns.html) instead.
+version of the book](/src/ch19-01-all-the-places-for-patterns.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch18-02-refutability.md
+++ b/second-edition/src/ch18-02-refutability.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch19-02-refutability.html) instead.
+version of the book](/src/ch19-02-refutability.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch18-03-pattern-syntax.md
+++ b/second-edition/src/ch18-03-pattern-syntax.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch19-03-pattern-syntax.html) instead.
+version of the book](/src/ch19-03-pattern-syntax.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch19-00-advanced-features.md
+++ b/second-edition/src/ch19-00-advanced-features.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch20-00-advanced-features.html) instead.
+version of the book](/src/ch20-00-advanced-features.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch19-01-unsafe-rust.md
+++ b/second-edition/src/ch19-01-unsafe-rust.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch20-01-unsafe-rust.html) instead.
+version of the book](/src/ch20-01-unsafe-rust.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch19-02-advanced-lifetimes.md
+++ b/second-edition/src/ch19-02-advanced-lifetimes.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../index.html) instead.
+version of the book](/src/index.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch19-03-advanced-traits.md
+++ b/second-edition/src/ch19-03-advanced-traits.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch20-02-advanced-traits.html) instead.
+version of the book](/src/ch20-02-advanced-traits.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch19-04-advanced-types.md
+++ b/second-edition/src/ch19-04-advanced-types.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch20-03-advanced-types.html) instead.
+version of the book](/src/ch20-03-advanced-types.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch19-05-advanced-functions-and-closures.md
+++ b/second-edition/src/ch19-05-advanced-functions-and-closures.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch20-04-advanced-functions-and-closures.html) instead.
+version of the book](/src/ch20-04-advanced-functions-and-closures.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch20-00-final-project-a-web-server.md
+++ b/second-edition/src/ch20-00-final-project-a-web-server.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch21-00-final-project-a-web-server.html) instead.
+version of the book](/src/ch21-00-final-project-a-web-server.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch20-01-single-threaded.md
+++ b/second-edition/src/ch20-01-single-threaded.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch21-01-single-threaded.html) instead.
+version of the book](/src/ch21-01-single-threaded.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch20-02-multithreaded.md
+++ b/second-edition/src/ch20-02-multithreaded.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch21-02-multithreaded.html) instead.
+version of the book](/src/ch21-02-multithreaded.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/ch20-03-graceful-shutdown-and-cleanup.md
+++ b/second-edition/src/ch20-03-graceful-shutdown-and-cleanup.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../ch21-03-graceful-shutdown-and-cleanup.html) instead.
+version of the book](/src/ch21-03-graceful-shutdown-and-cleanup.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust

--- a/second-edition/src/foreword.md
+++ b/second-edition/src/foreword.md
@@ -3,7 +3,7 @@
 The second edition of the book is no longer distributed with Rust's documentation.
 
 If you came here via a link or web search, you may want to check out [the current
-version of the book](../foreword.html) instead.
+version of the book](/src/foreword.md) instead.
 
 If you have an internet connection, you can [find a copy distributed with
 Rust


### PR DESCRIPTION
Previously every chapter in /second-edition/src had a link to the current version of the book, eg:
```[the current version of the book](../appendix-00.html)```

However, this is a dead link and does not exist, so I replaced these links with:
```[the current version of the book](/src/appendix-00.md)```
This is what seems to be the correct link, though if a different page was intended to be linked to then I can change that.

- DeaDvey