### PR TITLE
ch17-06: Fix incorrect link for chapter 16 reference

### DIFF
--- a/src/ch17-06-futures-tasks-threads.md
+++ b/src/ch17-06-futures-tasks-threads.md
@@ -99,7 +99,7 @@ Next, we’ll talk about idiomatic ways to model problems and structure solution
 as your Rust programs get bigger. In addition, we’ll discuss how Rust’s idioms
 relate to those you might be familiar with from object-oriented programming.
 
-[ch16]: http://localhost:3000/ch16-00-concurrency.html
+[ch16]: ch16-00-concurrency.html
 [combining-futures]: ch17-03-more-futures.html#building-our-own-async-abstractions
 [streams]: ch17-04-streams.html#composing-streams
 [ch21]: ch21-00-final-project-a-web-server.html


### PR DESCRIPTION
remove `http://localhost:3000/` domain