### PR TITLE
Minor change to 8.3

### DIFF
--- a/src/ch08-03-hash-maps.md
+++ b/src/ch08-03-hash-maps.md
@@ -202,7 +202,7 @@ whitespace, of the value in `text`. The `or_insert` method returns a mutable
 reference (`&mut V`) to the value for the specified key. Here, we store that
 mutable reference in the `count` variable, so in order to assign to that value,
 we must first dereference `count` using the asterisk (`*`). The mutable
-reference goes out of scope at the end of the `for` loop, so all of these
+reference goes out of scope after each iteration of the `for` loop, so all of these
 changes are safe and allowed by the borrowing rules.
 
 ### Hashing Functions


### PR DESCRIPTION
> The mutable reference goes out of scope **at the end** of the for loop, so all of these changes are safe and allowed by the borrowing rules.

is changed to

> The mutable reference goes out of scope **after each iteration** of the for loop, so all of these changes are safe and allowed by the borrowing rules.

I believe this wording better clarifies *why* the changes are safe. With the old wording, the reader may be led to believe that every mutable reference remains in scope until the end of the for loop. This would not be allowed by the borrow checker. The change makes it clear that each mutable reference goes out of scope after each iteration.

I'm sure most readers would figure this out on their own, but I figured I'd submit this in case it is worth changing.