### PR TITLE
Do not assume specific fonts in SVG images

### DIFF
--- a/src/img/trpl04-01.svg
+++ b/src/img/trpl04-01.svg
@@ -13,50 +13,50 @@
 <g id="node1" class="node">
 <title>table0</title>
 <polyline fill="none" stroke="#000000" points="8,-124 96,-124 "/>
-<text text-anchor="start" x="45.7759" y="-129.8" font-family="Times,serif" font-size="14.00" fill="#000000">s1</text>
+<text text-anchor="start" x="45.7759" y="-129.8" font-family="serif" font-size="14.00" fill="#000000">s1</text>
 <polygon fill="none" stroke="#000000" points="8,-104 8,-124 60,-124 60,-104 8,-104"/>
-<text text-anchor="start" x="18.8413" y="-109.8" font-family="Times,serif" font-size="14.00" fill="#000000">name</text>
+<text text-anchor="start" x="18.8413" y="-109.8" font-family="serif" font-size="14.00" fill="#000000">name</text>
 <polygon fill="none" stroke="#000000" points="60,-104 60,-124 96,-124 96,-104 60,-104"/>
-<text text-anchor="start" x="62.8413" y="-109.8" font-family="Times,serif" font-size="14.00" fill="#000000">value</text>
+<text text-anchor="start" x="62.8413" y="-109.8" font-family="serif" font-size="14.00" fill="#000000">value</text>
 <polygon fill="none" stroke="#000000" points="8,-84 8,-104 60,-104 60,-84 8,-84"/>
-<text text-anchor="start" x="26.2241" y="-89.8" font-family="Times,serif" font-size="14.00" fill="#000000">ptr</text>
+<text text-anchor="start" x="26.2241" y="-89.8" font-family="serif" font-size="14.00" fill="#000000">ptr</text>
 <polygon fill="none" stroke="#000000" points="60,-84 60,-104 96,-104 96,-84 60,-84"/>
 <polygon fill="none" stroke="#000000" points="8,-64 8,-84 60,-84 60,-64 8,-64"/>
-<text text-anchor="start" x="25.4482" y="-69.8" font-family="Times,serif" font-size="14.00" fill="#000000">len</text>
+<text text-anchor="start" x="25.4482" y="-69.8" font-family="serif" font-size="14.00" fill="#000000">len</text>
 <polygon fill="none" stroke="#000000" points="60,-64 60,-84 96,-84 96,-64 60,-64"/>
-<text text-anchor="start" x="74.5" y="-69.8" font-family="Times,serif" font-size="14.00" fill="#000000">5</text>
+<text text-anchor="start" x="74.5" y="-69.8" font-family="serif" font-size="14.00" fill="#000000">5</text>
 <polygon fill="none" stroke="#000000" points="8,-44 8,-64 60,-64 60,-44 8,-44"/>
-<text text-anchor="start" x="10.6826" y="-49.8" font-family="Times,serif" font-size="14.00" fill="#000000">capacity</text>
+<text text-anchor="start" x="10.6826" y="-49.8" font-family="serif" font-size="14.00" fill="#000000">capacity</text>
 <polygon fill="none" stroke="#000000" points="60,-44 60,-64 96,-64 96,-44 60,-44"/>
-<text text-anchor="start" x="74.5" y="-49.8" font-family="Times,serif" font-size="14.00" fill="#000000">5</text>
+<text text-anchor="start" x="74.5" y="-49.8" font-family="serif" font-size="14.00" fill="#000000">5</text>
 </g>
 <!-- table1 -->
 <g id="node2" class="node">
 <title>table1</title>
 <polygon fill="none" stroke="#000000" points="148.5,-104 148.5,-124 185.5,-124 185.5,-104 148.5,-104"/>
-<text text-anchor="start" x="151.4482" y="-109.8" font-family="Times,serif" font-size="14.00" fill="#000000">index</text>
+<text text-anchor="start" x="151.4482" y="-109.8" font-family="serif" font-size="14.00" fill="#000000">index</text>
 <polygon fill="none" stroke="#000000" points="185.5,-104 185.5,-124 221.5,-124 221.5,-104 185.5,-104"/>
-<text text-anchor="start" x="188.3413" y="-109.8" font-family="Times,serif" font-size="14.00" fill="#000000">value</text>
+<text text-anchor="start" x="188.3413" y="-109.8" font-family="serif" font-size="14.00" fill="#000000">value</text>
 <polygon fill="none" stroke="#000000" points="148.5,-84 148.5,-104 185.5,-104 185.5,-84 148.5,-84"/>
-<text text-anchor="start" x="163.5" y="-89.8" font-family="Times,serif" font-size="14.00" fill="#000000">0</text>
+<text text-anchor="start" x="163.5" y="-89.8" font-family="serif" font-size="14.00" fill="#000000">0</text>
 <polygon fill="none" stroke="#000000" points="185.5,-84 185.5,-104 221.5,-104 221.5,-84 185.5,-84"/>
-<text text-anchor="start" x="200" y="-89.8" font-family="Times,serif" font-size="14.00" fill="#000000">h</text>
+<text text-anchor="start" x="200" y="-89.8" font-family="serif" font-size="14.00" fill="#000000">h</text>
 <polygon fill="none" stroke="#000000" points="148.5,-64 148.5,-84 185.5,-84 185.5,-64 148.5,-64"/>
-<text text-anchor="start" x="163.5" y="-69.8" font-family="Times,serif" font-size="14.00" fill="#000000">1</text>
+<text text-anchor="start" x="163.5" y="-69.8" font-family="serif" font-size="14.00" fill="#000000">1</text>
 <polygon fill="none" stroke="#000000" points="185.5,-64 185.5,-84 221.5,-84 221.5,-64 185.5,-64"/>
-<text text-anchor="start" x="200.3931" y="-69.8" font-family="Times,serif" font-size="14.00" fill="#000000">e</text>
+<text text-anchor="start" x="200.3931" y="-69.8" font-family="serif" font-size="14.00" fill="#000000">e</text>
 <polygon fill="none" stroke="#000000" points="148.5,-44 148.5,-64 185.5,-64 185.5,-44 148.5,-44"/>
-<text text-anchor="start" x="163.5" y="-49.8" font-family="Times,serif" font-size="14.00" fill="#000000">2</text>
+<text text-anchor="start" x="163.5" y="-49.8" font-family="serif" font-size="14.00" fill="#000000">2</text>
 <polygon fill="none" stroke="#000000" points="185.5,-44 185.5,-64 221.5,-64 221.5,-44 185.5,-44"/>
-<text text-anchor="start" x="201.5552" y="-49.8" font-family="Times,serif" font-size="14.00" fill="#000000">l</text>
+<text text-anchor="start" x="201.5552" y="-49.8" font-family="serif" font-size="14.00" fill="#000000">l</text>
 <polygon fill="none" stroke="#000000" points="148.5,-24 148.5,-44 185.5,-44 185.5,-24 148.5,-24"/>
-<text text-anchor="start" x="163.5" y="-29.8" font-family="Times,serif" font-size="14.00" fill="#000000">3</text>
+<text text-anchor="start" x="163.5" y="-29.8" font-family="serif" font-size="14.00" fill="#000000">3</text>
 <polygon fill="none" stroke="#000000" points="185.5,-24 185.5,-44 221.5,-44 221.5,-24 185.5,-24"/>
-<text text-anchor="start" x="201.5552" y="-29.8" font-family="Times,serif" font-size="14.00" fill="#000000">l</text>
+<text text-anchor="start" x="201.5552" y="-29.8" font-family="serif" font-size="14.00" fill="#000000">l</text>
 <polygon fill="none" stroke="#000000" points="148.5,-4 148.5,-24 185.5,-24 185.5,-4 148.5,-4"/>
-<text text-anchor="start" x="163.5" y="-9.8" font-family="Times,serif" font-size="14.00" fill="#000000">4</text>
+<text text-anchor="start" x="163.5" y="-9.8" font-family="serif" font-size="14.00" fill="#000000">4</text>
 <polygon fill="none" stroke="#000000" points="185.5,-4 185.5,-24 221.5,-24 221.5,-4 185.5,-4"/>
-<text text-anchor="start" x="200" y="-9.8" font-family="Times,serif" font-size="14.00" fill="#000000">o</text>
+<text text-anchor="start" x="200" y="-9.8" font-family="serif" font-size="14.00" fill="#000000">o</text>
 </g>
 <!-- table0&#45;&gt;table1 -->
 <g id="edge1" class="edge">

--- a/src/img/trpl04-02.svg
+++ b/src/img/trpl04-02.svg
@@ -13,50 +13,50 @@
 <g id="node1" class="node">
 <title>table0</title>
 <polyline fill="none" stroke="#000000" points="8,-210 96,-210 "/>
-<text text-anchor="start" x="45.7759" y="-215.8" font-family="Times,serif" font-size="14.00" fill="#000000">s1</text>
+<text text-anchor="start" x="45.7759" y="-215.8" font-family="serif" font-size="14.00" fill="#000000">s1</text>
 <polygon fill="none" stroke="#000000" points="8,-190 8,-210 60,-210 60,-190 8,-190"/>
-<text text-anchor="start" x="18.8413" y="-195.8" font-family="Times,serif" font-size="14.00" fill="#000000">name</text>
+<text text-anchor="start" x="18.8413" y="-195.8" font-family="serif" font-size="14.00" fill="#000000">name</text>
 <polygon fill="none" stroke="#000000" points="60,-190 60,-210 96,-210 96,-190 60,-190"/>
-<text text-anchor="start" x="62.8413" y="-195.8" font-family="Times,serif" font-size="14.00" fill="#000000">value</text>
+<text text-anchor="start" x="62.8413" y="-195.8" font-family="serif" font-size="14.00" fill="#000000">value</text>
 <polygon fill="none" stroke="#000000" points="8,-170 8,-190 60,-190 60,-170 8,-170"/>
-<text text-anchor="start" x="26.2241" y="-175.8" font-family="Times,serif" font-size="14.00" fill="#000000">ptr</text>
+<text text-anchor="start" x="26.2241" y="-175.8" font-family="serif" font-size="14.00" fill="#000000">ptr</text>
 <polygon fill="none" stroke="#000000" points="60,-170 60,-190 96,-190 96,-170 60,-170"/>
 <polygon fill="none" stroke="#000000" points="8,-150 8,-170 60,-170 60,-150 8,-150"/>
-<text text-anchor="start" x="25.4482" y="-155.8" font-family="Times,serif" font-size="14.00" fill="#000000">len</text>
+<text text-anchor="start" x="25.4482" y="-155.8" font-family="serif" font-size="14.00" fill="#000000">len</text>
 <polygon fill="none" stroke="#000000" points="60,-150 60,-170 96,-170 96,-150 60,-150"/>
-<text text-anchor="start" x="74.5" y="-155.8" font-family="Times,serif" font-size="14.00" fill="#000000">5</text>
+<text text-anchor="start" x="74.5" y="-155.8" font-family="serif" font-size="14.00" fill="#000000">5</text>
 <polygon fill="none" stroke="#000000" points="8,-130 8,-150 60,-150 60,-130 8,-130"/>
-<text text-anchor="start" x="10.6826" y="-135.8" font-family="Times,serif" font-size="14.00" fill="#000000">capacity</text>
+<text text-anchor="start" x="10.6826" y="-135.8" font-family="serif" font-size="14.00" fill="#000000">capacity</text>
 <polygon fill="none" stroke="#000000" points="60,-130 60,-150 96,-150 96,-130 60,-130"/>
-<text text-anchor="start" x="74.5" y="-135.8" font-family="Times,serif" font-size="14.00" fill="#000000">5</text>
+<text text-anchor="start" x="74.5" y="-135.8" font-family="serif" font-size="14.00" fill="#000000">5</text>
 </g>
 <!-- table1 -->
 <g id="node3" class="node">
 <title>table1</title>
 <polygon fill="none" stroke="#000000" points="148.5,-127 148.5,-147 185.5,-147 185.5,-127 148.5,-127"/>
-<text text-anchor="start" x="151.4482" y="-132.8" font-family="Times,serif" font-size="14.00" fill="#000000">index</text>
+<text text-anchor="start" x="151.4482" y="-132.8" font-family="serif" font-size="14.00" fill="#000000">index</text>
 <polygon fill="none" stroke="#000000" points="185.5,-127 185.5,-147 221.5,-147 221.5,-127 185.5,-127"/>
-<text text-anchor="start" x="188.3413" y="-132.8" font-family="Times,serif" font-size="14.00" fill="#000000">value</text>
+<text text-anchor="start" x="188.3413" y="-132.8" font-family="serif" font-size="14.00" fill="#000000">value</text>
 <polygon fill="none" stroke="#000000" points="148.5,-107 148.5,-127 185.5,-127 185.5,-107 148.5,-107"/>
-<text text-anchor="start" x="163.5" y="-112.8" font-family="Times,serif" font-size="14.00" fill="#000000">0</text>
+<text text-anchor="start" x="163.5" y="-112.8" font-family="serif" font-size="14.00" fill="#000000">0</text>
 <polygon fill="none" stroke="#000000" points="185.5,-107 185.5,-127 221.5,-127 221.5,-107 185.5,-107"/>
-<text text-anchor="start" x="200" y="-112.8" font-family="Times,serif" font-size="14.00" fill="#000000">h</text>
+<text text-anchor="start" x="200" y="-112.8" font-family="serif" font-size="14.00" fill="#000000">h</text>
 <polygon fill="none" stroke="#000000" points="148.5,-87 148.5,-107 185.5,-107 185.5,-87 148.5,-87"/>
-<text text-anchor="start" x="163.5" y="-92.8" font-family="Times,serif" font-size="14.00" fill="#000000">1</text>
+<text text-anchor="start" x="163.5" y="-92.8" font-family="serif" font-size="14.00" fill="#000000">1</text>
 <polygon fill="none" stroke="#000000" points="185.5,-87 185.5,-107 221.5,-107 221.5,-87 185.5,-87"/>
-<text text-anchor="start" x="200.3931" y="-92.8" font-family="Times,serif" font-size="14.00" fill="#000000">e</text>
+<text text-anchor="start" x="200.3931" y="-92.8" font-family="serif" font-size="14.00" fill="#000000">e</text>
 <polygon fill="none" stroke="#000000" points="148.5,-67 148.5,-87 185.5,-87 185.5,-67 148.5,-67"/>
-<text text-anchor="start" x="163.5" y="-72.8" font-family="Times,serif" font-size="14.00" fill="#000000">2</text>
+<text text-anchor="start" x="163.5" y="-72.8" font-family="serif" font-size="14.00" fill="#000000">2</text>
 <polygon fill="none" stroke="#000000" points="185.5,-67 185.5,-87 221.5,-87 221.5,-67 185.5,-67"/>
-<text text-anchor="start" x="201.5552" y="-72.8" font-family="Times,serif" font-size="14.00" fill="#000000">l</text>
+<text text-anchor="start" x="201.5552" y="-72.8" font-family="serif" font-size="14.00" fill="#000000">l</text>
 <polygon fill="none" stroke="#000000" points="148.5,-47 148.5,-67 185.5,-67 185.5,-47 148.5,-47"/>
-<text text-anchor="start" x="163.5" y="-52.8" font-family="Times,serif" font-size="14.00" fill="#000000">3</text>
+<text text-anchor="start" x="163.5" y="-52.8" font-family="serif" font-size="14.00" fill="#000000">3</text>
 <polygon fill="none" stroke="#000000" points="185.5,-47 185.5,-67 221.5,-67 221.5,-47 185.5,-47"/>
-<text text-anchor="start" x="201.5552" y="-52.8" font-family="Times,serif" font-size="14.00" fill="#000000">l</text>
+<text text-anchor="start" x="201.5552" y="-52.8" font-family="serif" font-size="14.00" fill="#000000">l</text>
 <polygon fill="none" stroke="#000000" points="148.5,-27 148.5,-47 185.5,-47 185.5,-27 148.5,-27"/>
-<text text-anchor="start" x="163.5" y="-32.8" font-family="Times,serif" font-size="14.00" fill="#000000">4</text>
+<text text-anchor="start" x="163.5" y="-32.8" font-family="serif" font-size="14.00" fill="#000000">4</text>
 <polygon fill="none" stroke="#000000" points="185.5,-27 185.5,-47 221.5,-47 221.5,-27 185.5,-27"/>
-<text text-anchor="start" x="200" y="-32.8" font-family="Times,serif" font-size="14.00" fill="#000000">o</text>
+<text text-anchor="start" x="200" y="-32.8" font-family="serif" font-size="14.00" fill="#000000">o</text>
 </g>
 <!-- table0&#45;&gt;table1 -->
 <g id="edge1" class="edge">
@@ -68,22 +68,22 @@
 <g id="node2" class="node">
 <title>table3</title>
 <polyline fill="none" stroke="#000000" points="8,-84 96,-84 "/>
-<text text-anchor="start" x="45.7759" y="-89.8" font-family="Times,serif" font-size="14.00" fill="#000000">s2</text>
+<text text-anchor="start" x="45.7759" y="-89.8" font-family="serif" font-size="14.00" fill="#000000">s2</text>
 <polygon fill="none" stroke="#000000" points="8,-64 8,-84 60,-84 60,-64 8,-64"/>
