### PR TITLE
ch17-05-traits-for-async.md: `value` -> `page_title`

### DIFF
--- a/src/ch17-05-traits-for-async.md
+++ b/src/ch17-05-traits-for-async.md
@@ -87,7 +87,7 @@ we need a loop:
 let mut page_title_fut = page_title(url);
 loop {
     match page_title_fut.poll() {
-        Ready(value) => match page_title {
+        Ready(page_title) => match page_title {
             Some(title) => println!("The title for {url} was {title}"),
             None => println!("{url} had no title"),
         }


### PR DESCRIPTION
The snippet just before this one has `Ready(page_title)`, so I'd guess that was fixed and this latter snippet overlooked.