### PR TITLE
Add console output for Listing 15-29 in chapter 15

### DIFF
--- a/src/ch15-06-reference-cycles.md
+++ b/src/ch15-06-reference-cycles.md
@@ -268,6 +268,16 @@ in Listing 15-29.
 
 </Listing>
 
+Then we will see the output:
+
+```console
+leaf strong = 1, weak = 0
+branch strong = 1, weak = 1
+leaf strong = 2, weak = 0
+leaf parent = None
+leaf strong = 1, weak = 0
+```
+
 After `leaf` is created, its `Rc<Node>` has a strong count of 1 and a weak
 count of 0. In the inner scope, we create `branch` and associate it with
 `leaf`, at which point when we print the counts, the `Rc<Node>` in `branch`


### PR DESCRIPTION
**Description**
This PR adds the missing console output for Listing 15-29 in Chapter 15 (“Smart Pointers”).
The output demonstrates the changes in strong_count and weak_count when branch is created in an inner scope and then dropped.

**Changes**
- Added console block after Listing 15-29 in `src/ch15-06-reference-cycles.md`.
- Output reflects the exact results produced by running the corresponding listing code.

**Reason**
The example previously lacked the actual runtime output, making it harder for readers to follow the explanation in the following paragraph. This change aligns the format with other listings in the book, where code examples are typically followed by their output.