### PR TITLE
trpl: remove build status badge from README

### DIFF
--- a/packages/trpl/README.md
+++ b/packages/trpl/README.md
@@ -1,7 +1,5 @@
 # The Rust Programming Language Book Crate
 
-![Build Status](https://github.com/chriskrycho/trpl-crate/workflows/CI/badge.svg)
-
 This repository is the home of the `trpl` crate used in _The Rust Programming
 Language_ book materials.
 


### PR DESCRIPTION
The crate is no longer at `chriskrycho/trpl-crate` (which returns a 404 error) and there is not a dedicated workflow on the main book repo that could be linked to instead.