### PR TITLE
Update the scraper dependency

### DIFF
--- a/packages/trpl/Cargo.toml
+++ b/packages/trpl/Cargo.toml
@@ -15,7 +15,7 @@ futures = "0.3"
 reqwest = { version = "0.12", default-features = false, features = [
     "rustls-tls",
 ] }
-scraper = "0.20"
+scraper = "0.23"
 tokio = { version = "1", default-features = false, features = [
     "fs",
     "rt-multi-thread",


### PR DESCRIPTION
I'm trying to get derive_more 2.0 (a crate I'm author of) on the
rust-playground. This involves getting the crates that pull in
derive_more to update their dependencies. This crate is the leaf crate
that pulls derive_more in. So hereby a PR to update the next one in the
chain.

Related:
- https://github.com/rust-lang/rust-playground/issues/1164#issuecomment-3020253643
- https://github.com/rust-scraper/scraper/pull/257
