### PR TITLE
Fix random number generation method in `src/main.rs`

### DIFF
--- a/listings/ch02-guessing-game-tutorial/listing-02-06/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/listing-02-06/src/main.rs
@@ -6,7 +6,7 @@ use rand::Rng;
 fn main() {
     println!("Guess the number!");
 
-    let secret_number = rand::thread_rng().gen_range(1..=100);
+    let secret_number = rand::rng().random_range(1..=100);
 
     loop {
         println!("Please input your guess.");


### PR DESCRIPTION
The Rust Book currently shows `rand::thread_rng().gen_range(1..=100)` for generating the secret number. This API has been deprecated in favor of the newer `rand::rng().random_range(1..=100)` introduced in recent versions of the `rand` crate.

This commit updates the example in `main.rs` to use the current recommended method, ensuring that readers following along with the book won’t encounter warnings or confusion when compiling the code with up-to-date dependencies.

No behavioral changes are introduced: the secret number is still generated uniformly at random between 1 and 100 (inclusive).