-<text text-anchor="start" x="18.8413" y="-69.8" font-family="Times,serif" font-size="14.00" fill="#000000">name</text>
+<text text-anchor="start" x="18.8413" y="-69.8" font-family="serif" font-size="14.00" fill="#000000">name</text>
 <polygon fill="none" stroke="#000000" points="60,-64 60,-84 96,-84 96,-64 60,-64"/>
-<text text-anchor="start" x="62.8413" y="-69.8" font-family="Times,serif" font-size="14.00" fill="#000000">value</text>
+<text text-anchor="start" x="62.8413" y="-69.8" font-family="serif" font-size="14.00" fill="#000000">value</text>
 <polygon fill="none" stroke="#000000" points="8,-44 8,-64 60,-64 60,-44 8,-44"/>
-<text text-anchor="start" x="26.2241" y="-49.8" font-family="Times,serif" font-size="14.00" fill="#000000">ptr</text>
+<text text-anchor="start" x="26.2241" y="-49.8" font-family="serif" font-size="14.00" fill="#000000">ptr</text>
 <polygon fill="none" stroke="#000000" points="60,-44 60,-64 96,-64 96,-44 60,-44"/>
 <polygon fill="none" stroke="#000000" points="8,-24 8,-44 60,-44 60,-24 8,-24"/>
-<text text-anchor="start" x="25.4482" y="-29.8" font-family="Times,serif" font-size="14.00" fill="#000000">len</text>
+<text text-anchor="start" x="25.4482" y="-29.8" font-family="serif" font-size="14.00" fill="#000000">len</text>
 <polygon fill="none" stroke="#000000" points="60,-24 60,-44 96,-44 96,-24 60,-24"/>
-<text text-anchor="start" x="74.5" y="-29.8" font-family="Times,serif" font-size="14.00" fill="#000000">5</text>
+<text text-anchor="start" x="74.5" y="-29.8" font-family="serif" font-size="14.00" fill="#000000">5</text>
 <polygon fill="none" stroke="#000000" points="8,-4 8,-24 60,-24 60,-4 8,-4"/>
-<text text-anchor="start" x="10.6826" y="-9.8" font-family="Times,serif" font-size="14.00" fill="#000000">capacity</text>
+<text text-anchor="start" x="10.6826" y="-9.8" font-family="serif" font-size="14.00" fill="#000000">capacity</text>
 <polygon fill="none" stroke="#000000" points="60,-4 60,-24 96,-24 96,-4 60,-4"/>
-<text text-anchor="start" x="74.5" y="-9.8" font-family="Times,serif" font-size="14.00" fill="#000000">5</text>
+<text text-anchor="start" x="74.5" y="-9.8" font-family="serif" font-size="14.00" fill="#000000">5</text>
 </g>
 <!-- table3&#45;&gt;table1 -->
 <g id="edge2" class="edge">

--- a/src/img/trpl04-03.svg
+++ b/src/img/trpl04-03.svg
@@ -13,50 +13,50 @@
 <g id="node1" class="node">
 <title>table0</title>
 <polyline fill="none" stroke="#000000" points="8,-124 96,-124 "/>
-<text text-anchor="start" x="45.7759" y="-129.8" font-family="Times,serif" font-size="14.00" fill="#000000">s2</text>
+<text text-anchor="start" x="45.7759" y="-129.8" font-family="serif" font-size="14.00" fill="#000000">s2</text>
 <polygon fill="none" stroke="#000000" points="8,-104 8,-124 60,-124 60,-104 8,-104"/>
-<text text-anchor="start" x="18.8413" y="-109.8" font-family="Times,serif" font-size="14.00" fill="#000000">name</text>
+<text text-anchor="start" x="18.8413" y="-109.8" font-family="serif" font-size="14.00" fill="#000000">name</text>
 <polygon fill="none" stroke="#000000" points="60,-104 60,-124 96,-124 96,-104 60,-104"/>
-<text text-anchor="start" x="62.8413" y="-109.8" font-family="Times,serif" font-size="14.00" fill="#000000">value</text>
+<text text-anchor="start" x="62.8413" y="-109.8" font-family="serif" font-size="14.00" fill="#000000">value</text>
 <polygon fill="none" stroke="#000000" points="8,-84 8,-104 60,-104 60,-84 8,-84"/>
-<text text-anchor="start" x="26.2241" y="-89.8" font-family="Times,serif" font-size="14.00" fill="#000000">ptr</text>
+<text text-anchor="start" x="26.2241" y="-89.8" font-family="serif" font-size="14.00" fill="#000000">ptr</text>
 <polygon fill="none" stroke="#000000" points="60,-84 60,-104 96,-104 96,-84 60,-84"/>
 <polygon fill="none" stroke="#000000" points="8,-64 8,-84 60,-84 60,-64 8,-64"/>
-<text text-anchor="start" x="25.4482" y="-69.8" font-family="Times,serif" font-size="14.00" fill="#000000">len</text>
+<text text-anchor="start" x="25.4482" y="-69.8" font-family="serif" font-size="14.00" fill="#000000">len</text>
 <polygon fill="none" stroke="#000000" points="60,-64 60,-84 96,-84 96,-64 60,-64"/>
-<text text-anchor="start" x="74.5" y="-69.8" font-family="Times,serif" font-size="14.00" fill="#000000">5</text>
+<text text-anchor="start" x="74.5" y="-69.8" font-family="serif" font-size="14.00" fill="#000000">5</text>
 <polygon fill="none" stroke="#000000" points="8,-44 8,-64 60,-64 60,-44 8,-44"/>
-<text text-anchor="start" x="10.6826" y="-49.8" font-family="Times,serif" font-size="14.00" fill="#000000">capacity</text>
+<text text-anchor="start" x="10.6826" y="-49.8" font-family="serif" font-size="14.00" fill="#000000">capacity</text>
 <polygon fill="none" stroke="#000000" points="60,-44 60,-64 96,-64 96,-44 60,-44"/>
-<text text-anchor="start" x="74.5" y="-49.8" font-family="Times,serif" font-size="14.00" fill="#000000">5</text>
+<text text-anchor="start" x="74.5" y="-49.8" font-family="serif" font-size="14.00" fill="#000000">5</text>
 </g>
 <!-- table1 -->
 <g id="node2" class="node">
 <title>table1</title>
 <polygon fill="none" stroke="#000000" points="148.5,-104 148.5,-124 185.5,-124 185.5,-104 148.5,-104"/>
-<text text-anchor="start" x="151.4482" y="-109.8" font-family="Times,serif" font-size="14.00" fill="#000000">index</text>
+<text text-anchor="start" x="151.4482" y="-109.8" font-family="serif" font-size="14.00" fill="#000000">index</text>
 <polygon fill="none" stroke="#000000" points="185.5,-104 185.5,-124 221.5,-124 221.5,-104 185.5,-104"/>
-<text text-anchor="start" x="188.3413" y="-109.8" font-family="Times,serif" font-size="14.00" fill="#000000">value</text>
+<text text-anchor="start" x="188.3413" y="-109.8" font-family="serif" font-size="14.00" fill="#000000">value</text>
 <polygon fill="none" stroke="#000000" points="148.5,-84 148.5,-104 185.5,-104 185.5,-84 148.5,-84"/>
-<text text-anchor="start" x="163.5" y="-89.8" font-family="Times,serif" font-size="14.00" fill="#000000">0</text>
+<text text-anchor="start" x="163.5" y="-89.8" font-family="serif" font-size="14.00" fill="#000000">0</text>
 <polygon fill="none" stroke="#000000" points="185.5,-84 185.5,-104 221.5,-104 221.5,-84 185.5,-84"/>
-<text text-anchor="start" x="200" y="-89.8" font-family="Times,serif" font-size="14.00" fill="#000000">h</text>
+<text text-anchor="start" x="200" y="-89.8" font-family="serif" font-size="14.00" fill="#000000">h</text>
 <polygon fill="none" stroke="#000000" points="148.5,-64 148.5,-84 185.5,-84 185.5,-64 148.5,-64"/>
-<text text-anchor="start" x="163.5" y="-69.8" font-family="Times,serif" font-size="14.00" fill="#000000">1</text>
+<text text-anchor="start" x="163.5" y="-69.8" font-family="serif" font-size="14.00" fill="#000000">1</text>
 <polygon fill="none" stroke="#000000" points="185.5,-64 185.5,-84 221.5,-84 221.5,-64 185.5,-64"/>
-<text text-anchor="start" x="200.3931" y="-69.8" font-family="Times,serif" font-size="14.00" fill="#000000">e</text>
+<text text-anchor="start" x="200.3931" y="-69.8" font-family="serif" font-size="14.00" fill="#000000">e</text>
 <polygon fill="none" stroke="#000000" points="148.5,-44 148.5,-64 185.5,-64 185.5,-44 148.5,-44"/>
-<text text-anchor="start" x="163.5" y="-49.8" font-family="Times,serif" font-size="14.00" fill="#000000">2</text>
+<text text-anchor="start" x="163.5" y="-49.8" font-family="serif" font-size="14.00" fill="#000000">2</text>
 <polygon fill="none" stroke="#000000" points="185.5,-44 185.5,-64 221.5,-64 221.5,-44 185.5,-44"/>
-<text text-anchor="start" x="201.5552" y="-49.8" font-family="Times,serif" font-size="14.00" fill="#000000">l</text>
+<text text-anchor="start" x="201.5552" y="-49.8" font-family="serif" font-size="14.00" fill="#000000">l</text>
 <polygon fill="none" stroke="#000000" points="148.5,-24 148.5,-44 185.5,-44 185.5,-24 148.5,-24"/>
-<text text-anchor="start" x="163.5" y="-29.8" font-family="Times,serif" font-size="14.00" fill="#000000">3</text>
+<text text-anchor="start" x="163.5" y="-29.8" font-family="serif" font-size="14.00" fill="#000000">3</text>
 <polygon fill="none" stroke="#000000" points="185.5,-24 185.5,-44 221.5,-44 221.5,-24 185.5,-24"/>
-<text text-anchor="start" x="201.5552" y="-29.8" font-family="Times,serif" font-size="14.00" fill="#000000">l</text>
+<text text-anchor="start" x="201.5552" y="-29.8" font-family="serif" font-size="14.00" fill="#000000">l</text>
 <polygon fill="none" stroke="#000000" points="148.5,-4 148.5,-24 185.5,-24 185.5,-4 148.5,-4"/>
-<text text-anchor="start" x="163.5" y="-9.8" font-family="Times,serif" font-size="14.00" fill="#000000">4</text>
+<text text-anchor="start" x="163.5" y="-9.8" font-family="serif" font-size="14.00" fill="#000000">4</text>
 <polygon fill="none" stroke="#000000" points="185.5,-4 185.5,-24 221.5,-24 221.5,-4 185.5,-4"/>
-<text text-anchor="start" x="200" y="-9.8" font-family="Times,serif" font-size="14.00" fill="#000000">o</text>
+<text text-anchor="start" x="200" y="-9.8" font-family="serif" font-size="14.00" fill="#000000">o</text>
 </g>
 <!-- table0&#45;&gt;table1 -->
 <g id="edge1" class="edge">
@@ -68,50 +68,50 @@
 <g id="node3" class="node">
 <title>table3</title>
 <polyline fill="none" stroke="#000000" points="8,-270 96,-270 "/>
-<text text-anchor="start" x="45.7759" y="-275.8" font-family="Times,serif" font-size="14.00" fill="#000000">s1</text>
+<text text-anchor="start" x="45.7759" y="-275.8" font-family="serif" font-size="14.00" fill="#000000">s1</text>
 <polygon fill="none" stroke="#000000" points="8,-250 8,-270 60,-270 60,-250 8,-250"/>
-<text text-anchor="start" x="18.8413" y="-255.8" font-family="Times,serif" font-size="14.00" fill="#000000">name</text>
+<text text-anchor="start" x="18.8413" y="-255.8" font-family="serif" font-size="14.00" fill="#000000">name</text>
 <polygon fill="none" stroke="#000000" points="60,-250 60,-270 96,-270 96,-250 60,-250"/>
-<text text-anchor="start" x="62.8413" y="-255.8" font-family="Times,serif" font-size="14.00" fill="#000000">value</text>
+<text text-anchor="start" x="62.8413" y="-255.8" font-family="serif" font-size="14.00" fill="#000000">value</text>
 <polygon fill="none" stroke="#000000" points="8,-230 8,-250 60,-250 60,-230 8,-230"/>
-<text text-anchor="start" x="26.2241" y="-235.8" font-family="Times,serif" font-size="14.00" fill="#000000">ptr</text>
+<text text-anchor="start" x="26.2241" y="-235.8" font-family="serif" font-size="14.00" fill="#000000">ptr</text>
 <polygon fill="none" stroke="#000000" points="60,-230 60,-250 96,-250 96,-230 60,-230"/>
 <polygon fill="none" stroke="#000000" points="8,-210 8,-230 60,-230 60,-210 8,-210"/>
-<text text-anchor="start" x="25.4482" y="-215.8" font-family="Times,serif" font-size="14.00" fill="#000000">len</text>
+<text text-anchor="start" x="25.4482" y="-215.8" font-family="serif" font-size="14.00" fill="#000000">len</text>
 <polygon fill="none" stroke="#000000" points="60,-210 60,-230 96,-230 96,-210 60,-210"/>
-<text text-anchor="start" x="74.5" y="-215.8" font-family="Times,serif" font-size="14.00" fill="#000000">5</text>
+<text text-anchor="start" x="74.5" y="-215.8" font-family="serif" font-size="14.00" fill="#000000">5</text>
 <polygon fill="none" stroke="#000000" points="8,-190 8,-210 60,-210 60,-190 8,-190"/>
-<text text-anchor="start" x="10.6826" y="-195.8" font-family="Times,serif" font-size="14.00" fill="#000000">capacity</text>
+<text text-anchor="start" x="10.6826" y="-195.8" font-family="serif" font-size="14.00" fill="#000000">capacity</text>
 <polygon fill="none" stroke="#000000" points="60,-190 60,-210 96,-210 96,-190 60,-190"/>
-<text text-anchor="start" x="74.5" y="-195.8" font-family="Times,serif" font-size="14.00" fill="#000000">5</text>
+<text text-anchor="start" x="74.5" y="-195.8" font-family="serif" font-size="14.00" fill="#000000">5</text>
 </g>
 <!-- table4 -->
 <g id="node4" class="node">
 <title>table4</title>
 <polygon fill="none" stroke="#000000" points="148.5,-250 148.5,-270 185.5,-270 185.5,-250 148.5,-250"/>
-<text text-anchor="start" x="151.4482" y="-255.8" font-family="Times,serif" font-size="14.00" fill="#000000">index</text>
+<text text-anchor="start" x="151.4482" y="-255.8" font-family="serif" font-size="14.00" fill="#000000">index</text>
 <polygon fill="none" stroke="#000000" points="185.5,-250 185.5,-270 221.5,-270 221.5,-250 185.5,-250"/>
-<text text-anchor="start" x="188.3413" y="-255.8" font-family="Times,serif" font-size="14.00" fill="#000000">value</text>
+<text text-anchor="start" x="188.3413" y="-255.8" font-family="serif" font-size="14.00" fill="#000000">value</text>
 <polygon fill="none" stroke="#000000" points="148.5,-230 148.5,-250 185.5,-250 185.5,-230 148.5,-230"/>
-<text text-anchor="start" x="163.5" y="-235.8" font-family="Times,serif" font-size="14.00" fill="#000000">0</text>
+<text text-anchor="start" x="163.5" y="-235.8" font-family="serif" font-size="14.00" fill="#000000">0</text>
 <polygon fill="none" stroke="#000000" points="185.5,-230 185.5,-250 221.5,-250 221.5,-230 185.5,-230"/>
-<text text-anchor="start" x="200" y="-235.8" font-family="Times,serif" font-size="14.00" fill="#000000">h</text>
+<text text-anchor="start" x="200" y="-235.8" font-family="serif" font-size="14.00" fill="#000000">h</text>
 <polygon fill="none" stroke="#000000" points="148.5,-210 148.5,-230 185.5,-230 185.5,-210 148.5,-210"/>
-<text text-anchor="start" x="163.5" y="-215.8" font-family="Times,serif" font-size="14.00" fill="#000000">1</text>
+<text text-anchor="start" x="163.5" y="-215.8" font-family="serif" font-size="14.00" fill="#000000">1</text>
 <polygon fill="none" stroke="#000000" points="185.5,-210 185.5,-230 221.5,-230 221.5,-210 185.5,-210"/>
-<text text-anchor="start" x="200.3931" y="-215.8" font-family="Times,serif" font-size="14.00" fill="#000000">e</text>
+<text text-anchor="start" x="200.3931" y="-215.8" font-family="serif" font-size="14.00" fill="#000000">e</text>
 <polygon fill="none" stroke="#000000" points="148.5,-190 148.5,-210 185.5,-210 185.5,-190 148.5,-190"/>
-<text text-anchor="start" x="163.5" y="-195.8" font-family="Times,serif" font-size="14.00" fill="#000000">2</text>
+<text text-anchor="start" x="163.5" y="-195.8" font-family="serif" font-size="14.00" fill="#000000">2</text>
 <polygon fill="none" stroke="#000000" points="185.5,-190 185.5,-210 221.5,-210 221.5,-190 185.5,-190"/>
-<text text-anchor="start" x="201.5552" y="-195.8" font-family="Times,serif" font-size="14.00" fill="#000000">l</text>
+<text text-anchor="start" x="201.5552" y="-195.8" font-family="serif" font-size="14.00" fill="#000000">l</text>
 <polygon fill="none" stroke="#000000" points="148.5,-170 148.5,-190 185.5,-190 185.5,-170 148.5,-170"/>
