### PR TITLE
Chapter 9.2: move "for" from backticks

### DIFF
--- a/src/ch09-02-recoverable-errors-with-result.md
+++ b/src/ch09-02-recoverable-errors-with-result.md
@@ -348,7 +348,7 @@ reasons.
 
 For example, we could change the `read_username_from_file` function in Listing
 9-7 to return a custom error type named `OurError` that we define. If we also
-define `impl From<io::Error> for OurError` to construct an instance of
+define `impl From<io::Error>` for `OurError` to construct an instance of
 `OurError` from an `io::Error`, then the `?` operator calls in the body of
 `read_username_from_file` will call `from` and convert the error types without
 needing to add any more code to the function.


### PR DESCRIPTION
"for" should be outside of backticks that represent code