### PR TITLE
Update ch13-02-iterators.md: Clarify that consuming iterator methods do not consume the underlying collection.

### DIFF
--- a/src/ch13-02-iterators.md
+++ b/src/ch13-02-iterators.md
@@ -129,6 +129,11 @@ test illustrating a use of the `sum` method.
 We aren’t allowed to use `v1_iter` after the call to `sum`, because `sum` takes
 ownership of the iterator we call it on.
 
+Note that calling `sum` consumes the iterator, not the collection it was created from. 
+Because `v1_iter` was created by calling `iter`, it only borrows `v1`. 
+As a result, although `v1_iter` is moved into `sum` and can no longer be used afterward, 
+the original vector `v1` remains valid and can still be used after the call to `sum`.
+
 ### Methods That Produce Other Iterators
 
 _Iterator adapters_ are methods defined on the `Iterator` trait that don’t


### PR DESCRIPTION
## Description

This PR adds a small clarification to the Methods That Consume the Iterator section in Chapter 13.

The existing text correctly explains that calling a consuming adapter like sum takes ownership of the iterator and prevents it from being used afterward. However, it does not explicitly state that the underlying collection remains valid when the iterator was created using `iter()`.

This omission can lead readers to incorrectly infer that calling sum also invalidates the original collection. The added paragraph clarifies that:

`v1_iter` borrows `v1`

`sum` consumes the iterator, not the vector

`v1` remains usable after the call to `sum`

A short sentence is added immediately after the existing explanation to make this distinction explicit, without introducing new concepts or changing the structure of the section.

## Scope

- Changes are limited to the src directory
- No changes to nostarch
- No formatting changes beyond the edited paragraph

## Notes

I understand that non-error changes may be deferred to a larger revision. This PR is submitted in case the clarification is considered a small correctness improvement appropriate to include earlier.

Thank you for your time and for maintaining the book.