### PR TITLE
Ch. 4: Clarify definition on reference/variable scope (#4706)

### DIFF
--- a/src/ch04-02-references-and-borrowing.md
+++ b/src/ch04-02-references-and-borrowing.md
@@ -171,8 +171,10 @@ from under them! However, multiple immutable references are allowed because no
 one who is just reading the data has the ability to affect anyone else’s
 reading of the data.
 
-Note that a reference’s scope starts from where it is introduced and continues
-through the last time that reference is used. For instance, this code will
+Note that a reference's scope is different from the variable scope we discussed
+earlier. While a variable's scope extends to the end of the block where it is declared,
+a reference's scope starts from where it is introduced and continues through
+the last time that reference is used. For instance, this code will
 compile because the last usage of the immutable references is in the `println!`,
 before the mutable reference is introduced:
 


### PR DESCRIPTION
Fix: #4706

Clarified the definition of variable scope and reference scope is different, since both two definition are used implicitly different in same chapter. 