### PR TITLE
Fix typo in Chapter 10 traits example output

### DIFF
--- a/src/ch10-02-traits.md
+++ b/src/ch10-02-traits.md
@@ -89,7 +89,7 @@ library crate:
 {{#rustdoc_include ../listings/ch10-generic-types-traits-and-lifetimes/no-listing-01-calling-trait-method/src/main.rs}}
 ```
 
-This code prints `1 new post: horse_ebooks: of course, as you probably already
+This code prints `1 new social post: horse_ebooks: of course, as you probably already
 know, people`.
 
 Other crates that depend on the `aggregator` crate can also bring the `Summary`


### PR DESCRIPTION
#### Issue

In Chapter 10.2 under the section [Implementing a Trait on a Type](https://doc.rust-lang.org/book/ch10-02-traits.html#implementing-a-trait-on-a-type) of *The Rust Book*, the text says:

```
This code prints 1 new post: horse_ebooks: of course, as you probably already know, people.
```

But the actual code uses:

```rust
println!("1 new social post: {}", post.summarize());
```

This creates a mismatch between the expected and actual output. The word **“social”** is missing in the textual explanation.

---

#### This PR fixes

* Updates the output description to match the format string in the code example.
* Corrected sentence:

```
This code prints 1 new social post: horse_ebooks: of course, as you probably already know, people.
```
---

#### 📄 Notes

* Only one line is modified in `src/ch10-02-traits.md`.
* No formatting or structural changes elsewhere.