### PR TITLE
Chapter 21.2, update legacy method with a newer method

### DIFF
--- a/listings/ch21-web-server/listing-21-10/src/main.rs
+++ b/listings/ch21-web-server/listing-21-10/src/main.rs
@@ -28,7 +28,7 @@ fn handle_connection(mut stream: TcpStream) {
     let request_line = buf_reader.lines().next().unwrap().unwrap();
 
     // ANCHOR: here
-    let (status_line, filename) = match &request_line[..] {
+    let (status_line, filename) = match request_line.as_str() {
         "GET / HTTP/1.1" => ("HTTP/1.1 200 OK", "hello.html"),
         "GET /sleep HTTP/1.1" => {
             thread::sleep(Duration::from_secs(5));


### PR DESCRIPTION
Update the method call in the match statement in Chapter 21 from taking a slice and referencing it to using the `as_str` method introduced in **Rust 1.7.0**