### PR TITLE
Ch. 17: Replace 'page_title' in match with 'value'

### DIFF
--- a/src/ch17-05-traits-for-async.md
+++ b/src/ch17-05-traits-for-async.md
@@ -87,7 +87,7 @@ we need a loop:
 let mut page_title_fut = page_title(url);
 loop {
     match page_title_fut.poll() {
-        Ready(value) => match page_title {
+        Ready(value) => match value {
             Some(title) => println!("The title for {url} was {title}"),
             None => println!("{url} had no title"),
         }


### PR DESCRIPTION
Hi folks!

A new rustacean here, enjoying the book a lot. 

I have realised that in the `match` expression I edited, there's a variable `page_title` that seems to be copy-pasted from a previous snippet. I'm not 100% sure about this, because I'm still getting used to Rust's syntax, but I'd say it has to be called `value`.

Let me know if I got something wrong, or if I should add something else to this PR.

