### PR TITLE
Fix assertion in split_at_mut funciton

### DIFF
--- a/listings/ch20-advanced-features/listing-20-06/src/main.rs
+++ b/listings/ch20-advanced-features/listing-20-06/src/main.rs
@@ -5,7 +5,7 @@ fn split_at_mut(values: &mut [i32], mid: usize) -> (&mut [i32], &mut [i32]) {
     let len = values.len();
     let ptr = values.as_mut_ptr();
 
-    assert!(mid <= len);
+    assert!(mid < len);
 
     unsafe {
         (


### PR DESCRIPTION
In case we receive a mid = values .len() then ptr would take pointer to not same type value