### PR TITLE
Update README instructions for running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ $ start chrome.exe .\book\index.html            # Windows (Cmd)
 To run the tests:
 
 ```bash
-$ cd packages/trpl
 $ mdbook test --library-path packages/trpl/target/debug/deps
 ```
 


### PR DESCRIPTION
It looks like changing a directory isn't necessary, given the library path is specified in the next line.