### PR TITLE
Update README instructions for web browsers on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,18 +57,16 @@ _Firefox:_
 
 ```bash
 $ firefox book/index.html                       # Linux
-$ open -a "Firefox" book/index.html             # OS X
-$ Start-Process "firefox.exe" .\book\index.html # Windows (PowerShell)
-$ start firefox.exe .\book\index.html           # Windows (Cmd)
+$ open -a "Firefox" book/index.html             # macOS
+$ start firefox.exe ".\book\index.html"         # Windows
 ```
 
 _Chrome:_
 
 ```bash
 $ google-chrome book/index.html                 # Linux
-$ open -a "Google Chrome" book/index.html       # OS X
-$ Start-Process "chrome.exe" .\book\index.html  # Windows (PowerShell)
-$ start chrome.exe .\book\index.html            # Windows (Cmd)
+$ open -a "Google Chrome" book/index.html       # macOS
+$ start chrome.exe ".\book\index.html"          # Windows
 ```
 
 To run the tests:


### PR DESCRIPTION
Git Bash tries to open `http://.bookindex.html/` with the provided command. Quoting the path solved the problem.

```shell start firefox.exe ".\book\index.html" ```

Cmd and Powershell both work with or without quotes.

Since `start` works in PowerShell, I removed Start-Process from the
README to simplify it, but I've only tested on Windows 11. I don't know
if start works everywhere, but I do have a Windows 10 machine I can
check on if you like?

Using Ubuntu in Windows Terminal (WSL) has the same problem as Git Bash
if the path isn't quoted. It works when using a command like this
(Windows version of Firefox):

```powershell.exe start firefox ".\book\index.html" ```