### PR TITLE
Add a link to the Arabic translation in the appendix

### DIFF
--- a/src/appendix-06-translation.md
+++ b/src/appendix-06-translation.md
@@ -5,6 +5,7 @@ For resources in languages other than English. Most are still in progress; see
 
 [label]: https://github.com/rust-lang/book/issues?q=is%3Aopen+is%3Aissue+label%3ATranslations
 
+- (AR) [العربية](https://github.com/rust-lang-arabic/book)
 - [Português](https://github.com/rust-br/rust-book-pt-br) (BR)
 - [Português](https://github.com/nunojesus/rust-book-pt-pt) (PT)
 - 简体中文: [KaiserY/trpl-zh-cn](https://github.com/KaiserY/trpl-zh-cn), [gnu4cn/rust-lang-Zh_CN](https://github.com/gnu4cn/rust-lang-Zh_CN)


### PR DESCRIPTION
Add a link to the Arabic translation in the appendix-06-translation.md in the main repo to reference:  https://github.com/rust-lang-arabic/book