### PR TITLE
Clarify implicit unit return in functions chapter

### DIFF
--- a/src/ch03-03-how-functions-work.md
+++ b/src/ch03-03-how-functions-work.md
@@ -247,7 +247,7 @@ Compiling this code will produce an error, as follows:
 The main error message, `mismatched types`, reveals the core issue with this
 code. The definition of the function `plus_one` says that it will return an
 `i32`, but statements don’t evaluate to a value, which is expressed by `()`,
-the unit type. Therefore, nothing is returned, which contradicts the function
-definition and results in an error. In this output, Rust provides a message to
-possibly help rectify this issue: It suggests removing the semicolon, which
-would fix the error.
+the unit type. Therefore, the function implicitly returns `()`, which
+contradicts the function definition and results in an error. In this output,
+Rust provides a message to possibly help rectify this issue: It suggests
+removing the semicolon, which would fix the error.


### PR DESCRIPTION
Closes #4678

## Summary
- replace the phrase "nothing is returned" with wording that matches the compiler output
- explain that adding the semicolon makes `plus_one` implicitly return `()`, the unit type

## Validation
- `mdbook build`

## Notes
- AI-assisted: I used Sisyphus to help draft and validate this wording change, and I reviewed the final diff before submission.