-<text text-anchor="start" x="163.5" y="-175.8" font-family="Times,serif" font-size="14.00" fill="#000000">3</text>
+<text text-anchor="start" x="163.5" y="-175.8" font-family="serif" font-size="14.00" fill="#000000">3</text>
 <polygon fill="none" stroke="#000000" points="185.5,-170 185.5,-190 221.5,-190 221.5,-170 185.5,-170"/>
-<text text-anchor="start" x="201.5552" y="-175.8" font-family="Times,serif" font-size="14.00" fill="#000000">l</text>
+<text text-anchor="start" x="201.5552" y="-175.8" font-family="serif" font-size="14.00" fill="#000000">l</text>
 <polygon fill="none" stroke="#000000" points="148.5,-150 148.5,-170 185.5,-170 185.5,-150 148.5,-150"/>
-<text text-anchor="start" x="163.5" y="-155.8" font-family="Times,serif" font-size="14.00" fill="#000000">4</text>
+<text text-anchor="start" x="163.5" y="-155.8" font-family="serif" font-size="14.00" fill="#000000">4</text>
 <polygon fill="none" stroke="#000000" points="185.5,-150 185.5,-170 221.5,-170 221.5,-150 185.5,-150"/>
-<text text-anchor="start" x="200" y="-155.8" font-family="Times,serif" font-size="14.00" fill="#000000">o</text>
+<text text-anchor="start" x="200" y="-155.8" font-family="serif" font-size="14.00" fill="#000000">o</text>
 </g>
 <!-- table3&#45;&gt;table4 -->
 <g id="edge2" class="edge">

--- a/src/img/trpl04-04.svg
+++ b/src/img/trpl04-04.svg
@@ -14,50 +14,50 @@
 <title>table0</title>
 <polygon fill="#c0c0c0" stroke="transparent" points="8,-130 8,-230 96,-230 96,-130 8,-130"/>
 <polyline fill="none" stroke="#000000" points="8,-210 96,-210 "/>
-<text text-anchor="start" x="45.7759" y="-215.8" font-family="Times,serif" font-size="14.00" fill="#000000">s1</text>
+<text text-anchor="start" x="45.7759" y="-215.8" font-family="serif" font-size="14.00" fill="#000000">s1</text>
 <polygon fill="none" stroke="#000000" points="8,-190 8,-210 60,-210 60,-190 8,-190"/>
-<text text-anchor="start" x="18.8413" y="-195.8" font-family="Times,serif" font-size="14.00" fill="#000000">name</text>
+<text text-anchor="start" x="18.8413" y="-195.8" font-family="serif" font-size="14.00" fill="#000000">name</text>
 <polygon fill="none" stroke="#000000" points="60,-190 60,-210 96,-210 96,-190 60,-190"/>
-<text text-anchor="start" x="62.8413" y="-195.8" font-family="Times,serif" font-size="14.00" fill="#000000">value</text>
+<text text-anchor="start" x="62.8413" y="-195.8" font-family="serif" font-size="14.00" fill="#000000">value</text>
 <polygon fill="none" stroke="#000000" points="8,-170 8,-190 60,-190 60,-170 8,-170"/>
-<text text-anchor="start" x="26.2241" y="-175.8" font-family="Times,serif" font-size="14.00" fill="#000000">ptr</text>
+<text text-anchor="start" x="26.2241" y="-175.8" font-family="serif" font-size="14.00" fill="#000000">ptr</text>
 <polygon fill="none" stroke="#000000" points="60,-170 60,-190 96,-190 96,-170 60,-170"/>
 <polygon fill="none" stroke="#000000" points="8,-150 8,-170 60,-170 60,-150 8,-150"/>
-<text text-anchor="start" x="25.4482" y="-155.8" font-family="Times,serif" font-size="14.00" fill="#000000">len</text>
+<text text-anchor="start" x="25.4482" y="-155.8" font-family="serif" font-size="14.00" fill="#000000">len</text>
 <polygon fill="none" stroke="#000000" points="60,-150 60,-170 96,-170 96,-150 60,-150"/>
-<text text-anchor="start" x="74.5" y="-155.8" font-family="Times,serif" font-size="14.00" fill="#000000">5</text>
+<text text-anchor="start" x="74.5" y="-155.8" font-family="serif" font-size="14.00" fill="#000000">5</text>
 <polygon fill="none" stroke="#000000" points="8,-130 8,-150 60,-150 60,-130 8,-130"/>
-<text text-anchor="start" x="10.6826" y="-135.8" font-family="Times,serif" font-size="14.00" fill="#000000">capacity</text>
+<text text-anchor="start" x="10.6826" y="-135.8" font-family="serif" font-size="14.00" fill="#000000">capacity</text>
 <polygon fill="none" stroke="#000000" points="60,-130 60,-150 96,-150 96,-130 60,-130"/>
-<text text-anchor="start" x="74.5" y="-135.8" font-family="Times,serif" font-size="14.00" fill="#000000">5</text>
+<text text-anchor="start" x="74.5" y="-135.8" font-family="serif" font-size="14.00" fill="#000000">5</text>
 </g>
 <!-- table1 -->
 <g id="node3" class="node">
 <title>table1</title>
 <polygon fill="none" stroke="#000000" points="148.5,-127 148.5,-147 185.5,-147 185.5,-127 148.5,-127"/>
-<text text-anchor="start" x="151.4482" y="-132.8" font-family="Times,serif" font-size="14.00" fill="#000000">index</text>
+<text text-anchor="start" x="151.4482" y="-132.8" font-family="serif" font-size="14.00" fill="#000000">index</text>
 <polygon fill="none" stroke="#000000" points="185.5,-127 185.5,-147 221.5,-147 221.5,-127 185.5,-127"/>
-<text text-anchor="start" x="188.3413" y="-132.8" font-family="Times,serif" font-size="14.00" fill="#000000">value</text>
+<text text-anchor="start" x="188.3413" y="-132.8" font-family="serif" font-size="14.00" fill="#000000">value</text>
 <polygon fill="none" stroke="#000000" points="148.5,-107 148.5,-127 185.5,-127 185.5,-107 148.5,-107"/>
-<text text-anchor="start" x="163.5" y="-112.8" font-family="Times,serif" font-size="14.00" fill="#000000">0</text>
+<text text-anchor="start" x="163.5" y="-112.8" font-family="serif" font-size="14.00" fill="#000000">0</text>
 <polygon fill="none" stroke="#000000" points="185.5,-107 185.5,-127 221.5,-127 221.5,-107 185.5,-107"/>
-<text text-anchor="start" x="200" y="-112.8" font-family="Times,serif" font-size="14.00" fill="#000000">h</text>
+<text text-anchor="start" x="200" y="-112.8" font-family="serif" font-size="14.00" fill="#000000">h</text>
 <polygon fill="none" stroke="#000000" points="148.5,-87 148.5,-107 185.5,-107 185.5,-87 148.5,-87"/>
-<text text-anchor="start" x="163.5" y="-92.8" font-family="Times,serif" font-size="14.00" fill="#000000">1</text>
+<text text-anchor="start" x="163.5" y="-92.8" font-family="serif" font-size="14.00" fill="#000000">1</text>
 <polygon fill="none" stroke="#000000" points="185.5,-87 185.5,-107 221.5,-107 221.5,-87 185.5,-87"/>
-<text text-anchor="start" x="200.3931" y="-92.8" font-family="Times,serif" font-size="14.00" fill="#000000">e</text>
+<text text-anchor="start" x="200.3931" y="-92.8" font-family="serif" font-size="14.00" fill="#000000">e</text>
 <polygon fill="none" stroke="#000000" points="148.5,-67 148.5,-87 185.5,-87 185.5,-67 148.5,-67"/>
-<text text-anchor="start" x="163.5" y="-72.8" font-family="Times,serif" font-size="14.00" fill="#000000">2</text>
+<text text-anchor="start" x="163.5" y="-72.8" font-family="serif" font-size="14.00" fill="#000000">2</text>
 <polygon fill="none" stroke="#000000" points="185.5,-67 185.5,-87 221.5,-87 221.5,-67 185.5,-67"/>
-<text text-anchor="start" x="201.5552" y="-72.8" font-family="Times,serif" font-size="14.00" fill="#000000">l</text>
+<text text-anchor="start" x="201.5552" y="-72.8" font-family="serif" font-size="14.00" fill="#000000">l</text>
 <polygon fill="none" stroke="#000000" points="148.5,-47 148.5,-67 185.5,-67 185.5,-47 148.5,-47"/>
-<text text-anchor="start" x="163.5" y="-52.8" font-family="Times,serif" font-size="14.00" fill="#000000">3</text>
+<text text-anchor="start" x="163.5" y="-52.8" font-family="serif" font-size="14.00" fill="#000000">3</text>
 <polygon fill="none" stroke="#000000" points="185.5,-47 185.5,-67 221.5,-67 221.5,-47 185.5,-47"/>
-<text text-anchor="start" x="201.5552" y="-52.8" font-family="Times,serif" font-size="14.00" fill="#000000">l</text>
+<text text-anchor="start" x="201.5552" y="-52.8" font-family="serif" font-size="14.00" fill="#000000">l</text>
 <polygon fill="none" stroke="#000000" points="148.5,-27 148.5,-47 185.5,-47 185.5,-27 148.5,-27"/>
-<text text-anchor="start" x="163.5" y="-32.8" font-family="Times,serif" font-size="14.00" fill="#000000">4</text>
+<text text-anchor="start" x="163.5" y="-32.8" font-family="serif" font-size="14.00" fill="#000000">4</text>
 <polygon fill="none" stroke="#000000" points="185.5,-27 185.5,-47 221.5,-47 221.5,-27 185.5,-27"/>
-<text text-anchor="start" x="200" y="-32.8" font-family="Times,serif" font-size="14.00" fill="#000000">o</text>
+<text text-anchor="start" x="200" y="-32.8" font-family="serif" font-size="14.00" fill="#000000">o</text>
 </g>
 <!-- table0&#45;&gt;table1 -->
 <g id="edge1" class="edge">
@@ -69,22 +69,22 @@
 <g id="node2" class="node">
 <title>table3</title>
 <polyline fill="none" stroke="#000000" points="8,-84 96,-84 "/>
-<text text-anchor="start" x="45.7759" y="-89.8" font-family="Times,serif" font-size="14.00" fill="#000000">s2</text>
+<text text-anchor="start" x="45.7759" y="-89.8" font-family="serif" font-size="14.00" fill="#000000">s2</text>
 <polygon fill="none" stroke="#000000" points="8,-64 8,-84 60,-84 60,-64 8,-64"/>
-<text text-anchor="start" x="18.8413" y="-69.8" font-family="Times,serif" font-size="14.00" fill="#000000">name</text>
+<text text-anchor="start" x="18.8413" y="-69.8" font-family="serif" font-size="14.00" fill="#000000">name</text>
 <polygon fill="none" stroke="#000000" points="60,-64 60,-84 96,-84 96,-64 60,-64"/>
-<text text-anchor="start" x="62.8413" y="-69.8" font-family="Times,serif" font-size="14.00" fill="#000000">value</text>
+<text text-anchor="start" x="62.8413" y="-69.8" font-family="serif" font-size="14.00" fill="#000000">value</text>
 <polygon fill="none" stroke="#000000" points="8,-44 8,-64 60,-64 60,-44 8,-44"/>
-<text text-anchor="start" x="26.2241" y="-49.8" font-family="Times,serif" font-size="14.00" fill="#000000">ptr</text>
+<text text-anchor="start" x="26.2241" y="-49.8" font-family="serif" font-size="14.00" fill="#000000">ptr</text>
 <polygon fill="none" stroke="#000000" points="60,-44 60,-64 96,-64 96,-44 60,-44"/>
 <polygon fill="none" stroke="#000000" points="8,-24 8,-44 60,-44 60,-24 8,-24"/>
-<text text-anchor="start" x="25.4482" y="-29.8" font-family="Times,serif" font-size="14.00" fill="#000000">len</text>
+<text text-anchor="start" x="25.4482" y="-29.8" font-family="serif" font-size="14.00" fill="#000000">len</text>
 <polygon fill="none" stroke="#000000" points="60,-24 60,-44 96,-44 96,-24 60,-24"/>
-<text text-anchor="start" x="74.5" y="-29.8" font-family="Times,serif" font-size="14.00" fill="#000000">5</text>
+<text text-anchor="start" x="74.5" y="-29.8" font-family="serif" font-size="14.00" fill="#000000">5</text>
 <polygon fill="none" stroke="#000000" points="8,-4 8,-24 60,-24 60,-4 8,-4"/>
-<text text-anchor="start" x="10.6826" y="-9.8" font-family="Times,serif" font-size="14.00" fill="#000000">capacity</text>
+<text text-anchor="start" x="10.6826" y="-9.8" font-family="serif" font-size="14.00" fill="#000000">capacity</text>
 <polygon fill="none" stroke="#000000" points="60,-4 60,-24 96,-24 96,-4 60,-4"/>
-<text text-anchor="start" x="74.5" y="-9.8" font-family="Times,serif" font-size="14.00" fill="#000000">5</text>
+<text text-anchor="start" x="74.5" y="-9.8" font-family="serif" font-size="14.00" fill="#000000">5</text>
 </g>
 <!-- table3&#45;&gt;table1 -->
 <g id="edge2" class="edge">

--- a/src/img/trpl04-05.svg
+++ b/src/img/trpl04-05.svg
@@ -15,46 +15,46 @@
 <g id="node1" class="node">
 <title>s</title>
 <polyline fill="none" stroke="black" points="8,-288 94,-288"/>
-<text text-anchor="start" x="48.38" y="-293.7" font-family="Times,serif" font-size="14.00">s</text>
+<text text-anchor="start" x="48.38" y="-293.7" font-family="serif" font-size="14.00">s</text>
 <polygon fill="none" stroke="black" points="8,-266 8,-288 59,-288 59,-266 8,-266"/>
-<text text-anchor="start" x="18.5" y="-271.7" font-family="Times,serif" font-size="14.00">name</text>
+<text text-anchor="start" x="18.5" y="-271.7" font-family="serif" font-size="14.00">name</text>
 <polygon fill="none" stroke="black" points="59,-266 59,-288 94,-288 94,-266 59,-266"/>
-<text text-anchor="start" x="61.88" y="-271.7" font-family="Times,serif" font-size="14.00">value</text>
+<text text-anchor="start" x="61.88" y="-271.7" font-family="serif" font-size="14.00">value</text>
 <polygon fill="none" stroke="black" points="8,-244 8,-266 59,-266 59,-244 8,-244"/>
-<text text-anchor="start" x="26" y="-249.7" font-family="Times,serif" font-size="14.00">ptr</text>
+<text text-anchor="start" x="26" y="-249.7" font-family="serif" font-size="14.00">ptr</text>
 <polygon fill="none" stroke="black" points="59,-244 59,-266 94,-266 94,-244 59,-244"/>
 <polygon fill="none" stroke="black" points="8,-222 8,-244 59,-244 59,-222 8,-222"/>
-<text text-anchor="start" x="25.25" y="-227.7" font-family="Times,serif" font-size="14.00">len</text>
+<text text-anchor="start" x="25.25" y="-227.7" font-family="serif" font-size="14.00">len</text>
 <polygon fill="none" stroke="black" points="59,-222 59,-244 94,-244 94,-222 59,-222"/>
-<text text-anchor="start" x="73.12" y="-227.7" font-family="Times,serif" font-size="14.00">4</text>
+<text text-anchor="start" x="73.12" y="-227.7" font-family="serif" font-size="14.00">4</text>
 <polygon fill="none" stroke="black" points="8,-200 8,-222 59,-222 59,-200 8,-200"/>
-<text text-anchor="start" x="11" y="-205.7" font-family="Times,serif" font-size="14.00">capacity</text>
+<text text-anchor="start" x="11" y="-205.7" font-family="serif" font-size="14.00">capacity</text>
 <polygon fill="none" stroke="black" points="59,-200 59,-222 94,-222 94,-200 59,-200"/>
-<text text-anchor="start" x="73.12" y="-205.7" font-family="Times,serif" font-size="14.00">4</text>
+<text text-anchor="start" x="73.12" y="-205.7" font-family="serif" font-size="14.00">4</text>
 </g>
 <!-- ahoy -->
 <g id="node3" class="node">
 <title>ahoy</title>
 <polygon fill="none" stroke="black" points="146,-266 146,-288 182,-288 182,-266 146,-266"/>
-<text text-anchor="start" x="149" y="-271.7" font-family="Times,serif" font-size="14.00">index</text>
+<text text-anchor="start" x="149" y="-271.7" font-family="serif" font-size="14.00">index</text>
 <polygon fill="none" stroke="black" points="182,-266 182,-288 217,-288 217,-266 182,-266"/>
-<text text-anchor="start" x="184.88" y="-271.7" font-family="Times,serif" font-size="14.00">value</text>
+<text text-anchor="start" x="184.88" y="-271.7" font-family="serif" font-size="14.00">value</text>
 <polygon fill="none" stroke="black" points="146,-244 146,-266 182,-266 182,-244 146,-244"/>
