### PR TITLE
Fix a typo in async chapter

### DIFF
--- a/src/ch17-02-concurrency-with-async.md
+++ b/src/ch17-02-concurrency-with-async.md
@@ -117,7 +117,7 @@ async blocks compile to anonymous futures, we can put each loop in an async
 block and have the runtime run them both to completion using the `trpl::join`
 function.
 
-In the section [Waiting for All Threads to Finishing Using `join`
+In the section [Waiting for All Threads to Finish Using `join`
 Handles][join-handles]<!-- ignore -->, we showed how to use the `join` method on
 the `JoinHandle` type returned when you call `std::thread::spawn`. The
 `trpl::join` function is similar, but for futures. When you give it two futures,


### PR DESCRIPTION
It said "Waiting for All Threads to Finishing Using `join` Handles" and it should be "Finish". Just something I spotted whilst reading online.

The same error exists in nostarch/chapter17.md but I wasn't sure what the process was for modifying that copy (it's for the printed book?).
