### PR TITLE
Fix include directive in ch05-02-example-structs.md

### DIFF
--- a/src/ch05-02-example-structs.md
+++ b/src/ch05-02-example-structs.md
@@ -154,13 +154,13 @@ we can see its value while we’re debugging our code.
 Compile the code with this change. Drat! We still get an error:
 
 ```text
-{{#include ../listings/ch05-using-structs-to-structure-related-data/output-only-01-debug/output.txt:3}}
+{{#include ../listings/ch05-using-structs-to-structure-related-data/output-only-01-debug/output.txt:7}}
 ```
 
 But again, the compiler gives us a helpful note:
 
 ```text
-{{#include ../listings/ch05-using-structs-to-structure-related-data/output-only-01-debug/output.txt:9:10}}
+{{#include ../listings/ch05-using-structs-to-structure-related-data/output-only-01-debug/output.txt:12}}
 ```
 
 Rust _does_ include functionality to print out debugging information, but we

--- a/src/ch05-02-example-structs.md
+++ b/src/ch05-02-example-structs.md
@@ -142,7 +142,7 @@ implementation of `Display` to use with `println!` and the `{}` placeholder.
 If we continue reading the errors, we’ll find this helpful note:
 
 ```text
-{{#include ../listings/ch05-using-structs-to-structure-related-data/listing-05-11/output.txt:9:10}}
+{{#include ../listings/ch05-using-structs-to-structure-related-data/listing-05-11/output.txt:13}}
 ```
 
 Let’s try it! The `println!` macro call will now look like `println!("rect1 is


### PR DESCRIPTION
Updated include directive to reference correct output range.

Fix for #4640