### PR TITLE
Chapter 20.2: use default type parameters to extend a trait (not a type)

### DIFF
--- a/nostarch/chapter20.md
+++ b/nostarch/chapter20.md
@@ -943,7 +943,7 @@ value of the `Rhs` type parameter instead of using the default of `Self`.
 
 You’ll use default type parameters in two main ways:
 
-1. To extend a type without breaking existing code
+1. To extend a trait without breaking existing code
 1. To allow customization in specific cases most users won’t need
 
 The standard library’s `Add` trait is an example of the second purpose:

--- a/src/ch20-02-advanced-traits.md
+++ b/src/ch20-02-advanced-traits.md
@@ -169,7 +169,7 @@ value of the `Rhs` type parameter instead of using the default of `Self`.
 
 You’ll use default type parameters in two main ways:
 
-1. To extend a type without breaking existing code
+1. To extend a trait without breaking existing code
 2. To allow customization in specific cases most users won’t need
 
 The standard library’s `Add` trait is an example of the second purpose:


### PR DESCRIPTION
Fix #4539.