### PR TITLE
swap types (back) to match the code

### DIFF
--- a/src/ch06-01-defining-an-enum.md
+++ b/src/ch06-01-defining-an-enum.md
@@ -271,7 +271,7 @@ any better than having null?
 In short, because `Option<T>` and `T` (where `T` can be any type) are different
 types, the compiler won’t let us use an `Option<T>` value as if it were
 definitely a valid value. For example, this code won’t compile, because it’s
-trying to add an `i8` to an `Option<i8>`:
+trying to add an `Option<i8>` to an `i8`:
 
 ```rust,ignore,does_not_compile
 {{#rustdoc_include ../listings/ch06-enums-and-pattern-matching/no-listing-07-cant-use-option-directly/src/main.rs:here}}


### PR DESCRIPTION
While #672 has me doubting whether I'm right, I think the (much improved since 2017!) compiler output is also pretty clear about the order of operations:

> the trait `Add<Option<i8>>` is not implemented for `i8`