-<text text-anchor="start" x="160.62" y="-249.7" font-family="Times,serif" font-size="14.00">0</text>
+<text text-anchor="start" x="160.62" y="-249.7" font-family="serif" font-size="14.00">0</text>
 <polygon fill="none" stroke="black" points="182,-244 182,-266 217,-266 217,-244 182,-244"/>
-<text text-anchor="start" x="196.5" y="-249.7" font-family="Times,serif" font-size="14.00">a</text>
+<text text-anchor="start" x="196.5" y="-249.7" font-family="serif" font-size="14.00">a</text>
 <polygon fill="none" stroke="black" points="146,-222 146,-244 182,-244 182,-222 146,-222"/>
-<text text-anchor="start" x="160.62" y="-227.7" font-family="Times,serif" font-size="14.00">1</text>
+<text text-anchor="start" x="160.62" y="-227.7" font-family="serif" font-size="14.00">1</text>
 <polygon fill="none" stroke="black" points="182,-222 182,-244 217,-244 217,-222 182,-222"/>
-<text text-anchor="start" x="196.12" y="-227.7" font-family="Times,serif" font-size="14.00">h</text>
+<text text-anchor="start" x="196.12" y="-227.7" font-family="serif" font-size="14.00">h</text>
 <polygon fill="none" stroke="black" points="146,-200 146,-222 182,-222 182,-200 146,-200"/>
-<text text-anchor="start" x="160.62" y="-205.7" font-family="Times,serif" font-size="14.00">2</text>
+<text text-anchor="start" x="160.62" y="-205.7" font-family="serif" font-size="14.00">2</text>
 <polygon fill="none" stroke="black" points="182,-200 182,-222 217,-222 217,-200 182,-200"/>
-<text text-anchor="start" x="196.12" y="-205.7" font-family="Times,serif" font-size="14.00">o</text>
+<text text-anchor="start" x="196.12" y="-205.7" font-family="serif" font-size="14.00">o</text>
 <polygon fill="none" stroke="black" points="146,-178 146,-200 182,-200 182,-178 146,-178"/>
-<text text-anchor="start" x="160.62" y="-183.7" font-family="Times,serif" font-size="14.00">3</text>
+<text text-anchor="start" x="160.62" y="-183.7" font-family="serif" font-size="14.00">3</text>
 <polygon fill="none" stroke="black" points="182,-178 182,-200 217,-200 217,-178 182,-178"/>
-<text text-anchor="start" x="196.12" y="-183.7" font-family="Times,serif" font-size="14.00">y</text>
+<text text-anchor="start" x="196.12" y="-183.7" font-family="serif" font-size="14.00">y</text>
 </g>
 <!-- s&#45;&gt;ahoy -->
 <g id="edge1" class="edge">
@@ -67,29 +67,29 @@
 <title>hello</title>
 <polygon fill="gray" stroke="none" points="146,-20 146,-152 217,-152 217,-20 146,-20"/>
 <polygon fill="none" stroke="black" points="146,-130 146,-152 182,-152 182,-130 146,-130"/>
-<text text-anchor="start" x="149" y="-135.7" font-family="Times,serif" font-size="14.00">index</text>
+<text text-anchor="start" x="149" y="-135.7" font-family="serif" font-size="14.00">index</text>
 <polygon fill="none" stroke="black" points="182,-130 182,-152 217,-152 217,-130 182,-130"/>
-<text text-anchor="start" x="184.88" y="-135.7" font-family="Times,serif" font-size="14.00">value</text>
+<text text-anchor="start" x="184.88" y="-135.7" font-family="serif" font-size="14.00">value</text>
 <polygon fill="none" stroke="black" points="146,-108 146,-130 182,-130 182,-108 146,-108"/>
-<text text-anchor="start" x="160.62" y="-113.7" font-family="Times,serif" font-size="14.00">0</text>
+<text text-anchor="start" x="160.62" y="-113.7" font-family="serif" font-size="14.00">0</text>
 <polygon fill="none" stroke="black" points="182,-108 182,-130 217,-130 217,-108 182,-108"/>
-<text text-anchor="start" x="196.12" y="-113.7" font-family="Times,serif" font-size="14.00">h</text>
+<text text-anchor="start" x="196.12" y="-113.7" font-family="serif" font-size="14.00">h</text>
 <polygon fill="none" stroke="black" points="146,-86 146,-108 182,-108 182,-86 146,-86"/>
-<text text-anchor="start" x="160.62" y="-91.7" font-family="Times,serif" font-size="14.00">1</text>
+<text text-anchor="start" x="160.62" y="-91.7" font-family="serif" font-size="14.00">1</text>
 <polygon fill="none" stroke="black" points="182,-86 182,-108 217,-108 217,-86 182,-86"/>
-<text text-anchor="start" x="196.5" y="-91.7" font-family="Times,serif" font-size="14.00">e</text>
+<text text-anchor="start" x="196.5" y="-91.7" font-family="serif" font-size="14.00">e</text>
 <polygon fill="none" stroke="black" points="146,-64 146,-86 182,-86 182,-64 146,-64"/>
-<text text-anchor="start" x="160.62" y="-69.7" font-family="Times,serif" font-size="14.00">2</text>
+<text text-anchor="start" x="160.62" y="-69.7" font-family="serif" font-size="14.00">2</text>
 <polygon fill="none" stroke="black" points="182,-64 182,-86 217,-86 217,-64 182,-64"/>
-<text text-anchor="start" x="197.62" y="-69.7" font-family="Times,serif" font-size="14.00">l</text>
+<text text-anchor="start" x="197.62" y="-69.7" font-family="serif" font-size="14.00">l</text>
 <polygon fill="none" stroke="black" points="146,-42 146,-64 182,-64 182,-42 146,-42"/>
-<text text-anchor="start" x="160.62" y="-47.7" font-family="Times,serif" font-size="14.00">3</text>
+<text text-anchor="start" x="160.62" y="-47.7" font-family="serif" font-size="14.00">3</text>
 <polygon fill="none" stroke="black" points="182,-42 182,-64 217,-64 217,-42 182,-42"/>
-<text text-anchor="start" x="197.62" y="-47.7" font-family="Times,serif" font-size="14.00">l</text>
+<text text-anchor="start" x="197.62" y="-47.7" font-family="serif" font-size="14.00">l</text>
 <polygon fill="none" stroke="black" points="146,-20 146,-42 182,-42 182,-20 146,-20"/>
-<text text-anchor="start" x="160.62" y="-25.7" font-family="Times,serif" font-size="14.00">4</text>
+<text text-anchor="start" x="160.62" y="-25.7" font-family="serif" font-size="14.00">4</text>
 <polygon fill="none" stroke="black" points="182,-20 182,-42 217,-42 217,-20 182,-20"/>
-<text text-anchor="start" x="196.12" y="-25.7" font-family="Times,serif" font-size="14.00">o</text>
+<text text-anchor="start" x="196.12" y="-25.7" font-family="serif" font-size="14.00">o</text>
 </g>
 </g>
 </svg>

--- a/src/img/trpl04-06.svg
+++ b/src/img/trpl04-06.svg
@@ -13,35 +13,35 @@
 <g id="node1" class="node">
 <title>table0</title>
 <polyline fill="none" stroke="#000000" points="8,-124 80,-124 "/>
-<text text-anchor="start" x="41.2759" y="-129.8" font-family="Times,serif" font-size="14.00" fill="#000000">s</text>
+<text text-anchor="start" x="41.2759" y="-129.8" font-family="serif" font-size="14.00" fill="#000000">s</text>
 <polygon fill="none" stroke="#000000" points="8,-104 8,-124 44,-124 44,-104 8,-104"/>
-<text text-anchor="start" x="10.8413" y="-109.8" font-family="Times,serif" font-size="14.00" fill="#000000">name</text>
+<text text-anchor="start" x="10.8413" y="-109.8" font-family="serif" font-size="14.00" fill="#000000">name</text>
 <polygon fill="none" stroke="#000000" points="44,-104 44,-124 80,-124 80,-104 44,-104"/>
-<text text-anchor="start" x="46.8413" y="-109.8" font-family="Times,serif" font-size="14.00" fill="#000000">value</text>
+<text text-anchor="start" x="46.8413" y="-109.8" font-family="serif" font-size="14.00" fill="#000000">value</text>
 <polygon fill="none" stroke="#000000" points="8,-84 8,-104 44,-104 44,-84 8,-84"/>
-<text text-anchor="start" x="18.2241" y="-89.8" font-family="Times,serif" font-size="14.00" fill="#000000">ptr</text>
+<text text-anchor="start" x="18.2241" y="-89.8" font-family="serif" font-size="14.00" fill="#000000">ptr</text>
 <polygon fill="none" stroke="#000000" points="44,-84 44,-104 80,-104 80,-84 44,-84"/>
 </g>
 <!-- table1 -->
 <g id="node2" class="node">
 <title>table1</title>
 <polyline fill="none" stroke="#000000" points="132,-124 220,-124 "/>
-<text text-anchor="start" x="169.7759" y="-129.8" font-family="Times,serif" font-size="14.00" fill="#000000">s1</text>
+<text text-anchor="start" x="169.7759" y="-129.8" font-family="serif" font-size="14.00" fill="#000000">s1</text>
 <polygon fill="none" stroke="#000000" points="132,-104 132,-124 184,-124 184,-104 132,-104"/>
-<text text-anchor="start" x="142.8413" y="-109.8" font-family="Times,serif" font-size="14.00" fill="#000000">name</text>
+<text text-anchor="start" x="142.8413" y="-109.8" font-family="serif" font-size="14.00" fill="#000000">name</text>
 <polygon fill="none" stroke="#000000" points="184,-104 184,-124 220,-124 220,-104 184,-104"/>
-<text text-anchor="start" x="186.8413" y="-109.8" font-family="Times,serif" font-size="14.00" fill="#000000">value</text>
+<text text-anchor="start" x="186.8413" y="-109.8" font-family="serif" font-size="14.00" fill="#000000">value</text>
 <polygon fill="none" stroke="#000000" points="132,-84 132,-104 184,-104 184,-84 132,-84"/>
-<text text-anchor="start" x="150.2241" y="-89.8" font-family="Times,serif" font-size="14.00" fill="#000000">ptr</text>
+<text text-anchor="start" x="150.2241" y="-89.8" font-family="serif" font-size="14.00" fill="#000000">ptr</text>
 <polygon fill="none" stroke="#000000" points="184,-84 184,-104 220,-104 220,-84 184,-84"/>
 <polygon fill="none" stroke="#000000" points="132,-64 132,-84 184,-84 184,-64 132,-64"/>
-<text text-anchor="start" x="149.4482" y="-69.8" font-family="Times,serif" font-size="14.00" fill="#000000">len</text>
+<text text-anchor="start" x="149.4482" y="-69.8" font-family="serif" font-size="14.00" fill="#000000">len</text>
 <polygon fill="none" stroke="#000000" points="184,-64 184,-84 220,-84 220,-64 184,-64"/>
-<text text-anchor="start" x="198.5" y="-69.8" font-family="Times,serif" font-size="14.00" fill="#000000">5</text>
+<text text-anchor="start" x="198.5" y="-69.8" font-family="serif" font-size="14.00" fill="#000000">5</text>
 <polygon fill="none" stroke="#000000" points="132,-44 132,-64 184,-64 184,-44 132,-44"/>
-<text text-anchor="start" x="134.6826" y="-49.8" font-family="Times,serif" font-size="14.00" fill="#000000">capacity</text>
+<text text-anchor="start" x="134.6826" y="-49.8" font-family="serif" font-size="14.00" fill="#000000">capacity</text>
 <polygon fill="none" stroke="#000000" points="184,-44 184,-64 220,-64 220,-44 184,-44"/>
-<text text-anchor="start" x="198.5" y="-49.8" font-family="Times,serif" font-size="14.00" fill="#000000">5</text>
+<text text-anchor="start" x="198.5" y="-49.8" font-family="serif" font-size="14.00" fill="#000000">5</text>
 </g>
 <!-- table0&#45;&gt;table1 -->
 <g id="edge2" class="edge">
@@ -53,29 +53,29 @@
 <g id="node3" class="node">
 <title>table2</title>
 <polygon fill="none" stroke="#000000" points="272.5,-104 272.5,-124 309.5,-124 309.5,-104 272.5,-104"/>
-<text text-anchor="start" x="275.4482" y="-109.8" font-family="Times,serif" font-size="14.00" fill="#000000">index</text>
+<text text-anchor="start" x="275.4482" y="-109.8" font-family="serif" font-size="14.00" fill="#000000">index</text>
 <polygon fill="none" stroke="#000000" points="309.5,-104 309.5,-124 345.5,-124 345.5,-104 309.5,-104"/>
-<text text-anchor="start" x="312.3413" y="-109.8" font-family="Times,serif" font-size="14.00" fill="#000000">value</text>
+<text text-anchor="start" x="312.3413" y="-109.8" font-family="serif" font-size="14.00" fill="#000000">value</text>
 <polygon fill="none" stroke="#000000" points="272.5,-84 272.5,-104 309.5,-104 309.5,-84 272.5,-84"/>
-<text text-anchor="start" x="287.5" y="-89.8" font-family="Times,serif" font-size="14.00" fill="#000000">0</text>
+<text text-anchor="start" x="287.5" y="-89.8" font-family="serif" font-size="14.00" fill="#000000">0</text>
 <polygon fill="none" stroke="#000000" points="309.5,-84 309.5,-104 345.5,-104 345.5,-84 309.5,-84"/>
-<text text-anchor="start" x="324" y="-89.8" font-family="Times,serif" font-size="14.00" fill="#000000">h</text>
+<text text-anchor="start" x="324" y="-89.8" font-family="serif" font-size="14.00" fill="#000000">h</text>
 <polygon fill="none" stroke="#000000" points="272.5,-64 272.5,-84 309.5,-84 309.5,-64 272.5,-64"/>
-<text text-anchor="start" x="287.5" y="-69.8" font-family="Times,serif" font-size="14.00" fill="#000000">1</text>
+<text text-anchor="start" x="287.5" y="-69.8" font-family="serif" font-size="14.00" fill="#000000">1</text>
 <polygon fill="none" stroke="#000000" points="309.5,-64 309.5,-84 345.5,-84 345.5,-64 309.5,-64"/>
-<text text-anchor="start" x="324.3931" y="-69.8" font-family="Times,serif" font-size="14.00" fill="#000000">e</text>
+<text text-anchor="start" x="324.3931" y="-69.8" font-family="serif" font-size="14.00" fill="#000000">e</text>
 <polygon fill="none" stroke="#000000" points="272.5,-44 272.5,-64 309.5,-64 309.5,-44 272.5,-44"/>
-<text text-anchor="start" x="287.5" y="-49.8" font-family="Times,serif" font-size="14.00" fill="#000000">2</text>
+<text text-anchor="start" x="287.5" y="-49.8" font-family="serif" font-size="14.00" fill="#000000">2</text>
 <polygon fill="none" stroke="#000000" points="309.5,-44 309.5,-64 345.5,-64 345.5,-44 309.5,-44"/>
-<text text-anchor="start" x="325.5552" y="-49.8" font-family="Times,serif" font-size="14.00" fill="#000000">l</text>
+<text text-anchor="start" x="325.5552" y="-49.8" font-family="serif" font-size="14.00" fill="#000000">l</text>
 <polygon fill="none" stroke="#000000" points="272.5,-24 272.5,-44 309.5,-44 309.5,-24 272.5,-24"/>
-<text text-anchor="start" x="287.5" y="-29.8" font-family="Times,serif" font-size="14.00" fill="#000000">3</text>
+<text text-anchor="start" x="287.5" y="-29.8" font-family="serif" font-size="14.00" fill="#000000">3</text>
 <polygon fill="none" stroke="#000000" points="309.5,-24 309.5,-44 345.5,-44 345.5,-24 309.5,-24"/>
-<text text-anchor="start" x="325.5552" y="-29.8" font-family="Times,serif" font-size="14.00" fill="#000000">l</text>
+<text text-anchor="start" x="325.5552" y="-29.8" font-family="serif" font-size="14.00" fill="#000000">l</text>
 <polygon fill="none" stroke="#000000" points="272.5,-4 272.5,-24 309.5,-24 309.5,-4 272.5,-4"/>
-<text text-anchor="start" x="287.5" y="-9.8" font-family="Times,serif" font-size="14.00" fill="#000000">4</text>
+<text text-anchor="start" x="287.5" y="-9.8" font-family="serif" font-size="14.00" fill="#000000">4</text>
 <polygon fill="none" stroke="#000000" points="309.5,-4 309.5,-24 345.5,-24 345.5,-4 309.5,-4"/>
-<text text-anchor="start" x="324" y="-9.8" font-family="Times,serif" font-size="14.00" fill="#000000">o</text>
+<text text-anchor="start" x="324" y="-9.8" font-family="serif" font-size="14.00" fill="#000000">o</text>
 </g>
 <!-- table1&#45;&gt;table2 -->
 <g id="edge1" class="edge">

--- a/src/img/trpl04-07.svg
+++ b/src/img/trpl04-07.svg
@@ -13,70 +13,70 @@
 <g id="node1" class="node">
 <title>table0</title>
 <polyline fill="none" stroke="#000000" points="16,-121 88,-121 "/>
-<text text-anchor="start" x="35.6689" y="-126.8" font-family="Times,serif" font-size="14.00" fill="#000000">world</text>
+<text text-anchor="start" x="35.6689" y="-126.8" font-family="serif" font-size="14.00" fill="#000000">world</text>
 <polygon fill="none" stroke="#000000" points="16,-101 16,-121 52,-121 52,-101 16,-101"/>
