### PR TITLE
Add Turkish translation link to appendix F

### DIFF
--- a/src/appendix-06-translation.md
+++ b/src/appendix-06-translation.md
@@ -30,3 +30,4 @@ For resources in languages other than English. Most are still in progress; see
 - [Tiếng Việt](https://github.com/tuanemdev/rust-book-vn)
 - [Italiano](https://nixxo.github.io/rust-lang-book-it/)
 - [বাংলা](https://github.com/IsmailHosenIsmailJames/rust-book-bn)
+- [Türkçe](https://hakantr.github.io/kitap-rs/)


### PR DESCRIPTION
Turkish translation of The Rust Programming Language book. Translation is mostly complete, minor reviews and fixes are ongoing.

Repository: https://github.com/hakantr/kitap-rs
Live site: https://hakantr.github.io/kitap-rs/