### PR TITLE
ch00-00-introduction.md: copy edit topic revisiting

### DIFF
--- a/src/ch00-00-introduction.md
+++ b/src/ch00-00-introduction.md
@@ -98,8 +98,8 @@ programming.
 
 In general, this book assumes that you’re reading it in sequence from front to
 back. Later chapters build on concepts in earlier chapters, and earlier
-chapters might not delve into details on a particular topic but will revisit
-the topic in a later chapter.
+chapters might not delve into details on a particular topic that are covered
+in a later chapter.
 
 You’ll find two kinds of chapters in this book: concept chapters and project
 chapters. In concept chapters, you’ll learn about an aspect of Rust. In project


### PR DESCRIPTION
Saying that "earlier chapters might not delve into details on a particular topic but will revisit the topic in a later chapter" can be confusing, since the earlier chapters are not revisiting the topic, but rather the book overall is. Instead, indicate that a later chapter covers those details.