-<text text-anchor="start" x="18.8413" y="-106.8" font-family="Times,serif" font-size="14.00" fill="#000000">name</text>
+<text text-anchor="start" x="18.8413" y="-106.8" font-family="serif" font-size="14.00" fill="#000000">name</text>
 <polygon fill="none" stroke="#000000" points="52,-101 52,-121 88,-121 88,-101 52,-101"/>
-<text text-anchor="start" x="54.8413" y="-106.8" font-family="Times,serif" font-size="14.00" fill="#000000">value</text>
+<text text-anchor="start" x="54.8413" y="-106.8" font-family="serif" font-size="14.00" fill="#000000">value</text>
 <polygon fill="none" stroke="#000000" points="16,-81 16,-101 52,-101 52,-81 16,-81"/>
-<text text-anchor="start" x="26.2241" y="-86.8" font-family="Times,serif" font-size="14.00" fill="#000000">ptr</text>
+<text text-anchor="start" x="26.2241" y="-86.8" font-family="serif" font-size="14.00" fill="#000000">ptr</text>
 <polygon fill="none" stroke="#000000" points="52,-81 52,-101 88,-101 88,-81 52,-81"/>
 <polygon fill="none" stroke="#000000" points="16,-61 16,-81 52,-81 52,-61 16,-61"/>
-<text text-anchor="start" x="25.4482" y="-66.8" font-family="Times,serif" font-size="14.00" fill="#000000">len</text>
+<text text-anchor="start" x="25.4482" y="-66.8" font-family="serif" font-size="14.00" fill="#000000">len</text>
 <polygon fill="none" stroke="#000000" points="52,-61 52,-81 88,-81 88,-61 52,-61"/>
-<text text-anchor="start" x="66.5" y="-66.8" font-family="Times,serif" font-size="14.00" fill="#000000">5</text>
+<text text-anchor="start" x="66.5" y="-66.8" font-family="serif" font-size="14.00" fill="#000000">5</text>
 </g>
 <!-- table4 -->
 <g id="node3" class="node">
 <title>table4</title>
 <polygon fill="none" stroke="#000000" points="148.5,-224 148.5,-244 185.5,-244 185.5,-224 148.5,-224"/>
-<text text-anchor="start" x="151.4482" y="-229.8" font-family="Times,serif" font-size="14.00" fill="#000000">index</text>
+<text text-anchor="start" x="151.4482" y="-229.8" font-family="serif" font-size="14.00" fill="#000000">index</text>
 <polygon fill="none" stroke="#000000" points="185.5,-224 185.5,-244 221.5,-244 221.5,-224 185.5,-224"/>
-<text text-anchor="start" x="188.3413" y="-229.8" font-family="Times,serif" font-size="14.00" fill="#000000">value</text>
+<text text-anchor="start" x="188.3413" y="-229.8" font-family="serif" font-size="14.00" fill="#000000">value</text>
 <polygon fill="none" stroke="#000000" points="148.5,-204 148.5,-224 185.5,-224 185.5,-204 148.5,-204"/>
-<text text-anchor="start" x="163.5" y="-209.8" font-family="Times,serif" font-size="14.00" fill="#000000">0</text>
+<text text-anchor="start" x="163.5" y="-209.8" font-family="serif" font-size="14.00" fill="#000000">0</text>
 <polygon fill="none" stroke="#000000" points="185.5,-204 185.5,-224 221.5,-224 221.5,-204 185.5,-204"/>
-<text text-anchor="start" x="200" y="-209.8" font-family="Times,serif" font-size="14.00" fill="#000000">h</text>
+<text text-anchor="start" x="200" y="-209.8" font-family="serif" font-size="14.00" fill="#000000">h</text>
 <polygon fill="none" stroke="#000000" points="148.5,-184 148.5,-204 185.5,-204 185.5,-184 148.5,-184"/>
-<text text-anchor="start" x="163.5" y="-189.8" font-family="Times,serif" font-size="14.00" fill="#000000">1</text>
+<text text-anchor="start" x="163.5" y="-189.8" font-family="serif" font-size="14.00" fill="#000000">1</text>
 <polygon fill="none" stroke="#000000" points="185.5,-184 185.5,-204 221.5,-204 221.5,-184 185.5,-184"/>
-<text text-anchor="start" x="200.3931" y="-189.8" font-family="Times,serif" font-size="14.00" fill="#000000">e</text>
+<text text-anchor="start" x="200.3931" y="-189.8" font-family="serif" font-size="14.00" fill="#000000">e</text>
 <polygon fill="none" stroke="#000000" points="148.5,-164 148.5,-184 185.5,-184 185.5,-164 148.5,-164"/>
-<text text-anchor="start" x="163.5" y="-169.8" font-family="Times,serif" font-size="14.00" fill="#000000">2</text>
+<text text-anchor="start" x="163.5" y="-169.8" font-family="serif" font-size="14.00" fill="#000000">2</text>
 <polygon fill="none" stroke="#000000" points="185.5,-164 185.5,-184 221.5,-184 221.5,-164 185.5,-164"/>
-<text text-anchor="start" x="201.5552" y="-169.8" font-family="Times,serif" font-size="14.00" fill="#000000">l</text>
+<text text-anchor="start" x="201.5552" y="-169.8" font-family="serif" font-size="14.00" fill="#000000">l</text>
 <polygon fill="none" stroke="#000000" points="148.5,-144 148.5,-164 185.5,-164 185.5,-144 148.5,-144"/>
-<text text-anchor="start" x="163.5" y="-149.8" font-family="Times,serif" font-size="14.00" fill="#000000">3</text>
+<text text-anchor="start" x="163.5" y="-149.8" font-family="serif" font-size="14.00" fill="#000000">3</text>
 <polygon fill="none" stroke="#000000" points="185.5,-144 185.5,-164 221.5,-164 221.5,-144 185.5,-144"/>
-<text text-anchor="start" x="201.5552" y="-149.8" font-family="Times,serif" font-size="14.00" fill="#000000">l</text>
+<text text-anchor="start" x="201.5552" y="-149.8" font-family="serif" font-size="14.00" fill="#000000">l</text>
 <polygon fill="none" stroke="#000000" points="148.5,-124 148.5,-144 185.5,-144 185.5,-124 148.5,-124"/>
-<text text-anchor="start" x="163.5" y="-129.8" font-family="Times,serif" font-size="14.00" fill="#000000">4</text>
+<text text-anchor="start" x="163.5" y="-129.8" font-family="serif" font-size="14.00" fill="#000000">4</text>
 <polygon fill="none" stroke="#000000" points="185.5,-124 185.5,-144 221.5,-144 221.5,-124 185.5,-124"/>
-<text text-anchor="start" x="200" y="-129.8" font-family="Times,serif" font-size="14.00" fill="#000000">o</text>
+<text text-anchor="start" x="200" y="-129.8" font-family="serif" font-size="14.00" fill="#000000">o</text>
 <polygon fill="none" stroke="#000000" points="148.5,-104 148.5,-124 185.5,-124 185.5,-104 148.5,-104"/>
-<text text-anchor="start" x="163.5" y="-109.8" font-family="Times,serif" font-size="14.00" fill="#000000">5</text>
+<text text-anchor="start" x="163.5" y="-109.8" font-family="serif" font-size="14.00" fill="#000000">5</text>
 <polygon fill="none" stroke="#000000" points="185.5,-104 185.5,-124 221.5,-124 221.5,-104 185.5,-104"/>
-<text text-anchor="start" x="201.75" y="-109.8" font-family="Times,serif" font-size="14.00" fill="#000000"> </text>
+<text text-anchor="start" x="201.75" y="-109.8" font-family="serif" font-size="14.00" fill="#000000"> </text>
 <polygon fill="none" stroke="#000000" points="148.5,-84 148.5,-104 185.5,-104 185.5,-84 148.5,-84"/>
-<text text-anchor="start" x="163.5" y="-89.8" font-family="Times,serif" font-size="14.00" fill="#000000">6</text>
+<text text-anchor="start" x="163.5" y="-89.8" font-family="serif" font-size="14.00" fill="#000000">6</text>
 <polygon fill="none" stroke="#000000" points="185.5,-84 185.5,-104 221.5,-104 221.5,-84 185.5,-84"/>
-<text text-anchor="start" x="198.4448" y="-89.8" font-family="Times,serif" font-size="14.00" fill="#000000">w</text>
+<text text-anchor="start" x="198.4448" y="-89.8" font-family="serif" font-size="14.00" fill="#000000">w</text>
 <polygon fill="none" stroke="#000000" points="148.5,-64 148.5,-84 185.5,-84 185.5,-64 148.5,-64"/>
-<text text-anchor="start" x="163.5" y="-69.8" font-family="Times,serif" font-size="14.00" fill="#000000">7</text>
+<text text-anchor="start" x="163.5" y="-69.8" font-family="serif" font-size="14.00" fill="#000000">7</text>
 <polygon fill="none" stroke="#000000" points="185.5,-64 185.5,-84 221.5,-84 221.5,-64 185.5,-64"/>
-<text text-anchor="start" x="200" y="-69.8" font-family="Times,serif" font-size="14.00" fill="#000000">o</text>
+<text text-anchor="start" x="200" y="-69.8" font-family="serif" font-size="14.00" fill="#000000">o</text>
 <polygon fill="none" stroke="#000000" points="148.5,-44 148.5,-64 185.5,-64 185.5,-44 148.5,-44"/>
-<text text-anchor="start" x="163.5" y="-49.8" font-family="Times,serif" font-size="14.00" fill="#000000">8</text>
+<text text-anchor="start" x="163.5" y="-49.8" font-family="serif" font-size="14.00" fill="#000000">8</text>
 <polygon fill="none" stroke="#000000" points="185.5,-44 185.5,-64 221.5,-64 221.5,-44 185.5,-44"/>
-<text text-anchor="start" x="201.1689" y="-49.8" font-family="Times,serif" font-size="14.00" fill="#000000">r</text>
+<text text-anchor="start" x="201.1689" y="-49.8" font-family="serif" font-size="14.00" fill="#000000">r</text>
 <polygon fill="none" stroke="#000000" points="148.5,-24 148.5,-44 185.5,-44 185.5,-24 148.5,-24"/>
-<text text-anchor="start" x="163.5" y="-29.8" font-family="Times,serif" font-size="14.00" fill="#000000">9</text>
+<text text-anchor="start" x="163.5" y="-29.8" font-family="serif" font-size="14.00" fill="#000000">9</text>
 <polygon fill="none" stroke="#000000" points="185.5,-24 185.5,-44 221.5,-44 221.5,-24 185.5,-24"/>
-<text text-anchor="start" x="201.5552" y="-29.8" font-family="Times,serif" font-size="14.00" fill="#000000">l</text>
+<text text-anchor="start" x="201.5552" y="-29.8" font-family="serif" font-size="14.00" fill="#000000">l</text>
 <polygon fill="none" stroke="#000000" points="148.5,-4 148.5,-24 185.5,-24 185.5,-4 148.5,-4"/>
-<text text-anchor="start" x="160" y="-9.8" font-family="Times,serif" font-size="14.00" fill="#000000">10</text>
+<text text-anchor="start" x="160" y="-9.8" font-family="serif" font-size="14.00" fill="#000000">10</text>
 <polygon fill="none" stroke="#000000" points="185.5,-4 185.5,-24 221.5,-24 221.5,-4 185.5,-4"/>
-<text text-anchor="start" x="200" y="-9.8" font-family="Times,serif" font-size="14.00" fill="#000000">d</text>
+<text text-anchor="start" x="200" y="-9.8" font-family="serif" font-size="14.00" fill="#000000">d</text>
 </g>
 <!-- table0&#45;&gt;table4 -->
 <g id="edge1" class="edge">
@@ -88,22 +88,22 @@
 <g id="node2" class="node">
 <title>table3</title>
 <polyline fill="none" stroke="#000000" points="8,-247 96,-247 "/>
-<text text-anchor="start" x="49.2759" y="-252.8" font-family="Times,serif" font-size="14.00" fill="#000000">s</text>
+<text text-anchor="start" x="49.2759" y="-252.8" font-family="serif" font-size="14.00" fill="#000000">s</text>
 <polygon fill="none" stroke="#000000" points="8,-227 8,-247 60,-247 60,-227 8,-227"/>
-<text text-anchor="start" x="18.8413" y="-232.8" font-family="Times,serif" font-size="14.00" fill="#000000">name</text>
+<text text-anchor="start" x="18.8413" y="-232.8" font-family="serif" font-size="14.00" fill="#000000">name</text>
 <polygon fill="none" stroke="#000000" points="60,-227 60,-247 96,-247 96,-227 60,-227"/>
-<text text-anchor="start" x="62.8413" y="-232.8" font-family="Times,serif" font-size="14.00" fill="#000000">value</text>
+<text text-anchor="start" x="62.8413" y="-232.8" font-family="serif" font-size="14.00" fill="#000000">value</text>
 <polygon fill="none" stroke="#000000" points="8,-207 8,-227 60,-227 60,-207 8,-207"/>
-<text text-anchor="start" x="26.2241" y="-212.8" font-family="Times,serif" font-size="14.00" fill="#000000">ptr</text>
+<text text-anchor="start" x="26.2241" y="-212.8" font-family="serif" font-size="14.00" fill="#000000">ptr</text>
 <polygon fill="none" stroke="#000000" points="60,-207 60,-227 96,-227 96,-207 60,-207"/>
 <polygon fill="none" stroke="#000000" points="8,-187 8,-207 60,-207 60,-187 8,-187"/>
-<text text-anchor="start" x="25.4482" y="-192.8" font-family="Times,serif" font-size="14.00" fill="#000000">len</text>
+<text text-anchor="start" x="25.4482" y="-192.8" font-family="serif" font-size="14.00" fill="#000000">len</text>
 <polygon fill="none" stroke="#000000" points="60,-187 60,-207 96,-207 96,-187 60,-187"/>
-<text text-anchor="start" x="71.2563" y="-192.8" font-family="Times,serif" font-size="14.00" fill="#000000">11</text>
+<text text-anchor="start" x="71.2563" y="-192.8" font-family="serif" font-size="14.00" fill="#000000">11</text>
 <polygon fill="none" stroke="#000000" points="8,-167 8,-187 60,-187 60,-167 8,-167"/>
-<text text-anchor="start" x="10.6826" y="-172.8" font-family="Times,serif" font-size="14.00" fill="#000000">capacity</text>
+<text text-anchor="start" x="10.6826" y="-172.8" font-family="serif" font-size="14.00" fill="#000000">capacity</text>
 <polygon fill="none" stroke="#000000" points="60,-167 60,-187 96,-187 96,-167 60,-167"/>
-<text text-anchor="start" x="71.2563" y="-172.8" font-family="Times,serif" font-size="14.00" fill="#000000">11</text>
+<text text-anchor="start" x="71.2563" y="-172.8" font-family="serif" font-size="14.00" fill="#000000">11</text>
 </g>
 <!-- table3&#45;&gt;table4 -->
 <g id="edge2" class="edge">

--- a/src/img/trpl15-01.svg
+++ b/src/img/trpl15-01.svg
@@ -13,31 +13,31 @@
 <g id="node1" class="node">
 <title>table0</title>
 <polyline fill="none" stroke="#000000" points="8,-128 162,-128 "/>
-<text text-anchor="start" x="70.6069" y="-133.8" font-family="Times,serif" font-size="14.00" fill="#000000">Cons</text>
+<text text-anchor="start" x="70.6069" y="-133.8" font-family="serif" font-size="14.00" fill="#000000">Cons</text>
 <polygon fill="none" stroke="#000000" points="8,-4 8,-128 31,-128 31,-4 8,-4"/>
-<text text-anchor="start" x="10.5552" y="-61.8" font-family="Times,serif" font-size="14.00" fill="#000000">i32</text>
+<text text-anchor="start" x="10.5552" y="-61.8" font-family="serif" font-size="14.00" fill="#000000">i32</text>
 <polygon fill="none" stroke="#000000" points="31,-4 31,-128 162,-128 162,-4 31,-4"/>
 <polyline fill="none" stroke="#000000" points="34,-105 159,-105 "/>
-<text text-anchor="start" x="82.1069" y="-110.8" font-family="Times,serif" font-size="14.00" fill="#000000">Cons</text>
+<text text-anchor="start" x="82.1069" y="-110.8" font-family="serif" font-size="14.00" fill="#000000">Cons</text>
 <polygon fill="none" stroke="#000000" points="34,-7 34,-105 57,-105 57,-7 34,-7"/>
-<text text-anchor="start" x="36.5552" y="-51.8" font-family="Times,serif" font-size="14.00" fill="#000000">i32</text>
+<text text-anchor="start" x="36.5552" y="-51.8" font-family="serif" font-size="14.00" fill="#000000">i32</text>
 <polygon fill="none" stroke="#000000" points="57,-7 57,-105 159,-105 159,-7 57,-7"/>
 <polyline fill="none" stroke="#000000" points="60,-82 156,-82 "/>
-<text text-anchor="start" x="93.6069" y="-87.8" font-family="Times,serif" font-size="14.00" fill="#000000">Cons</text>
+<text text-anchor="start" x="93.6069" y="-87.8" font-family="serif" font-size="14.00" fill="#000000">Cons</text>
 <polygon fill="none" stroke="#000000" points="60,-10 60,-82 83,-82 83,-10 60,-10"/>
