### PR TITLE
fix: build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The Rust Programming Language
 
-![Build Status](https://github.com/rust-lang/book/workflows/CI/badge.svg)
+[![Build Status](https://github.com/rust-lang/book/actions/workflows/main.yml/badge.svg)](https://github.com/rust-lang/book/actions/workflows/main.yml)
 
 This repository contains the source of "The Rust Programming Language" book.
 

--- a/packages/trpl/README.md
+++ b/packages/trpl/README.md
@@ -1,6 +1,6 @@
 # The Rust Programming Language Book Crate
 
-![Build Status](https://github.com/chriskrycho/trpl-crate/workflows/CI/badge.svg)
+[![Build Status](https://github.com/rust-lang/book/actions/workflows/main.yml/badge.svg)](https://github.com/rust-lang/book/actions/workflows/main.yml)
 
 This repository is the home of the `trpl` crate used in _The Rust Programming
 Language_ book materials.


### PR DESCRIPTION
This patch:
+ fixes the broken link to CI build status badge:
![image](https://github.com/user-attachments/assets/6ad33188-a4b1-4ab0-be39-4f7a39cffedc)
+ links the build status to gha workflow run
