### PR TITLE
Remove $ prompts when copying terminal commands

### DIFF
--- a/ferris.js
+++ b/ferris.js
@@ -26,6 +26,46 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 });
 
+// Remove $ prompts when copying terminal commands (but not command + output blocks)
+document.addEventListener('copy', function (e) {
+  try {
+    const selection = window.getSelection();
+
+    // Check if selection exists and has content
+    if (!selection || !selection.toString()) {
+      return;
+    }
+
+    const selectionText = selection.toString();
+
+    // Only process if it contains terminal prompts
+    if (!selectionText.includes('$ ')) {
+      return;
+    }
+
+    // Split into lines to analyze the selection
+    const lines = selectionText.split('\n');
+
+    // Only remove $ if ALL non-empty lines start with $ (i.e., only commands, no output)
+    const nonEmptyLines = lines.filter(line => line.trim().length > 0);
+    const allLinesAreCommands = nonEmptyLines.length > 0 &&
+      nonEmptyLines.every(line => line.trim().startsWith('$ '));
+
+    // Only clean if we're copying pure commands (no mixed command + output)
+    if (allLinesAreCommands) {
+      const cleaned = selectionText.replace(/^\$ /gm, '');
+
+      if (cleaned !== selectionText && e.clipboardData) {
+        e.clipboardData.setData('text/plain', cleaned);
+        e.preventDefault();
+      }
+    }
+  } catch (error) {
+    // Fail silently - let default copy behavior happen
+    console.warn('Copy enhancement failed, using default behavior');
+  }
+});
+
 /**
  * @param {FerrisType} type
  */


### PR DESCRIPTION
QOL improvement for online doc interaction - prevent `$` prompt char from being copied with the copy to clipboard button on code blocks. 

This might not be the most elegant way to tackle this; however, the other solution was to introduce HTML to specifically exclude the `$` char from the code block and thus from being selected at all. However, that would break the printability of the book. 

For reference:
<img width="765" height="56" alt="Screenshot 2025-08-29 at 10 39 23 PM" src="https://github.com/user-attachments/assets/80301f34-5c94-4966-8e63-1f2a2c0fe086" />

Earlier, if you pressed the copy button, it would copy the entire line like so: 
`$ curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | sh`

After the improvement, the copied text would be:
`curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | sh`

---

Copying of texts without `$` is unaffected. 

---

Copying of texts having `$` but aren't necessarily shell code is smartly exempted. So, if you copy this:
<img width="765" height="125" alt="Screenshot 2025-08-29 at 10 42 44 PM" src="https://github.com/user-attachments/assets/ce54ff95-eeec-4114-931d-b9e9216b1b39" />

It would remain as is:
```
$ cargo run
   Compiling functions v0.1.0 (file:///projects/functions)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.21s
     Running `target/debug/functions`
The value of x is: 5
```