-<text text-anchor="start" x="62.5552" y="-41.8" font-family="Times,serif" font-size="14.00" fill="#000000">i32</text>
+<text text-anchor="start" x="62.5552" y="-41.8" font-family="serif" font-size="14.00" fill="#000000">i32</text>
 <polygon fill="none" stroke="#000000" points="83,-10 83,-82 156,-82 156,-10 83,-10"/>
 <polyline fill="none" stroke="#000000" points="86,-59 153,-59 "/>
-<text text-anchor="start" x="105.1069" y="-64.8" font-family="Times,serif" font-size="14.00" fill="#000000">Cons</text>
+<text text-anchor="start" x="105.1069" y="-64.8" font-family="serif" font-size="14.00" fill="#000000">Cons</text>
 <polygon fill="none" stroke="#000000" points="86,-13 86,-59 109,-59 109,-13 86,-13"/>
-<text text-anchor="start" x="88.5552" y="-31.8" font-family="Times,serif" font-size="14.00" fill="#000000">i32</text>
+<text text-anchor="start" x="88.5552" y="-31.8" font-family="serif" font-size="14.00" fill="#000000">i32</text>
 <polygon fill="none" stroke="#000000" points="109,-13 109,-59 153,-59 153,-13 109,-13"/>
 <polyline fill="none" stroke="#000000" points="112,-36 150,-36 "/>
-<text text-anchor="start" x="116.6069" y="-41.8" font-family="Times,serif" font-size="14.00" fill="#000000">Cons</text>
+<text text-anchor="start" x="116.6069" y="-41.8" font-family="serif" font-size="14.00" fill="#000000">Cons</text>
 <polygon fill="none" stroke="#000000" points="112,-16 112,-36 135,-36 135,-16 112,-16"/>
-<text text-anchor="start" x="114.5552" y="-21.8" font-family="Times,serif" font-size="14.00" fill="#000000">i32</text>
+<text text-anchor="start" x="114.5552" y="-21.8" font-family="serif" font-size="14.00" fill="#000000">i32</text>
 <polygon fill="none" stroke="#000000" points="135,-16 135,-36 150,-36 150,-16 135,-16"/>
-<text text-anchor="start" x="137.5098" y="-21.8" font-family="Times,serif" font-size="14.00" fill="#000000">∞</text>
+<text text-anchor="start" x="137.5098" y="-21.8" font-family="serif" font-size="14.00" fill="#000000">∞</text>
 </g>
 </g>
 </svg>

--- a/src/img/trpl15-02.svg
+++ b/src/img/trpl15-02.svg
@@ -13,14 +13,14 @@
 <g id="node1" class="node">
 <title>table0</title>
 <polyline fill="none" stroke="#000000" points="8.5,-50 71.5,-50 "/>
-<text text-anchor="start" x="25.6069" y="-55.8" font-family="Times,serif" font-size="14.00" fill="#000000">Cons</text>
+<text text-anchor="start" x="25.6069" y="-55.8" font-family="serif" font-size="14.00" fill="#000000">Cons</text>
 <polygon fill="none" stroke="#000000" points="8.5,-4 8.5,-50 31.5,-50 31.5,-4 8.5,-4"/>
-<text text-anchor="start" x="11.0552" y="-22.8" font-family="Times,serif" font-size="14.00" fill="#000000">i32</text>
+<text text-anchor="start" x="11.0552" y="-22.8" font-family="serif" font-size="14.00" fill="#000000">i32</text>
 <polygon fill="none" stroke="#000000" points="31.5,-4 31.5,-50 71.5,-50 71.5,-4 31.5,-4"/>
 <polyline fill="none" stroke="#000000" points="34.5,-27 68.5,-27 "/>
-<text text-anchor="start" x="39.8311" y="-32.8" font-family="Times,serif" font-size="14.00" fill="#000000">Box</text>
+<text text-anchor="start" x="39.8311" y="-32.8" font-family="serif" font-size="14.00" fill="#000000">Box</text>
 <polygon fill="none" stroke="#000000" points="34.5,-7 34.5,-27 68.5,-27 68.5,-7 34.5,-7"/>
-<text text-anchor="start" x="37.1172" y="-12.8" font-family="Times,serif" font-size="14.00" fill="#000000">usize</text>
+<text text-anchor="start" x="37.1172" y="-12.8" font-family="serif" font-size="14.00" fill="#000000">usize</text>
 </g>
 </g>
 </svg>

--- a/src/img/trpl15-03.svg
+++ b/src/img/trpl15-03.svg
@@ -13,15 +13,15 @@
 <!-- table4 -->
 <g id="node1" class="node">
 <title>table4</title>
-<text text-anchor="start" x="21" y="-121.8" font-family="Times,serif" font-size="14.00" fill="#000000">b</text>
+<text text-anchor="start" x="21" y="-121.8" font-family="serif" font-size="14.00" fill="#000000">b</text>
 </g>
 <!-- table5 -->
 <g id="node2" class="node">
 <title>table5</title>
 <polygon fill="none" stroke="#000000" points="104,-116 104,-136 117,-136 117,-116 104,-116"/>
-<text text-anchor="start" x="107" y="-121.8" font-family="Times,serif" font-size="14.00" fill="#000000">3</text>
+<text text-anchor="start" x="107" y="-121.8" font-family="serif" font-size="14.00" fill="#000000">3</text>
 <polygon fill="none" stroke="#000000" points="117,-116 117,-136 130,-136 130,-116 117,-116"/>
-<text text-anchor="start" x="120" y="-121.8" font-family="Times,serif" font-size="14.00" fill="#000000"> &#160;</text>
+<text text-anchor="start" x="120" y="-121.8" font-family="serif" font-size="14.00" fill="#000000"> &#160;</text>
 </g>
 <!-- table4&#45;&gt;table5 -->
 <g id="edge4" class="edge">
@@ -33,9 +33,9 @@
 <g id="node4" class="node">
 <title>table1</title>
 <polygon fill="none" stroke="#000000" points="194,-62 194,-82 207,-82 207,-62 194,-62"/>
-<text text-anchor="start" x="197" y="-67.8" font-family="Times,serif" font-size="14.00" fill="#000000">5</text>
+<text text-anchor="start" x="197" y="-67.8" font-family="serif" font-size="14.00" fill="#000000">5</text>
 <polygon fill="none" stroke="#000000" points="207,-62 207,-82 220,-82 220,-62 207,-62"/>
-<text text-anchor="start" x="210" y="-67.8" font-family="Times,serif" font-size="14.00" fill="#000000"> &#160;</text>
+<text text-anchor="start" x="210" y="-67.8" font-family="serif" font-size="14.00" fill="#000000"> &#160;</text>
 </g>
 <!-- table5&#45;&gt;table1 -->
 <g id="edge5" class="edge">
@@ -46,7 +46,7 @@
 <!-- table0 -->
 <g id="node3" class="node">
 <title>table0</title>
-<text text-anchor="start" x="110.8931" y="-67.8" font-family="Times,serif" font-size="14.00" fill="#000000">a</text>
+<text text-anchor="start" x="110.8931" y="-67.8" font-family="serif" font-size="14.00" fill="#000000">a</text>
 </g>
 <!-- table0&#45;&gt;table1 -->
 <g id="edge1" class="edge">
@@ -58,9 +58,9 @@
 <g id="node5" class="node">
 <title>table2</title>
 <polygon fill="none" stroke="#000000" points="281,-62 281,-82 301,-82 301,-62 281,-62"/>
-<text text-anchor="start" x="284" y="-67.8" font-family="Times,serif" font-size="14.00" fill="#000000">10</text>
+<text text-anchor="start" x="284" y="-67.8" font-family="serif" font-size="14.00" fill="#000000">10</text>
 <polygon fill="none" stroke="#000000" points="301,-62 301,-82 314,-82 314,-62 301,-62"/>
-<text text-anchor="start" x="304" y="-67.8" font-family="Times,serif" font-size="14.00" fill="#000000"> &#160;</text>
+<text text-anchor="start" x="304" y="-67.8" font-family="serif" font-size="14.00" fill="#000000"> &#160;</text>
 </g>
 <!-- table1&#45;&gt;table2 -->
 <g id="edge2" class="edge">
@@ -72,7 +72,7 @@
 <g id="node6" class="node">
 <title>table3</title>
 <polygon fill="none" stroke="#000000" points="376,-62 376,-82 399,-82 399,-62 376,-62"/>
-<text text-anchor="start" x="378.5552" y="-67.8" font-family="Times,serif" font-size="14.00" fill="#000000">Nil</text>
+<text text-anchor="start" x="378.5552" y="-67.8" font-family="serif" font-size="14.00" fill="#000000">Nil</text>
 </g>
 <!-- table2&#45;&gt;table3 -->
 <g id="edge3" class="edge">
@@ -83,15 +83,15 @@
 <!-- table6 -->
 <g id="node7" class="node">
 <title>table6</title>
-<text text-anchor="start" x="20.8931" y="-13.8" font-family="Times,serif" font-size="14.00" fill="#000000">c</text>
+<text text-anchor="start" x="20.8931" y="-13.8" font-family="serif" font-size="14.00" fill="#000000">c</text>
 </g>
 <!-- table7 -->
 <g id="node8" class="node">
 <title>table7</title>
 <polygon fill="none" stroke="#000000" points="104,-8 104,-28 117,-28 117,-8 104,-8"/>
-<text text-anchor="start" x="107" y="-13.8" font-family="Times,serif" font-size="14.00" fill="#000000">4</text>
+<text text-anchor="start" x="107" y="-13.8" font-family="serif" font-size="14.00" fill="#000000">4</text>
 <polygon fill="none" stroke="#000000" points="117,-8 117,-28 130,-28 130,-8 117,-8"/>
-<text text-anchor="start" x="120" y="-13.8" font-family="Times,serif" font-size="14.00" fill="#000000"> &#160;</text>
+<text text-anchor="start" x="120" y="-13.8" font-family="serif" font-size="14.00" fill="#000000"> &#160;</text>
 </g>
 <!-- table6&#45;&gt;table7 -->
 <g id="edge6" class="edge">

--- a/src/img/trpl15-04.svg
+++ b/src/img/trpl15-04.svg
@@ -12,17 +12,17 @@
 <g id="node1" class="node">
 <title>l1</title>
 <polygon fill="none" stroke="black" points="90,-52.59 90,-88.59 144,-88.59 144,-52.59 90,-52.59"/>
-<text text-anchor="middle" x="104" y="-66.89" font-family="Times,serif" font-size="14.00">5</text>
+<text text-anchor="middle" x="104" y="-66.89" font-family="serif" font-size="14.00">5</text>
 <polyline fill="none" stroke="black" points="118,-52.59 118,-88.59 "/>
-<text text-anchor="middle" x="131" y="-66.89" font-family="Times,serif" font-size="14.00"> </text>
+<text text-anchor="middle" x="131" y="-66.89" font-family="serif" font-size="14.00"> </text>
 </g>
 <!-- l2 -->
 <g id="node2" class="node">
 <title>l2</title>
 <polygon fill="none" stroke="black" points="180,-52.59 180,-88.59 234,-88.59 234,-52.59 180,-52.59"/>
-<text text-anchor="middle" x="196" y="-66.89" font-family="Times,serif" font-size="14.00">10</text>
+<text text-anchor="middle" x="196" y="-66.89" font-family="serif" font-size="14.00">10</text>
 <polyline fill="none" stroke="black" points="212,-52.59 212,-88.59 "/>
-<text text-anchor="middle" x="223" y="-66.89" font-family="Times,serif" font-size="14.00"> </text>
+<text text-anchor="middle" x="223" y="-66.89" font-family="serif" font-size="14.00"> </text>
 </g>
 <!-- l1&#45;&gt;l2 -->
 <g id="edge5" class="edge">
@@ -60,7 +60,7 @@
 <g id="node5" class="node">
 <title>a</title>
 <polygon fill="none" stroke="black" points="0,-70.59 0,-106.59 54,-106.59 54,-70.59 0,-70.59"/>
-<text text-anchor="middle" x="27" y="-84.89" font-family="Times,serif" font-size="14.00">a</text>
+<text text-anchor="middle" x="27" y="-84.89" font-family="serif" font-size="14.00">a</text>
 </g>
 <!-- a&#45;&gt;l1 -->
 <g id="edge1" class="edge">
@@ -72,7 +72,7 @@
 <g id="node6" class="node">
 <title>b</title>
 <polygon fill="none" stroke="black" points="90,-107.59 90,-143.59 144,-143.59 144,-107.59 90,-107.59"/>
-<text text-anchor="middle" x="117" y="-121.89" font-family="Times,serif" font-size="14.00">b</text>
+<text text-anchor="middle" x="117" y="-121.89" font-family="serif" font-size="14.00">b</text>
 </g>
 <!-- b&#45;&gt;l2 -->
 <g id="edge2" class="edge">

--- a/src/img/trpl17-01.svg
+++ b/src/img/trpl17-01.svg
@@ -11,31 +11,31 @@
 <g id="clust1" class="cluster">
 <title>cluster_task_a</title>
 <polygon fill="none" stroke="black" points="8,-93 8,-170 676.21,-170 676.21,-93 8,-93"/>
-<text text-anchor="middle" x="342.11" y="-152.7" font-family="Times,serif" font-size="14.00">Task A</text>
+<text text-anchor="middle" x="342.11" y="-152.7" font-family="serif" font-size="14.00">Task A</text>
 </g>
 <g id="clust2" class="cluster">
 <title>cluster_task_b</title>
 <polygon fill="none" stroke="black" points="8.72,-8 8.72,-85 675.49,-85 675.49,-8 8.72,-8"/>
-<text text-anchor="middle" x="342.11" y="-67.7" font-family="Times,serif" font-size="14.00">Task B</text>
+<text text-anchor="middle" x="342.11" y="-67.7" font-family="serif" font-size="14.00">Task B</text>
 </g>
 <!-- A1 -->
 <g id="node1" class="node">
 <title>A1</title>
 <polygon fill="none" stroke="black" points="47.36,-137 16,-119 47.36,-101 78.73,-119 47.36,-137"/>
-<text text-anchor="middle" x="47.36" y="-113.95" font-family="Times,serif" font-size="14.00">A1</text>
+<text text-anchor="middle" x="47.36" y="-113.95" font-family="serif" font-size="14.00">A1</text>
 </g>
 <!-- A2 -->
 <g id="node2" class="node">
 <title>A2</title>
 <polygon fill="none" stroke="black" points="243.38,-137 212.01,-119 243.38,-101 274.74,-119 243.38,-137"/>
-<text text-anchor="middle" x="243.38" y="-113.95" font-family="Times,serif" font-size="14.00">A2</text>
+<text text-anchor="middle" x="243.38" y="-113.95" font-family="serif" font-size="14.00">A2</text>
 </g>
 <!-- A1&#45;&gt;A2 -->
 <!-- B1 -->
 <g id="node7" class="node">
 <title>B1</title>
 <polygon fill="none" stroke="black" points="145.37,-52 114.73,-34 145.37,-16 176.01,-34 145.37,-52"/>
-<text text-anchor="middle" x="145.37" y="-28.95" font-family="Times,serif" font-size="14.00">B1</text>
+<text text-anchor="middle" x="145.37" y="-28.95" font-family="serif" font-size="14.00">B1</text>
 </g>
 <!-- A1&#45;&gt;B1 -->
 <g id="edge9" class="edge">
@@ -47,14 +47,14 @@
 <g id="node3" class="node">
 <title>A3</title>
 <polygon fill="none" stroke="black" points="439.39,-137 408.02,-119 439.39,-101 470.75,-119 439.39,-137"/>
-<text text-anchor="middle" x="439.39" y="-113.95" font-family="Times,serif" font-size="14.00">A3</text>
+<text text-anchor="middle" x="439.39" y="-113.95" font-family="serif" font-size="14.00">A3</text>
 </g>
 <!-- A2&#45;&gt;A3 -->
 <!-- B2 -->
 <g id="node8" class="node">
 <title>B2</title>
 <polygon fill="none" stroke="black" points="341.38,-52 310.74,-34 341.38,-16 372.02,-34 341.38,-52"/>
-<text text-anchor="middle" x="341.38" y="-28.95" font-family="Times,serif" font-size="14.00">B2</text>
+<text text-anchor="middle" x="341.38" y="-28.95" font-family="serif" font-size="14.00">B2</text>
 </g>
 <!-- A2&#45;&gt;B2 -->
 <g id="edge11" class="edge">
@@ -66,7 +66,7 @@
 <g id="node4" class="node">
 <title>A4</title>
 <polygon fill="none" stroke="black" points="538.12,-137 506.75,-119 538.12,-101 569.48,-119 538.12,-137"/>
-<text text-anchor="middle" x="538.12" y="-113.95" font-family="Times,serif" font-size="14.00">A4</text>
+<text text-anchor="middle" x="538.12" y="-113.95" font-family="serif" font-size="14.00">A4</text>
 </g>
 <!-- A3&#45;&gt;A4 -->
 <!-- A3&#45;&gt;A4 -->
@@ -82,7 +82,7 @@
 <g id="node9" class="node">
 <title>B3</title>
 <polygon fill="none" stroke="black" points="636.85,-52 606.21,-34 636.85,-16 667.49,-34 636.85,-52"/>
