### PR TITLE
Clarified comment for ch04 code example

### DIFF
--- a/listings/ch04-understanding-ownership/listing-04-03/src/main.rs
+++ b/listings/ch04-understanding-ownership/listing-04-03/src/main.rs
@@ -2,7 +2,7 @@ fn main() {
     let s = String::from("hello");  // s comes into scope
 
     takes_ownership(s);             // s's value moves into the function...
-                                    // ... and so is no longer valid here
+                                    // ... so s is no longer valid here
 
     let x = 5;                      // x comes into scope
 


### PR DESCRIPTION
I thought, *"and so is no longer valid here"* was a bit confusing; although redundant, I figured mentioning **s** again cleared it up.