### PR TITLE
adding the extra "CRLF" after response's headers in the format in CH21.1

### DIFF
--- a/src/ch21-01-single-threaded.md
+++ b/src/ch21-01-single-threaded.md
@@ -216,6 +216,7 @@ HTTP is a text-based protocol, and a request takes this format:
 ```text
 Method Request-URI HTTP-Version CRLF
 headers CRLF
+CRLF
 message-body
 ```
 


### PR DESCRIPTION
fixed the response format since it didn't the necessary CRLF after headers. it can be confusing to add the extra CRLF in "\r\n\r\n" but never show it textually even if you explained in a tiny sentence.