-<text text-anchor="middle" x="636.85" y="-28.95" font-family="Times,serif" font-size="14.00">B3</text>
+<text text-anchor="middle" x="636.85" y="-28.95" font-family="serif" font-size="14.00">B3</text>
 </g>
 <!-- A4&#45;&gt;B3 -->
 <g id="edge14" class="edge">

--- a/src/img/trpl17-02.svg
+++ b/src/img/trpl17-02.svg
@@ -11,24 +11,24 @@
 <g id="clust1" class="cluster">
 <title>cluster_ColleagueB</title>
 <polygon fill="none" stroke="black" points="8.72,-8 8.72,-85 382.2,-85 382.2,-8 8.72,-8"/>
-<text text-anchor="middle" x="195.46" y="-67.7" font-family="Times,serif" font-size="14.00">Task B</text>
+<text text-anchor="middle" x="195.46" y="-67.7" font-family="serif" font-size="14.00">Task B</text>
 </g>
 <g id="clust2" class="cluster">
 <title>cluster_ColleagueA</title>
 <polygon fill="none" stroke="black" points="8,-93 8,-170 382.92,-170 382.92,-93 8,-93"/>
-<text text-anchor="middle" x="195.46" y="-152.7" font-family="Times,serif" font-size="14.00">Task A</text>
+<text text-anchor="middle" x="195.46" y="-152.7" font-family="serif" font-size="14.00">Task A</text>
 </g>
 <!-- B1 -->
 <g id="node1" class="node">
 <title>B1</title>
 <polygon fill="none" stroke="black" points="47.36,-52 16.72,-34 47.36,-16 78.01,-34 47.36,-52"/>
-<text text-anchor="middle" x="47.36" y="-28.95" font-family="Times,serif" font-size="14.00">B1</text>
+<text text-anchor="middle" x="47.36" y="-28.95" font-family="serif" font-size="14.00">B1</text>
 </g>
 <!-- B2 -->
 <g id="node2" class="node">
 <title>B2</title>
 <polygon fill="none" stroke="black" points="146.09,-52 115.45,-34 146.09,-16 176.74,-34 146.09,-52"/>
-<text text-anchor="middle" x="146.09" y="-28.95" font-family="Times,serif" font-size="14.00">B2</text>
+<text text-anchor="middle" x="146.09" y="-28.95" font-family="serif" font-size="14.00">B2</text>
 </g>
 <!-- B1&#45;&gt;B2 -->
 <g id="edge1" class="edge">
@@ -40,7 +40,7 @@
 <g id="node3" class="node">
 <title>B3</title>
 <polygon fill="none" stroke="black" points="244.82,-52 214.18,-34 244.82,-16 275.47,-34 244.82,-52"/>
-<text text-anchor="middle" x="244.82" y="-28.95" font-family="Times,serif" font-size="14.00">B3</text>
+<text text-anchor="middle" x="244.82" y="-28.95" font-family="serif" font-size="14.00">B3</text>
 </g>
 <!-- B2&#45;&gt;B3 -->
 <g id="edge2" class="edge">
@@ -54,13 +54,13 @@
 <g id="node5" class="node">
 <title>A1</title>
 <polygon fill="none" stroke="black" points="47.36,-137 16,-119 47.36,-101 78.73,-119 47.36,-137"/>
-<text text-anchor="middle" x="47.36" y="-113.95" font-family="Times,serif" font-size="14.00">A1</text>
+<text text-anchor="middle" x="47.36" y="-113.95" font-family="serif" font-size="14.00">A1</text>
 </g>
 <!-- A2 -->
 <g id="node6" class="node">
 <title>A2</title>
 <polygon fill="none" stroke="black" points="146.09,-137 114.73,-119 146.09,-101 177.46,-119 146.09,-137"/>
-<text text-anchor="middle" x="146.09" y="-113.95" font-family="Times,serif" font-size="14.00">A2</text>
+<text text-anchor="middle" x="146.09" y="-113.95" font-family="serif" font-size="14.00">A2</text>
 </g>
 <!-- A1&#45;&gt;A2 -->
 <g id="edge4" class="edge">
@@ -72,7 +72,7 @@
 <g id="node7" class="node">
 <title>A3</title>
 <polygon fill="none" stroke="black" points="244.82,-137 213.46,-119 244.82,-101 276.19,-119 244.82,-137"/>
-<text text-anchor="middle" x="244.82" y="-113.95" font-family="Times,serif" font-size="14.00">A3</text>
+<text text-anchor="middle" x="244.82" y="-113.95" font-family="serif" font-size="14.00">A3</text>
 </g>
 <!-- A2&#45;&gt;A3 -->
 <g id="edge5" class="edge">
@@ -84,7 +84,7 @@
 <g id="node8" class="node">
 <title>A4</title>
 <polygon fill="none" stroke="black" points="343.55,-137 312.19,-119 343.55,-101 374.92,-119 343.55,-137"/>
-<text text-anchor="middle" x="343.55" y="-113.95" font-family="Times,serif" font-size="14.00">A4</text>
+<text text-anchor="middle" x="343.55" y="-113.95" font-family="serif" font-size="14.00">A4</text>
 </g>
 <!-- A3&#45;&gt;A4 -->
 <g id="edge6" class="edge">

--- a/src/img/trpl17-03.svg
+++ b/src/img/trpl17-03.svg
@@ -11,24 +11,24 @@
 <g id="clust1" class="cluster">
 <title>cluster_ColleagueB</title>
 <polygon fill="none" stroke="black" points="8,-93 8,-170 408.98,-170 408.98,-93 8,-93"/>
-<text text-anchor="middle" x="208.49" y="-152.7" font-family="Times,serif" font-size="14.00">Task A</text>
+<text text-anchor="middle" x="208.49" y="-152.7" font-family="serif" font-size="14.00">Task A</text>
 </g>
 <g id="clust2" class="cluster">
 <title>cluster_ColleagueA</title>
 <polygon fill="none" stroke="black" points="8.72,-8 8.72,-85 408.25,-85 408.25,-8 8.72,-8"/>
-<text text-anchor="middle" x="208.49" y="-67.7" font-family="Times,serif" font-size="14.00">Task B</text>
+<text text-anchor="middle" x="208.49" y="-67.7" font-family="serif" font-size="14.00">Task B</text>
 </g>
 <!-- A1 -->
 <g id="node1" class="node">
 <title>A1</title>
 <polygon fill="none" stroke="black" points="47.36,-137 16,-119 47.36,-101 78.73,-119 47.36,-137"/>
-<text text-anchor="middle" x="47.36" y="-113.95" font-family="Times,serif" font-size="14.00">A1</text>
+<text text-anchor="middle" x="47.36" y="-113.95" font-family="serif" font-size="14.00">A1</text>
 </g>
 <!-- A2 -->
 <g id="node2" class="node">
 <title>A2</title>
 <polygon fill="none" stroke="black" points="146.09,-137 114.73,-119 146.09,-101 177.46,-119 146.09,-137"/>
-<text text-anchor="middle" x="146.09" y="-113.95" font-family="Times,serif" font-size="14.00">A2</text>
+<text text-anchor="middle" x="146.09" y="-113.95" font-family="serif" font-size="14.00">A2</text>
 </g>
 <!-- A1&#45;&gt;A2 -->
 <g id="edge1" class="edge">
@@ -48,7 +48,7 @@
 <g id="node4" class="node">
 <title>A3</title>
 <polygon fill="none" stroke="black" points="369.61,-137 338.25,-119 369.61,-101 400.98,-119 369.61,-137"/>
-<text text-anchor="middle" x="369.61" y="-113.95" font-family="Times,serif" font-size="14.00">A3</text>
+<text text-anchor="middle" x="369.61" y="-113.95" font-family="serif" font-size="14.00">A3</text>
 </g>
 <!-- A0_1&#45;&gt;A3 -->
 <g id="edge3" class="edge">
@@ -62,13 +62,13 @@
 <g id="node5" class="node">
 <title>B1</title>
 <polygon fill="none" stroke="black" points="47.36,-52 16.72,-34 47.36,-16 78.01,-34 47.36,-52"/>
-<text text-anchor="middle" x="47.36" y="-28.95" font-family="Times,serif" font-size="14.00">B1</text>
+<text text-anchor="middle" x="47.36" y="-28.95" font-family="serif" font-size="14.00">B1</text>
 </g>
 <!-- B2 -->
 <g id="node6" class="node">
 <title>B2</title>
 <polygon fill="none" stroke="black" points="146.09,-52 115.45,-34 146.09,-16 176.74,-34 146.09,-52"/>
-<text text-anchor="middle" x="146.09" y="-28.95" font-family="Times,serif" font-size="14.00">B2</text>
+<text text-anchor="middle" x="146.09" y="-28.95" font-family="serif" font-size="14.00">B2</text>
 </g>
 <!-- B1&#45;&gt;B2 -->
 <g id="edge4" class="edge">
@@ -80,7 +80,7 @@
 <g id="node7" class="node">
 <title>B3</title>
 <polygon fill="none" stroke="black" points="257.85,-52 227.21,-34 257.85,-16 288.49,-34 257.85,-52"/>
-<text text-anchor="middle" x="257.85" y="-28.95" font-family="Times,serif" font-size="14.00">B3</text>
+<text text-anchor="middle" x="257.85" y="-28.95" font-family="serif" font-size="14.00">B3</text>
 </g>
 <!-- B2&#45;&gt;B3 -->
 <g id="edge5" class="edge">
@@ -98,7 +98,7 @@
 <g id="node8" class="node">
 <title>B4</title>
 <polygon fill="none" stroke="black" points="369.61,-52 338.97,-34 369.61,-16 400.25,-34 369.61,-52"/>
-<text text-anchor="middle" x="369.61" y="-28.95" font-family="Times,serif" font-size="14.00">B4</text>
+<text text-anchor="middle" x="369.61" y="-28.95" font-family="serif" font-size="14.00">B4</text>
 </g>
 <!-- B3&#45;&gt;B4 -->
 <g id="edge6" class="edge">

--- a/src/img/trpl17-04.svg
+++ b/src/img/trpl17-04.svg
@@ -12,13 +12,13 @@
 <g id="node1" class="node">
 <title>fut1</title>
 <polyline fill="none" stroke="black" points="13.12,-71.5 40.88,-71.5"/>
-<text text-anchor="start" x="16.12" y="-77.7" font-family="Times,serif" font-size="14.00">fut1</text>
+<text text-anchor="start" x="16.12" y="-77.7" font-family="serif" font-size="14.00">fut1</text>
 <polygon fill="none" stroke="black" points="13.12,-49 13.12,-71.5 40.88,-71.5 40.88,-49 13.12,-49"/>
-<text text-anchor="start" x="23.62" y="-55.2" font-family="Times,serif" font-size="14.00">0</text>
+<text text-anchor="start" x="23.62" y="-55.2" font-family="serif" font-size="14.00">0</text>
 <polygon fill="none" stroke="black" points="13.12,-26.5 13.12,-49 40.88,-49 40.88,-26.5 13.12,-26.5"/>
-<text text-anchor="start" x="23.62" y="-32.7" font-family="Times,serif" font-size="14.00">1</text>
+<text text-anchor="start" x="23.62" y="-32.7" font-family="serif" font-size="14.00">1</text>
 <polygon fill="none" stroke="black" points="13.12,-4 13.12,-26.5 40.88,-26.5 40.88,-4 13.12,-4"/>
-<text text-anchor="start" x="23.25" y="-10.2" font-family="Times,serif" font-size="14.00"> &#160;</text>
+<text text-anchor="start" x="23.25" y="-10.2" font-family="serif" font-size="14.00"> &#160;</text>
 </g>
 <!-- fut1&#45;&gt;fut1 -->
 <g id="edge1" class="edge">

--- a/src/img/trpl17-05.svg
+++ b/src/img/trpl17-05.svg
@@ -16,25 +16,25 @@
 <title>fut1</title>
 <polygon fill="gray" stroke="none" points="29.12,-20 29.12,-110 56.88,-110 56.88,-20 29.12,-20"/>
 <polyline fill="none" stroke="black" points="29.12,-87.5 56.88,-87.5"/>
-<text text-anchor="start" x="32.12" y="-93.7" font-family="Times,serif" font-size="14.00">fut1</text>
+<text text-anchor="start" x="32.12" y="-93.7" font-family="serif" font-size="14.00">fut1</text>
 <polygon fill="none" stroke="black" points="29.12,-65 29.12,-87.5 56.88,-87.5 56.88,-65 29.12,-65"/>
-<text text-anchor="start" x="40" y="-71.2" font-family="Times,serif" font-size="14.00">?</text>
+<text text-anchor="start" x="40" y="-71.2" font-family="serif" font-size="14.00">?</text>
 <polygon fill="none" stroke="black" points="29.12,-42.5 29.12,-65 56.88,-65 56.88,-42.5 29.12,-42.5"/>
-<text text-anchor="start" x="40" y="-48.7" font-family="Times,serif" font-size="14.00">?</text>
+<text text-anchor="start" x="40" y="-48.7" font-family="serif" font-size="14.00">?</text>
 <polygon fill="none" stroke="black" points="29.12,-20 29.12,-42.5 56.88,-42.5 56.88,-20 29.12,-20"/>
-<text text-anchor="start" x="40" y="-26.2" font-family="Times,serif" font-size="14.00">?</text>
+<text text-anchor="start" x="40" y="-26.2" font-family="serif" font-size="14.00">?</text>
 </g>
 <!-- fut2 -->
 <g id="node2" class="node">
 <title>fut2</title>
 <polyline fill="none" stroke="black" points="119.12,-87.5 146.88,-87.5"/>
-<text text-anchor="start" x="122.12" y="-93.7" font-family="Times,serif" font-size="14.00">fut2</text>
+<text text-anchor="start" x="122.12" y="-93.7" font-family="serif" font-size="14.00">fut2</text>
 <polygon fill="none" stroke="black" points="119.12,-65 119.12,-87.5 146.88,-87.5 146.88,-65 119.12,-65"/>
-<text text-anchor="start" x="129.62" y="-71.2" font-family="Times,serif" font-size="14.00">0</text>
+<text text-anchor="start" x="129.62" y="-71.2" font-family="serif" font-size="14.00">0</text>
 <polygon fill="none" stroke="black" points="119.12,-42.5 119.12,-65 146.88,-65 146.88,-42.5 119.12,-42.5"/>
-<text text-anchor="start" x="129.62" y="-48.7" font-family="Times,serif" font-size="14.00">1</text>
+<text text-anchor="start" x="129.62" y="-48.7" font-family="serif" font-size="14.00">1</text>
 <polygon fill="none" stroke="black" points="119.12,-20 119.12,-42.5 146.88,-42.5 146.88,-20 119.12,-20"/>
-<text text-anchor="start" x="131.12" y="-26.2" font-family="Times,serif" font-size="14.00"> </text>
+<text text-anchor="start" x="131.12" y="-26.2" font-family="serif" font-size="14.00"> </text>
 </g>
 <!-- fut2&#45;&gt;fut1 -->
 <g id="edge1" class="edge">

--- a/src/img/trpl17-06.svg
+++ b/src/img/trpl17-06.svg
@@ -14,20 +14,20 @@
 <g id="clust2" class="cluster">
 <title>cluster_box_internal</title>
 <polygon fill="none" stroke="black" points="82,-88 82,-132 111.5,-132 111.5,-88 82,-88"/>
-<text text-anchor="middle" x="96.75" y="-114.7" font-family="Times,serif" font-size="14.00">b1</text>
+<text text-anchor="middle" x="96.75" y="-114.7" font-family="serif" font-size="14.00">b1</text>
 </g>
 <g id="clust3" class="cluster">
 <title>cluster_deref</title>
 <polygon fill="none" stroke="black" stroke-width="2" points="131.5,-8 131.5,-169 201.5,-169 201.5,-8 131.5,-8"/>
-<text text-anchor="middle" x="166.5" y="-151.7" font-family="Times,serif" font-size="14.00">pinned</text>
+<text text-anchor="middle" x="166.5" y="-151.7" font-family="serif" font-size="14.00">pinned</text>
 </g>
 <!-- pinned_box -->
 <g id="node1" class="node">
 <title>pinned_box</title>
 <polyline fill="none" stroke="black" points="15,-109 39,-109"/>
-<text text-anchor="start" x="18" y="-115.2" font-family="Times,serif" font-size="14.00">Pin</text>
+<text text-anchor="start" x="18" y="-115.2" font-family="serif" font-size="14.00">Pin</text>
 <polygon fill="none" stroke="black" points="15,-86.5 15,-109 39,-109 39,-86.5 15,-86.5"/>
-<text text-anchor="start" x="25.12" y="-92.7" font-family="Times,serif" font-size="14.00"> </text>
+<text text-anchor="start" x="25.12" y="-92.7" font-family="serif" font-size="14.00"> </text>
 </g>
 <!-- pin -->
 <g id="node2" class="node">
@@ -43,15 +43,15 @@
 <g id="node3" class="node">
 <title>box</title>
 <polyline fill="none" stroke="black" points="156,-109.75 177,-109.75"/>
-<text text-anchor="start" x="159" y="-115.95" font-family="Times,serif" font-size="14.00">fut</text>
+<text text-anchor="start" x="159" y="-115.95" font-family="serif" font-size="14.00">fut</text>
 <polygon fill="none" stroke="black" points="156,-87.25 156,-109.75 177,-109.75 177,-87.25 156,-87.25"/>
