### PR TITLE
Clarify that feature flags can't be used by default on stable/beta

### DIFF
--- a/src/appendix-07-nightly-rust.md
+++ b/src/appendix-07-nightly-rust.md
@@ -131,10 +131,10 @@ using a nightly release of Rust and annotate your source code with the
 appropriate flag to opt in.
 
 If you’re using a beta or stable release of Rust, you can’t use any feature
-flags. This is the key that allows us to get practical use with new features
-before we declare them stable forever. Those who wish to opt into the bleeding
-edge can do so, and those who want a rock-solid experience can stick with
-stable and know that their code won’t break. Stability without stagnation.
+flags by default. This is the key that allows us to get practical use with new
+features before we declare them stable forever. Those who wish to opt into the
+bleeding edge can do so, and those who want a rock-solid experience can stick
+with stable and know that their code won’t break. Stability without stagnation.
 
 This book only contains information about stable features, as in-progress
 features are still changing, and surely they’ll be different between when this


### PR DESCRIPTION
The current statement that feature flags "can't be used" on stable/beta is technically inaccurate. This PR adds "by default" to make it accurate while keeping the content appropriate for beginners.

discussed: https://github.com/rust-lang/rustc-dev-guide/pull/2655#issuecomment-3573819507

cc @tshepang