### PR TITLE
added the short hand for the #[should_panic = "msg"]

### DIFF
--- a/listings/ch11-writing-automated-tests/listing-11-09/src/lib.rs
+++ b/listings/ch11-writing-automated-tests/listing-11-09/src/lib.rs
@@ -27,7 +27,7 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "less than or equal to 100")]
-    #[should_panic = "less than or equal to 100"]//this would work fine 
+    //#[should_panic = "less than or equal to 100"]//this would work fine 
     fn greater_than_100() {
         Guess::new(200);
     }

--- a/listings/ch11-writing-automated-tests/listing-11-09/src/lib.rs
+++ b/listings/ch11-writing-automated-tests/listing-11-09/src/lib.rs
@@ -27,6 +27,7 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "less than or equal to 100")]
+    #[should_panic = "less than or equal to 100"]//this would work fine 
     fn greater_than_100() {
         Guess::new(200);
     }


### PR DESCRIPTION
#[should_panic = "msg"] is shorthand for #[should_panic(expected = "msg")]