-<text text-anchor="start" x="163.12" y="-93.45" font-family="Times,serif" font-size="14.00">0</text>
+<text text-anchor="start" x="163.12" y="-93.45" font-family="serif" font-size="14.00">0</text>
 <polygon fill="none" stroke="black" points="156,-64.75 156,-87.25 177,-87.25 177,-64.75 156,-64.75"/>
-<text text-anchor="start" x="164.62" y="-70.95" font-family="Times,serif" font-size="14.00"> </text>
+<text text-anchor="start" x="164.62" y="-70.95" font-family="serif" font-size="14.00"> </text>
 <polygon fill="none" stroke="black" stroke-dasharray="5,2" points="156,-42.25 156,-64.75 177,-64.75 177,-42.25 156,-42.25"/>
-<text text-anchor="start" x="160.88" y="-48.45" font-family="Times,serif" font-size="14.00">...</text>
+<text text-anchor="start" x="160.88" y="-48.45" font-family="serif" font-size="14.00">...</text>
 <polygon fill="none" stroke="black" points="156,-19.75 156,-42.25 177,-42.25 177,-19.75 156,-19.75"/>
-<text text-anchor="start" x="163.12" y="-25.95" font-family="Times,serif" font-size="14.00">1</text>
+<text text-anchor="start" x="163.12" y="-25.95" font-family="serif" font-size="14.00">1</text>
 </g>
 <!-- pin&#45;&gt;box -->
 <g id="edge2" class="edge">

--- a/src/img/trpl17-07.svg
+++ b/src/img/trpl17-07.svg
@@ -20,7 +20,7 @@
 <g id="clust4" class="cluster">
 <title>cluster_box_2_internal</title>
 <polygon fill="lightgrey" stroke="black" points="118.45,-156 118.45,-200 147.95,-200 147.95,-156 118.45,-156"/>
-<text text-anchor="middle" x="133.2" y="-182.7" font-family="Times,serif" font-size="14.00">b1</text>
+<text text-anchor="middle" x="133.2" y="-182.7" font-family="serif" font-size="14.00">b1</text>
 </g>
 <g id="clust5" class="cluster">
 <title>cluster_box_2</title>
@@ -28,20 +28,20 @@
 <g id="clust6" class="cluster">
 <title>cluster_box_2_internal</title>
 <polygon fill="none" stroke="black" points="118.45,-88 118.45,-132 147.95,-132 147.95,-88 118.45,-88"/>
-<text text-anchor="middle" x="133.2" y="-114.7" font-family="Times,serif" font-size="14.00">b2</text>
+<text text-anchor="middle" x="133.2" y="-114.7" font-family="serif" font-size="14.00">b2</text>
 </g>
 <g id="clust7" class="cluster">
 <title>cluster_target</title>
 <polygon fill="none" stroke="black" stroke-width="2" points="185.4,-8 185.4,-169 255.4,-169 255.4,-8 185.4,-8"/>
-<text text-anchor="middle" x="220.4" y="-151.7" font-family="Times,serif" font-size="14.00">pinned</text>
+<text text-anchor="middle" x="220.4" y="-151.7" font-family="serif" font-size="14.00">pinned</text>
 </g>
 <!-- pin -->
 <g id="node1" class="node">
 <title>pin</title>
 <polyline fill="none" stroke="black" points="31,-137 55,-137"/>
-<text text-anchor="start" x="34" y="-143.2" font-family="Times,serif" font-size="14.00">Pin</text>
+<text text-anchor="start" x="34" y="-143.2" font-family="serif" font-size="14.00">Pin</text>
 <polygon fill="none" stroke="black" points="31,-114.5 31,-137 55,-137 55,-114.5 31,-114.5"/>
-<text text-anchor="start" x="41.12" y="-120.7" font-family="Times,serif" font-size="14.00"> </text>
+<text text-anchor="start" x="41.12" y="-120.7" font-family="serif" font-size="14.00"> </text>
 </g>
 <!-- box1 -->
 <!-- pin&#45;&gt;box1 -->
@@ -60,15 +60,15 @@
 <g id="node4" class="node">
 <title>fut</title>
 <polyline fill="none" stroke="black" points="209.9,-109.75 230.9,-109.75"/>
-<text text-anchor="start" x="212.9" y="-115.95" font-family="Times,serif" font-size="14.00">fut</text>
+<text text-anchor="start" x="212.9" y="-115.95" font-family="serif" font-size="14.00">fut</text>
 <polygon fill="none" stroke="black" points="209.9,-87.25 209.9,-109.75 230.9,-109.75 230.9,-87.25 209.9,-87.25"/>
-<text text-anchor="start" x="217.03" y="-93.45" font-family="Times,serif" font-size="14.00">0</text>
+<text text-anchor="start" x="217.03" y="-93.45" font-family="serif" font-size="14.00">0</text>
 <polygon fill="none" stroke="black" points="209.9,-64.75 209.9,-87.25 230.9,-87.25 230.9,-64.75 209.9,-64.75"/>
-<text text-anchor="start" x="218.53" y="-70.95" font-family="Times,serif" font-size="14.00"> </text>
+<text text-anchor="start" x="218.53" y="-70.95" font-family="serif" font-size="14.00"> </text>
 <polygon fill="none" stroke="black" stroke-dasharray="5,2" points="209.9,-42.25 209.9,-64.75 230.9,-64.75 230.9,-42.25 209.9,-42.25"/>
-<text text-anchor="start" x="214.78" y="-48.45" font-family="Times,serif" font-size="14.00">...</text>
+<text text-anchor="start" x="214.78" y="-48.45" font-family="serif" font-size="14.00">...</text>
 <polygon fill="none" stroke="black" points="209.9,-19.75 209.9,-42.25 230.9,-42.25 230.9,-19.75 209.9,-19.75"/>
-<text text-anchor="start" x="217.03" y="-25.95" font-family="Times,serif" font-size="14.00">1</text>
+<text text-anchor="start" x="217.03" y="-25.95" font-family="serif" font-size="14.00">1</text>
 </g>
 <!-- box2&#45;&gt;fut -->
 <g id="edge4" class="edge">

--- a/src/img/trpl17-08.svg
+++ b/src/img/trpl17-08.svg
@@ -11,15 +11,15 @@
 <g id="clust1" class="cluster">
 <title>cluster_deref</title>
 <polygon fill="none" stroke="black" stroke-dasharray="5,2" points="82,-8 82,-85 251.1,-85 251.1,-8 82,-8"/>
-<text text-anchor="middle" x="166.55" y="-67.7" font-family="Times,serif" font-size="14.00">String</text>
+<text text-anchor="middle" x="166.55" y="-67.7" font-family="serif" font-size="14.00">String</text>
 </g>
 <!-- pinned_box -->
 <g id="node1" class="node">
 <title>pinned_box</title>
 <polyline fill="none" stroke="black" points="15,-45 39,-45"/>
-<text text-anchor="start" x="18" y="-51.2" font-family="Times,serif" font-size="14.00">Pin</text>
+<text text-anchor="start" x="18" y="-51.2" font-family="serif" font-size="14.00">Pin</text>
 <polygon fill="none" stroke="black" points="15,-22.5 15,-45 39,-45 39,-22.5 15,-22.5"/>
-<text text-anchor="start" x="25.12" y="-28.7" font-family="Times,serif" font-size="14.00"> </text>
+<text text-anchor="start" x="25.12" y="-28.7" font-family="serif" font-size="14.00"> </text>
 </g>
 <!-- pin -->
 <g id="node2" class="node">
@@ -35,17 +35,17 @@
 <g id="node3" class="node">
 <title>fut</title>
 <polygon fill="none" stroke="black" points="137.6,-22.75 137.6,-45.25 178.1,-45.25 178.1,-22.75 137.6,-22.75"/>
-<text text-anchor="start" x="140.6" y="-28.95" font-family="Times,serif" font-size="14.00">5usize</text>
+<text text-anchor="start" x="140.6" y="-28.95" font-family="serif" font-size="14.00">5usize</text>
 <polygon fill="none" stroke="black" points="178.1,-22.75 178.1,-45.25 190.85,-45.25 190.85,-22.75 178.1,-22.75"/>
-<text text-anchor="start" x="181.1" y="-28.95" font-family="Times,serif" font-size="14.00">h</text>
+<text text-anchor="start" x="181.1" y="-28.95" font-family="serif" font-size="14.00">h</text>
 <polygon fill="none" stroke="black" points="190.85,-22.75 190.85,-45.25 202.85,-45.25 202.85,-22.75 190.85,-22.75"/>
-<text text-anchor="start" x="193.85" y="-28.95" font-family="Times,serif" font-size="14.00">e</text>
+<text text-anchor="start" x="193.85" y="-28.95" font-family="serif" font-size="14.00">e</text>
 <polygon fill="none" stroke="black" points="202.85,-22.75 202.85,-45.25 212.6,-45.25 212.6,-22.75 202.85,-22.75"/>
-<text text-anchor="start" x="205.85" y="-28.95" font-family="Times,serif" font-size="14.00">l</text>
+<text text-anchor="start" x="205.85" y="-28.95" font-family="serif" font-size="14.00">l</text>
 <polygon fill="none" stroke="black" points="212.6,-22.75 212.6,-45.25 222.35,-45.25 222.35,-22.75 212.6,-22.75"/>
-<text text-anchor="start" x="215.6" y="-28.95" font-family="Times,serif" font-size="14.00">l</text>
+<text text-anchor="start" x="215.6" y="-28.95" font-family="serif" font-size="14.00">l</text>
 <polygon fill="none" stroke="black" points="222.35,-22.75 222.35,-45.25 235.1,-45.25 235.1,-22.75 222.35,-22.75"/>
-<text text-anchor="start" x="225.35" y="-28.95" font-family="Times,serif" font-size="14.00">o</text>
+<text text-anchor="start" x="225.35" y="-28.95" font-family="serif" font-size="14.00">o</text>
 </g>
 <!-- pin&#45;&gt;fut -->
 <g id="edge2" class="edge">

--- a/src/img/trpl17-09.svg
+++ b/src/img/trpl17-09.svg
@@ -14,15 +14,15 @@
 <g id="clust2" class="cluster">
 <title>cluster_deref</title>
 <polygon fill="none" stroke="black" stroke-dasharray="5,2" points="154,-16 154,-109 349.6,-109 349.6,-16 154,-16"/>
-<text text-anchor="middle" x="251.8" y="-91.7" font-family="Times,serif" font-size="14.00">String</text>
+<text text-anchor="middle" x="251.8" y="-91.7" font-family="serif" font-size="14.00">String</text>
 </g>
 <!-- pinned_box -->
 <g id="node1" class="node">
 <title>pinned_box</title>
 <polyline fill="none" stroke="black" points="59,-152 83,-152"/>
-<text text-anchor="start" x="62" y="-158.2" font-family="Times,serif" font-size="14.00">Pin</text>
+<text text-anchor="start" x="62" y="-158.2" font-family="serif" font-size="14.00">Pin</text>
 <polygon fill="none" stroke="black" points="59,-129.5 59,-152 83,-152 83,-129.5 59,-129.5"/>
-<text text-anchor="start" x="69.12" y="-135.7" font-family="Times,serif" font-size="14.00"> </text>
+<text text-anchor="start" x="69.12" y="-135.7" font-family="serif" font-size="14.00"> </text>
 </g>
 <!-- pin -->
 <g id="node3" class="node">
@@ -39,41 +39,41 @@
 <title>string1</title>
 <polygon fill="lightgray" stroke="none" points="24,-39 24,-83 118,-83 118,-39 24,-39"/>
 <polyline fill="none" stroke="black" points="24,-61 118,-61"/>
-<text text-anchor="start" x="65" y="-66.7" font-family="Times,serif" font-size="14.00">s1</text>
+<text text-anchor="start" x="65" y="-66.7" font-family="serif" font-size="14.00">s1</text>
 <polygon fill="none" stroke="black" points="24,-39 24,-61 64,-61 64,-39 24,-39"/>
-<text text-anchor="start" x="26.75" y="-44.7" font-family="Times,serif" font-size="14.00">5usize</text>
+<text text-anchor="start" x="26.75" y="-44.7" font-family="serif" font-size="14.00">5usize</text>
 <polygon fill="none" stroke="black" points="64,-39 64,-61 76,-61 76,-39 64,-39"/>
-<text text-anchor="start" x="66.62" y="-44.7" font-family="Times,serif" font-size="14.00">h</text>
+<text text-anchor="start" x="66.62" y="-44.7" font-family="serif" font-size="14.00">h</text>
 <polygon fill="none" stroke="black" points="76,-39 76,-61 88,-61 88,-39 76,-39"/>
-<text text-anchor="start" x="79" y="-44.7" font-family="Times,serif" font-size="14.00">e</text>
+<text text-anchor="start" x="79" y="-44.7" font-family="serif" font-size="14.00">e</text>
 <polygon fill="none" stroke="black" points="88,-39 88,-61 97,-61 97,-39 88,-39"/>
-<text text-anchor="start" x="90.62" y="-44.7" font-family="Times,serif" font-size="14.00">l</text>
+<text text-anchor="start" x="90.62" y="-44.7" font-family="serif" font-size="14.00">l</text>
 <polygon fill="none" stroke="black" points="97,-39 97,-61 106,-61 106,-39 97,-39"/>
-<text text-anchor="start" x="99.62" y="-44.7" font-family="Times,serif" font-size="14.00">l</text>
+<text text-anchor="start" x="99.62" y="-44.7" font-family="serif" font-size="14.00">l</text>
 <polygon fill="none" stroke="black" points="106,-39 106,-61 118,-61 118,-39 106,-39"/>
-<text text-anchor="start" x="108.62" y="-44.7" font-family="Times,serif" font-size="14.00">o</text>
+<text text-anchor="start" x="108.62" y="-44.7" font-family="serif" font-size="14.00">o</text>
 </g>
 <!-- string2 -->
 <g id="node4" class="node">
 <title>string2</title>
 <polyline fill="none" stroke="black" points="209.6,-50 333.6,-50"/>
-<text text-anchor="start" x="265.6" y="-55.7" font-family="Times,serif" font-size="14.00">s2</text>
+<text text-anchor="start" x="265.6" y="-55.7" font-family="serif" font-size="14.00">s2</text>
 <polygon fill="none" stroke="black" points="209.6,-28 209.6,-50 249.6,-50 249.6,-28 209.6,-28"/>
-<text text-anchor="start" x="212.35" y="-33.7" font-family="Times,serif" font-size="14.00">7usize</text>
+<text text-anchor="start" x="212.35" y="-33.7" font-family="serif" font-size="14.00">7usize</text>
 <polygon fill="none" stroke="black" points="249.6,-28 249.6,-50 261.6,-50 261.6,-28 249.6,-28"/>
-<text text-anchor="start" x="252.23" y="-33.7" font-family="Times,serif" font-size="14.00">g</text>
+<text text-anchor="start" x="252.23" y="-33.7" font-family="serif" font-size="14.00">g</text>
 <polygon fill="none" stroke="black" points="261.6,-28 261.6,-50 273.6,-50 273.6,-28 261.6,-28"/>
-<text text-anchor="start" x="264.23" y="-33.7" font-family="Times,serif" font-size="14.00">o</text>
+<text text-anchor="start" x="264.23" y="-33.7" font-family="serif" font-size="14.00">o</text>
 <polygon fill="none" stroke="black" points="273.6,-28 273.6,-50 285.6,-50 285.6,-28 273.6,-28"/>
-<text text-anchor="start" x="276.23" y="-33.7" font-family="Times,serif" font-size="14.00">o</text>
+<text text-anchor="start" x="276.23" y="-33.7" font-family="serif" font-size="14.00">o</text>
 <polygon fill="none" stroke="black" points="285.6,-28 285.6,-50 297.6,-50 297.6,-28 285.6,-28"/>
-<text text-anchor="start" x="288.23" y="-33.7" font-family="Times,serif" font-size="14.00">d</text>
+<text text-anchor="start" x="288.23" y="-33.7" font-family="serif" font-size="14.00">d</text>
 <polygon fill="none" stroke="black" points="297.6,-28 297.6,-50 309.6,-50 309.6,-28 297.6,-28"/>
-<text text-anchor="start" x="300.23" y="-33.7" font-family="Times,serif" font-size="14.00">b</text>
+<text text-anchor="start" x="300.23" y="-33.7" font-family="serif" font-size="14.00">b</text>
 <polygon fill="none" stroke="black" points="309.6,-28 309.6,-50 321.6,-50 321.6,-28 309.6,-28"/>
-<text text-anchor="start" x="312.23" y="-33.7" font-family="Times,serif" font-size="14.00">y</text>
+<text text-anchor="start" x="312.23" y="-33.7" font-family="serif" font-size="14.00">y</text>
 <polygon fill="none" stroke="black" points="321.6,-28 321.6,-50 333.6,-50 333.6,-28 321.6,-28"/>
-<text text-anchor="start" x="324.6" y="-33.7" font-family="Times,serif" font-size="14.00">e</text>
+<text text-anchor="start" x="324.6" y="-33.7" font-family="serif" font-size="14.00">e</text>
 </g>
 <!-- pin&#45;&gt;string2 -->
 <g id="edge2" class="edge">


### PR DESCRIPTION
Fixes #1154

Replaces hard-coded `Times,serif` font families in SVG images with the
generic `serif` family to avoid platform-specific font assumptions and
ensure more consistent rendering across systems.
