### PR TITLE
Clarify package vs crate terminology in backyard example.

### DIFF
--- a/src/ch07-02-defining-modules-to-control-scope-and-privacy.md
+++ b/src/ch07-02-defining-modules-to-control-scope-and-privacy.md
@@ -46,9 +46,8 @@ great place to refer to as a reminder of how modules work.
   crate::garden::vegetables::Asparagus;` and from then on you only need to
   write `Asparagus` to make use of that type in the scope.
 
-Here, we create a binary crate named `backyard` that illustrates these rules.
-The crate’s directory, also named `backyard`, contains these files and
-directories:
+To illustrate these rules, we create a package named `backyard` that contains a binary crate.
+The package contains these files and directories:
 
 ```text
 backyard


### PR DESCRIPTION
The original text said "binary crate named backyard" and "crate's directory," but technically backyard is a package containing a binary crate. This commit updates the wording to use correct Rust terminology while keeping the text beginner-friendly.