### PR TITLE
Fix Listing 19-10 for ch19-02-refutability chapter

### DIFF
--- a/listings/ch19-patterns-and-matching/listing-19-10/output.txt
+++ b/listings/ch19-patterns-and-matching/listing-19-10/output.txt
@@ -1,13 +1,13 @@
 $ cargo run
    Compiling patterns v0.1.0 (file:///projects/patterns)
-warning: irrefutable `let...else` pattern
- --> src/main.rs:2:5
+warning: irrefutable `if let` pattern
+ --> src/main.rs:3:8
   |
-2 |     let x = 5 else {
-  |     ^^^^^^^^^
+2 |     if let x = 5 {
+  |        ^^^^^^^^^
   |
-  = note: this pattern will always match, so the `else` clause is useless
-  = help: consider removing the `else` clause
+  = note: this pattern will always match, so the `if let` is useless
+  = help: consider replacing the `if let` with a `let`
   = note: `#[warn(irrefutable_let_patterns)]` on by default
 
 warning: `patterns` (bin "patterns") generated 1 warning

--- a/listings/ch19-patterns-and-matching/listing-19-10/src/main.rs
+++ b/listings/ch19-patterns-and-matching/listing-19-10/src/main.rs
@@ -1,7 +1,7 @@
 fn main() {
     // ANCHOR: here
-    let x = 5 else {
+    if let x = 5 {
         return;
-    };
+    }
     // ANCHOR_END: here
 }


### PR DESCRIPTION
The listing is supposed to show why it doesn't make sense to use "if let" with an irrefutable pattern. Currently the live book is showing a "let else" which could cause confusion for readers. For example: [https://doc.rust-lang.org/book/ch19-02-refutability.html#listing-19-10](https://doc.rust-lang.org/book/ch19-02-refutability.html#listing-19-10). This commit should fix the confusion.