### PR TITLE
Prevent Ferris from hiding code

### DIFF
--- a/ferris.css
+++ b/ferris.css
@@ -19,6 +19,11 @@ body.ayu .not_desired_behavior {
   background: #501f21;
 }
 
+:root {
+  --ferris-large-width: 4.5em;
+  --ferris-small-width: 2.3em;
+}
+
 .ferris-container {
   position: absolute;
   z-index: 99;
@@ -33,11 +38,19 @@ body.ayu .not_desired_behavior {
 }
 
 .ferris-large {
-  width: 4.5em;
+  width: var(--ferris-large-width);
 }
 
 .ferris-small {
-  width: 2.3em;
+  width: var(--ferris-small-width);
+}
+
+.ferris-buffer-large {
+  margin-right: calc(var(--ferris-large-width) + 1.0em);
+}
+
+.ferris-buffer-small {
+  margin-right: calc(var(--ferris-small-width) + 0.5em);
 }
 
 .ferris-explain {


### PR DESCRIPTION
Fixes #2893.

I am so very rusty with JavaScript and DOM manipulation. This was more painful to get done than I expected. But I think it was worth it.

The premise is simple: if Ferris is hiding some code, let the user scroll horizontally far enough until the code is no longer hidden. However, we *don't* want to create excessive scrolling unnecessarily.

~~THIS IS A DRAFT.~~ To do:

- [ ] JavaScript: need code review. Some lines are obvious junk. I think the general code structure is sound, but I'm really not sure about style and linter errors. As I said, I'm rusty with JS, and not in the good meaning of "rusty"! Let me know what needs fixing.
- [x] CSS: should probably use CSS variables to put the ferris width and margin size in one place. Also, I wasn't sure if I should use margin or padding. Any idea?
- [x] Make the margin smaller for small Ferris.

Before: Note that the horizontal scroll bar is at its limit.
<img width="305" height="276" alt="image" src="https://github.com/user-attachments/assets/bc2408f6-3773-4810-9a16-d285c90445d3" />
After:
<img width="301" height="271" alt="image" src="https://github.com/user-attachments/assets/dc94cfb1-bf36-4092-bf08-5d90093b4f33" />


Before:
<img width="300" height="252" alt="image" src="https://github.com/user-attachments/assets/943c3ad3-b908-438f-b536-d9ac23d451a0" />
After: The longer line below Ferris is not given a margin unnecessarily.
<img width="300" height="261" alt="image" src="https://github.com/user-attachments/assets/2fcb791a-bda4-4212-8b71-d50d8608e480" />