### PR TITLE
Update ch04-02-references-and-borrowing.md: Explain dangling reference prevention better.

### DIFF
--- a/src/ch04-02-references-and-borrowing.md
+++ b/src/ch04-02-references-and-borrowing.md
@@ -198,8 +198,8 @@ pointer_—a pointer that references a location in memory that may have been
 given to someone else—by freeing some memory while preserving a pointer to that
 memory. In Rust, by contrast, the compiler guarantees that references will
 never be dangling references: if you have a reference to some data, the
-compiler will ensure that the data will not go out of scope before the
-reference to the data does.
+compiler will not let you use that reference after the data has gone
+out of scope.
 
 Let’s try to create a dangling reference to see how Rust prevents them with a
 compile-time error:


### PR DESCRIPTION
Explain dangling reference prevention better.

The original wording might lead someone learning Rust to think that data will be kept around for as long as a reference exists. Instead, as soon as data is dropped, the reference is barred from being used. Those are two different mechanisms, and this disambiguates which one is in place.

Original discussion can be found here, on the Rust discord: https://discord.com/channels/273534239310479360/1120124565591425034/1419141200127983727