### PR TITLE
Temporarily remove the link to `Drop::drop`

### DIFF
--- a/src/ch04-01-what-is-ownership.md
+++ b/src/ch04-01-what-is-ownership.md
@@ -219,7 +219,7 @@ from Listing 4-1 using a `String` instead of a string literal:
 There is a natural point at which we can return the memory our `String` needs
 to the allocator: when `s` goes out of scope. When a variable goes out of
 scope, Rust calls a special function for us. This function is called
-[`drop`][drop]<!-- ignore -->, and it’s where the author of `String` can put
+`drop`, and it’s where the author of `String` can put
 the code to return the memory. Rust calls `drop` automatically at the closing
 curly bracket.
 
@@ -520,4 +520,3 @@ transferring ownership: references.
 [derivable-traits]: appendix-03-derivable-traits.html
 [methods]: ch05-03-method-syntax.html#methods
 [paths-module-tree]: ch07-03-paths-for-referring-to-an-item-in-the-module-tree.html
-[drop]: ../std/ops/trait.Drop.html#tymethod.drop


### PR DESCRIPTION
See [rust#144537](https://github.com/rust-lang/rust/pull/144537), `tymethod.drop` doesn't work for `Drop::drop` because `Drop::pin_drop` is added.