### PR TITLE
Fix Vec::new() type annotation requirement in listing-08-03

### DIFF
--- a/listings/ch08-common-collections/listing-08-03/src/main.rs
+++ b/listings/ch08-common-collections/listing-08-03/src/main.rs
@@ -1,6 +1,6 @@
 fn main() {
     // ANCHOR: here
-    let mut v = Vec::new();
+    let mut v : Vec<i32> = Vec::new();
 
     v.push(5);
     v.push(6);


### PR DESCRIPTION
The current code in listing-08-03 uses `Vec::new()` without type annotation, 
which will not compile as Rust cannot infer the vector's type. Added explicit 
type annotation to make the example compilable.