### PR TITLE
Clarify numeric literal terminology in data types section

### DIFF
--- a/src/ch03-02-data-types.md
+++ b/src/ch03-02-data-types.md
@@ -74,20 +74,24 @@ computer your program is running on, which is denoted in the table as “arch”
 architecture.
 
 You can write integer literals in any of the forms shown in Table 3-2. Note
-that number literals that can be multiple numeric types allow a type suffix,
-such as `57u8`, to designate the type. Number literals can also use `_` as a
+that numeric literals (both integer and floating-point) allow type suffixes 
+like 57u8 or 3.14f32 to designate their type. Numeric literals can also use _ as a
 visual separator to make the number easier to read, such as `1_000`, which will
-have the same value as if you had specified `1000`.
+have the same value as 1000. These features work for both integer and floating-point literals.
 
 <span class="caption">Table 3-2: Integer Literals in Rust</span>
 
-| Number literals  | Example       |
+| Integer literals  | Example       |
 | ---------------- | ------------- |
 | Decimal          | `98_222`      |
 | Hex              | `0xff`        |
 | Octal            | `0o77`        |
 | Binary           | `0b1111_0000` |
 | Byte (`u8` only) | `b'A'`        |
+
+> Note: While this table shows integer literal formats, many numeric literal features
+> (like type suffixes and `_` separators) also apply to floating-point literals.
+> We'll cover floating-point literals in more detail later in this chapter.
 
 So how do you know which type of integer to use? If you’re unsure, Rust’s
 defaults are generally good places to start: integer types default to `i32`.


### PR DESCRIPTION
This PR enhances clarity in the "Integer Literals" documentation section by:

1. Acknowledging the intentional shift from "integer literals" to "number literals"

2. Explicitly connecting numeric literal features to floating-point literals

3. Maintaining table accuracy while explaining broader applicability

The changes help readers understand that type suffixes and visual separators apply to all numeric literals, while keeping the section focused on integer examples.