### PR TITLE
[ch00-00] Clean: Remove duplicate sentence

### DIFF
--- a/src/ch00-00-introduction.md
+++ b/src/ch00-00-introduction.md
@@ -180,8 +180,7 @@ As such, we’ll provide many examples that don’t compile along with the error
 message the compiler will show you in each situation. Know that if you enter
 and run a random example, it may not compile! Make sure you read the
 surrounding text to see whether the example you’re trying to run is meant to
-error. In most situations, we’ll lead you to the correct version of any code
-that doesn’t compile. Ferris will also help you distinguish code that isn’t
+error. Ferris will also help you distinguish code that isn’t
 meant to work:
 
 | Ferris                                                                                                           | Meaning                                          |


### PR DESCRIPTION
This exact sentence appears right below the Ferris graphic. It feels like it fits better below there so removing the one above it.