### PR TITLE
Add a hint for the readers with a suggested workaround

### DIFF
--- a/src/ch21-02-multithreaded.md
+++ b/src/ch21-02-multithreaded.md
@@ -670,6 +670,10 @@ thread run them.
 > might load one at a time in five-second intervals. Some web browsers execute
 > multiple instances of the same request sequentially for caching reasons. This
 > limitation is not caused by our web server.
+>
+> To work around this limitation, you can either make requests from different
+> browsers (as opposed to separate browser tabs), or avoid using a browser
+> altogether and send the requests using a tool like `curl`.
 
 This is a good time to pause and consider how the code in Listings 21-18, 21-19,
 and 21-20 would be different if we were using futures instead of a closure for


### PR DESCRIPTION
...for a described limitation.

In this PR, I suggest including a hint for the readers of the book to clarify how they can observe the behavior described in the multi-threaded web server section. Due to certain browser-specific limitations (such as request caching or connection reuse within the same browser), the non-blocking handling of concurrent requests may not be evident when using a single browser.

The added note suggests using either multiple different browsers or a tool like `curl` to simulate multiple simultaneous requests more effectively, helping readers better understand and verify the server’s concurrent behavior as intended.
