### PR TITLE
Propagate code update from listing 21-23 and onwards into final code

### DIFF
--- a/listings/ch21-web-server/no-listing-07-final-code/src/lib.rs
+++ b/listings/ch21-web-server/no-listing-07-final-code/src/lib.rs
@@ -51,19 +51,17 @@ impl Drop for ThreadPool {
     fn drop(&mut self) {
         drop(self.sender.take());
 
-        for worker in &mut self.workers {
+        for worker in self.workers.drain(..) {
             println!("Shutting down worker {}", worker.id);
 
-            if let Some(thread) = worker.thread.take() {
-                thread.join().unwrap();
-            }
+            worker.thread.join().unwrap();
         }
     }
 }
 
 struct Worker {
     id: usize,
-    thread: Option<thread::JoinHandle<()>>,
+    thread: thread::JoinHandle<()>,
 }
 
 impl Worker {
@@ -86,9 +84,6 @@ impl Worker {
             }
         });
 
-        Worker {
-            id,
-            thread: Some(thread),
-        }
+        Worker { id, thread }
     }
 }


### PR DESCRIPTION
Fix inconsistency in final code with `no-listing-04-update-drop-definition` presenting `Vec::drain` method (and propagated to listing `21-23`, `21-24`, and `21-25`) (closes #4642).

Final code is same as listing 21-25 (the last listing presented).