### PR TITLE
Soften text in test-organization section that says not all code needs to be tested

### DIFF
--- a/src/ch11-03-test-organization.md
+++ b/src/ch11-03-test-organization.md
@@ -241,7 +241,8 @@ straightforward _src/main.rs_ file that calls logic that lives in the
 _src/lib.rs_ file. Using that structure, integration tests _can_ test the
 library crate with `use` to make the important functionality available. If the
 important functionality works, the small amount of code in the _src/main.rs_
-file will work as well, and that small amount of code doesn’t need to be tested.
+file may not need to be tested, or can be tested by executing the binary from
+the integration test.
 
 ## Summary
 


### PR DESCRIPTION
This came up in a URLO discussion:
<https://users.rust-lang.org/t/slightly-scary-line-about-testing-binary-crate/130649> and I agreed with the OP that it shouldn't say outright that the code in main doesn't need to be tested.