### PR TITLE
Ch.17: add missing word in intro

### DIFF
--- a/src/ch17-06-futures-tasks-threads.md
+++ b/src/ch17-06-futures-tasks-threads.md
@@ -2,9 +2,9 @@
 
 As we saw in [Chapter 16][ch16]<!-- ignore -->, threads provide one approach to
 concurrency. We’ve seen another approach in this chapter: using async with
-futures and streams. If you‘re wondering when to choose method over the other,
-the answer is: it depends! And in many cases, the choice isn’t threads _or_
-async but rather threads _and_ async.
+futures and streams. If you‘re wondering when to choose one method over the
+other, the answer is: it depends! And in many cases, the choice isn’t threads
+_or_ async but rather threads _and_ async.
 
 Many operating systems have supplied threading-based concurrency models for
 decades now, and many programming languages support them as a result. However,


### PR DESCRIPTION
Add missing word in the first paragraph:

```
If you‘re wondering when to choose method over the other,
```
vs
```
If you‘re wondering when to choose one method over the other,
```