### PR TITLE
Keep `struct Config` private in chapter 12 listings

### DIFF
--- a/listings/ch12-an-io-project/listing-12-22/src/main.rs
+++ b/listings/ch12-an-io-project/listing-12-22/src/main.rs
@@ -25,10 +25,10 @@ fn main() {
 }
 
 // ANCHOR: here
-pub struct Config {
-    pub query: String,
-    pub file_path: String,
-    pub ignore_case: bool,
+struct Config {
+    query: String,
+    file_path: String,
+    ignore_case: bool,
 }
 // ANCHOR_END: here
 

--- a/listings/ch12-an-io-project/listing-12-23/src/main.rs
+++ b/listings/ch12-an-io-project/listing-12-23/src/main.rs
@@ -19,10 +19,10 @@ fn main() {
     }
 }
 
-pub struct Config {
-    pub query: String,
-    pub file_path: String,
-    pub ignore_case: bool,
+struct Config {
+    query: String,
+    file_path: String,
+    ignore_case: bool,
 }
 
 // ANCHOR: here

--- a/listings/ch12-an-io-project/listing-12-24/src/main.rs
+++ b/listings/ch12-an-io-project/listing-12-24/src/main.rs
@@ -21,10 +21,10 @@ fn main() {
 }
 // ANCHOR_END: here
 
-pub struct Config {
-    pub query: String,
-    pub file_path: String,
-    pub ignore_case: bool,
+struct Config {
+    query: String,
+    file_path: String,
+    ignore_case: bool,
 }
 
 impl Config {

--- a/listings/ch13-functional-features/listing-12-23-reproduced/src/main.rs
+++ b/listings/ch13-functional-features/listing-12-23-reproduced/src/main.rs
@@ -19,10 +19,10 @@ fn main() {
     }
 }
 
-pub struct Config {
-    pub query: String,
-    pub file_path: String,
-    pub ignore_case: bool,
+struct Config {
+    query: String,
+    file_path: String,
+    ignore_case: bool,
 }
 
 // ANCHOR: ch13

--- a/listings/ch13-functional-features/listing-12-24-reproduced/src/main.rs
+++ b/listings/ch13-functional-features/listing-12-24-reproduced/src/main.rs
@@ -25,10 +25,10 @@ fn main() {
 }
 // ANCHOR_END: ch13
 
-pub struct Config {
-    pub query: String,
-    pub file_path: String,
-    pub ignore_case: bool,
+struct Config {
+    query: String,
+    file_path: String,
+    ignore_case: bool,
 }
 
 impl Config {

--- a/listings/ch13-functional-features/listing-13-18/src/main.rs
+++ b/listings/ch13-functional-features/listing-13-18/src/main.rs
@@ -23,10 +23,10 @@ fn main() {
 }
 // ANCHOR_END: here
 
-pub struct Config {
-    pub query: String,
-    pub file_path: String,
-    pub ignore_case: bool,
+struct Config {
+    query: String,
+    file_path: String,
+    ignore_case: bool,
 }
 
 impl Config {

--- a/listings/ch13-functional-features/listing-13-19/src/main.rs
+++ b/listings/ch13-functional-features/listing-13-19/src/main.rs
@@ -17,10 +17,10 @@ fn main() {
     }
 }
 
-pub struct Config {
-    pub query: String,
-    pub file_path: String,
-    pub ignore_case: bool,
+struct Config {
+    query: String,
+    file_path: String,
+    ignore_case: bool,
 }
 
 // ANCHOR: here

--- a/listings/ch13-functional-features/listing-13-20/src/main.rs
+++ b/listings/ch13-functional-features/listing-13-20/src/main.rs
@@ -17,10 +17,10 @@ fn main() {
     }
 }
 
-pub struct Config {
-    pub query: String,
-    pub file_path: String,
-    pub ignore_case: bool,
+struct Config {
+    query: String,
+    file_path: String,
+    ignore_case: bool,
 }
 
 // ANCHOR: here

--- a/nostarch/chapter12.md
+++ b/nostarch/chapter12.md
@@ -1454,10 +1454,10 @@ anywhere yet:
 Filename: src/main.rs
 
 ```
-pub struct Config {
-    pub query: String,
-    pub file_path: String,
-    pub ignore_case: bool,
+struct Config {
+    query: String,
+    file_path: String,
+    ignore_case: bool,
 }
 ```
 


### PR DESCRIPTION
Resolves #4524.

As described in that issue, this struct doesn't need to be public. It appears that in a past incarnation of the code, it used to be in lib.rs which is why it was made public, but this is no longer the case.

Note that some no-listings, such as [no-listing-02-using-search-in-run](https://github.com/rust-lang/book/blob/main/listings/ch12-an-io-project/no-listing-02-using-search-in-run/src/lib.rs), this struct is still in lib.rs instead of main.rs. These no-listings should probably be updated to match the code structure of the listings. I will open a separate issue for this if there isn't one already.