### PR TITLE
ch11: fix incorrect assertion example in testing chapter

### DIFF
--- a/src/ch11-01-writing-tests.md
+++ b/src/ch11-01-writing-tests.md
@@ -327,8 +327,8 @@ assertion functions are called `expected` and `actual`, and the order in which
 we specify the arguments matters. However, in Rust, they’re called `left` and
 `right`, and the order in which we specify the value we expect and the value the
 code produces doesn’t matter. We could write the assertion in this test as
-`assert_eq!(add_two(2), result)`, which would result in the same failure message
-that displays `` assertion failed: `(left == right)` ``.
+`assert_eq!(4, result)`, which would result in the same failure message that
+displays `` assertion failed: `(left == right)` ``.
 
 The `assert_ne!` macro will pass if the two values we give it are not equal and
 fail if they’re equal. This macro is most useful for cases when we’re not sure


### PR DESCRIPTION
Reordered version of `assert_eq!(result, 4);`  in listing 11-7 would be `assert_eq!(4, result);` in the explanation text.