### PR TITLE
Clarify lifetimes in `search` function in chapter 12.4

### DIFF
--- a/listings/ch12-an-io-project/listing-12-16/src/lib.rs
+++ b/listings/ch12-an-io-project/listing-12-16/src/lib.rs
@@ -1,5 +1,5 @@
 // ANCHOR: here
-pub fn search<'a>(query: &str, contents: &'a str) -> Vec<&'a str> {
+pub fn search<'a, 'b>(query: &'a str, contents: &'b str) -> Vec<&'b str> {
     vec![]
 }
 // ANCHOR_END: here

--- a/listings/ch12-an-io-project/listing-12-17/src/lib.rs
+++ b/listings/ch12-an-io-project/listing-12-17/src/lib.rs
@@ -1,5 +1,5 @@
 // ANCHOR: here
-pub fn search<'a>(query: &str, contents: &'a str) -> Vec<&'a str> {
+pub fn search<'a, 'b>(query: &'a str, contents: &'b str) -> Vec<&'b str> {
     for line in contents.lines() {
         // do something with line
     }

--- a/listings/ch12-an-io-project/listing-12-18/src/lib.rs
+++ b/listings/ch12-an-io-project/listing-12-18/src/lib.rs
@@ -1,5 +1,5 @@
 // ANCHOR: here
-pub fn search<'a>(query: &str, contents: &'a str) -> Vec<&'a str> {
+pub fn search<'a, 'b>(query: &'a str, contents: &'b str) -> Vec<&'b str> {
     for line in contents.lines() {
         if line.contains(query) {
             // do something with line

--- a/listings/ch12-an-io-project/listing-12-19/src/lib.rs
+++ b/listings/ch12-an-io-project/listing-12-19/src/lib.rs
@@ -1,6 +1,6 @@
 // ANCHOR: here
 // ANCHOR: ch13
-pub fn search<'a>(query: &str, contents: &'a str) -> Vec<&'a str> {
+pub fn search<'a, 'b>(query: &'a str, contents: &'b str) -> Vec<&'b str> {
     let mut results = Vec::new();
 
     for line in contents.lines() {


### PR DESCRIPTION
This PR updates the `search` function signature in chapter 12.4 to explicitly declare two lifetimes: one for the `query` parameter and one for the `contents` parameter.

Original code:

```rust
pub fn search<'a>(query: &str, contents: &'a str) -> Vec<&'a str>
```
Updated code:
```rust
pub fn search<'a, 'b>(query: &'a str, contents: &'b str) -> Vec<&'b str>
```
## Why this change?

While the original function signature compiles correctly, it may be confusing to beginners. Using a single lifetime parameter can suggest that both `query` and `contents` must live for the same duration, even though the return value depends only on `contents`.

According to the first lifetime elision rule, as written in Chapter 10:

> The first rule is that the compiler assigns a lifetime parameter to each parameter that’s a reference.  
> In other words, a function with one parameter gets one lifetime parameter:  
> `fn foo<'a>(x: &'a i32);`  
> a function with two parameters gets two separate lifetime parameters:  
> `fn foo<'a, 'b>(x: &'a i32, y: &'b i32);`  
> and so on.

To make this explicit, the revised version introduces two separate lifetimes — `'a` and `'b`. This highlights that the input references are independent, and clearly shows that the return value is tied only to `contents`.

This adjustment improves clarity and aligns more closely with how lifetimes are explained earlier in the book. It helps prevent misconceptions and builds a more accurate mental model for new readers.

Let me know if you'd like any revisions — happy to adjust!
