### PR TITLE
Clarify PATH directory for Rust installation troubleshooting

### DIFF
--- a/src/ch01-01-installation.md
+++ b/src/ch01-01-installation.md
@@ -106,6 +106,20 @@ In Linux and macOS, use:
 $ echo $PATH
 ```
 
+Ensure that the directory containing `.cargo` is present in your `PATH` variables. If you installed Rust using `rustup` with the default settings, these variables are:
+
+Windows:
+
+```text
+%USERPROFILE%\.cargo\bin
+```
+
+Linux and macOS:
+
+```text
+$HOME/.cargo/bin
+```
+
 If that’s all correct and Rust still isn’t working, there are a number of
 places you can get help. Find out how to get in touch with other Rustaceans (a
 silly nickname we call ourselves) on [the community page][community].


### PR DESCRIPTION
The troubleshooting section mentions to check for Rust in system variables for Windows, Linux, and macOS; however, it does not explicitly state which path directory it should be present. 

This change adds the default cargo bin directory when using `rustup` for:
- Windows
- Linux
- macOS

I hope this clarification may be more direct about verifying PATH configs.