### PR TITLE
Change filter closure to use move semantics

### DIFF
--- a/listings/ch13-functional-features/listing-13-22/src/lib.rs
+++ b/listings/ch13-functional-features/listing-13-22/src/lib.rs
@@ -2,7 +2,7 @@
 pub fn search<'a>(query: &str, contents: &'a str) -> Vec<&'a str> {
     contents
         .lines()
-        .filter(|line| line.contains(query))
+        .filter(move |line| line.contains(query))
         .collect()
 }
 // ANCHOR_END: here


### PR DESCRIPTION
Without the move, the function search will not compile with the following message

```
closure may outlive the current function, but it borrows `query`, which is owned by the current function
may outlive borrowed value `query`
```