### PR TITLE
Translation: added Italian translation link

### DIFF
--- a/src/appendix-06-translation.md
+++ b/src/appendix-06-translation.md
@@ -26,3 +26,4 @@ For resources in languages other than English. Most are still in progress; see
 - [हिंदी](https://github.com/venkatarun95/rust-book-hindi)
 - [ไทย](https://github.com/rust-lang-th/book-th)
 - [Danske](https://github.com/DanKHansen/book-dk)
+- [Italiano](https://nixxo.github.io/rust-lang-book-it/)


### PR DESCRIPTION
As the title suggest.

together with @lorenko we are translating the book in Italian and publishing it with Github Pages here: https://nixxo.github.io/rust-lang-book-it/.
hopefully the link can be added in the appendix. cheers.


fixing https://github.com/rust-lang/book/issues/3449


