### PR TITLE
Synchronize TrplNote name

### DIFF
--- a/packages/mdbook-trpl/src/note/mod.rs
+++ b/packages/mdbook-trpl/src/note/mod.rs
@@ -30,7 +30,7 @@ pub struct TrplNote;
 
 impl Preprocessor for TrplNote {
     fn name(&self) -> &str {
-        "simple-note-preprocessor"
+        "trpl-note"
     }
 
     fn run(&self, _ctx: &PreprocessorContext, mut book: Book) -> Result<Book> {


### PR DESCRIPTION
This changes the name of the `TrplNote` mdbook preprocessor so that it matches the name used in `book.toml`. The reason this needs to be in sync is that in upstream we use `MDBook::with_preprocessor` to replace the preprocessor, but unfortunately it grabs the name from the preprocessor itself. If these are out of sync, it ends up not being able to replace the old preprocessor config. The API in mdbook should probably be better to make it easier to manage the config. For now, this is probably the easiest fix.