### PR TITLE
fix(chapter10): small typo in sentence

### DIFF
--- a/src/ch10-03-lifetime-syntax.md
+++ b/src/ch10-03-lifetime-syntax.md
@@ -97,7 +97,7 @@ Here, `x` has the lifetime `'b`, which in this case is larger than `'a`. This
 means `r` can reference `x` because Rust knows that the reference in `r` will
 always be valid while `x` is valid.
 
-Now that you know where the lifetimes of references are and how Rust analyzes
+Now that you know what the lifetimes of references are and how Rust analyzes
 lifetimes to ensure references will always be valid, let’s explore generic
 lifetimes of parameters and return values in the context of functions.
 


### PR DESCRIPTION
`Now that you know where the lifetimes of references are...` => `Now that you know what the lifetimes of references are...`