### PR TITLE
Clarify that `Pin` is not a trait

### DIFF
--- a/src/ch17-05-traits-for-async.md
+++ b/src/ch17-05-traits-for-async.md
@@ -123,7 +123,7 @@ yet ready.
 
 <a id="pinning-and-the-pin-and-unpin-traits"></a>
 
-### The `Pin` and `Unpin` Traits
+### The `Pin` struct and the `Unpin` trait
 
 When we introduced the idea of pinning in Listing 17-16, we ran into a very
 gnarly error message. Here is the relevant part of it again:


### PR DESCRIPTION
Thanks for the new chapter on `async`, some things just clicked while I read it.

I have one small suggestion,  for me the title of this section of the chapter of `async` book "[The Pin and Unpin Traits](https://doc.rust-lang.org/nightly/book/ch17-05-traits-for-async.html#the-pin-and-unpin-traits)" imply that both `Pin` and `Unpin` are traits, but that's not the case. 

The changes I proposed in this PR try to clarify that