### PR TITLE
Use recommended message style in example

### DIFF
--- a/src/ch03-02-data-types.md
+++ b/src/ch03-02-data-types.md
@@ -13,7 +13,7 @@ Number”][comparing-the-guess-to-the-secret-number]<!-- ignore --> section in
 Chapter 2, we must add a type annotation, like this:
 
 ```rust
-let guess: u32 = "42".parse().expect("Not a number!");
+let guess: u32 = "42".parse().expect("value should parse to a number");
 ```
 
 If we don’t add the `: u32` type annotation shown in the preceding code, Rust


### PR DESCRIPTION
The first example in ch03-02 had a message in the `expect` call written contrary to style recommendations in 

https://doc.rust-lang.org/stable/std/error/index.html#common-message-styles

The example was not *wrong*, just missing an opportunity to reinforce style norms for beginners.