### PR TITLE
Disable hover background on Ferris in short code snippets

### DIFF
--- a/ferris.css
+++ b/ferris.css
@@ -65,3 +65,7 @@ pre:hover > .buttons button {
   visibility: visible;
   opacity: 1;
 }
+
+pre > .buttons :hover:not(button) {
+  background-color: transparent;
+}


### PR DESCRIPTION
Fixes #4529, see that issue for more details.

Tested only by editing the CSS live using dev tools. Did so in both Firefox and Chromium, results look good.

### Background
For short code snippets (fewer than 4 lines) which need Ferris, Ferris is made smaller and placed with the buttons. Some CSS from mdBook then applies to it unintentionally, giving it an ugly background when hovered over:

<img width="820" height="183" alt="Image" src="https://github.com/user-attachments/assets/4913a985-c8cc-48c1-b296-da6e73526039" />

(Colors will be different depending on theme)

All relevant existing code is referenced in https://github.com/rust-lang/book/issues/4529#issuecomment-3418829411 and https://github.com/rust-lang/book/issues/4529#issuecomment-3418860407

This PR simply changes the background back to transparent, fixing the issue.

### Alternatives
It might be cleaner to change the selector in the rule in mdBook so it only applies to buttons in the first place:
https://github.com/rust-lang/mdBook/blob/780fd83cacef0471e876f596949aaf71a2dc2b10/crates/mdbook-html/front-end/css/chrome.css#L238-L242
Change the selector to: `pre > .buttons button:hover`
But that would potentially affect other users of mdBook so it's probably a bad idea.

It might also be worth considering moving Ferris outside of the buttons. Which brings me to...

### Side notes
Is small Ferris too small? It certainly seems that way to me.