### PR TITLE
Ch 17 - Make wait time consistent between examples

### DIFF
--- a/listings/ch17-async-await/listing-17-27/src/main.rs
+++ b/listings/ch17-async-await/listing-17-27/src/main.rs
@@ -6,11 +6,11 @@ fn main() {
     trpl::run(async {
         // ANCHOR: here
         let slow = async {
-            trpl::sleep(Duration::from_millis(100)).await;
-            "I finished!"
+            trpl::sleep(Duration::from_secs(5)).await;
+            "Finally finished"
         };
 
-        match timeout(slow, Duration::from_millis(10)).await {
+        match timeout(slow, Duration::from_secs(2)).await {
             Ok(message) => println!("Succeeded with '{message}'"),
             Err(duration) => {
                 println!("Failed after {} seconds", duration.as_secs())


### PR DESCRIPTION
Modify listing 17-27 to uses the same wait time as the subsequent listing, 17-28. This also helps with the output getting truncated (since the `Err` arm uses `duration.as_secs()` when println-ing).

Also modify the completion println to match 17-28.