### PR TITLE
Add readability note about shadowing in ch03-01

### DIFF
--- a/src/ch03-01-variables-and-mutability.md
+++ b/src/ch03-01-variables-and-mutability.md
@@ -183,6 +183,9 @@ The error says we’re not allowed to mutate a variable’s type:
 {{#include ../listings/ch03-common-programming-concepts/no-listing-05-mut-cant-change-types/output.txt}}
 ```
 
+> Note: Shadowing is often most useful for short, local transformations.
+> Overusing it across larger or nested scopes can make code harder to read.
+
 Now that we’ve explored how variables work, let’s look at more data types they
 can have.
 


### PR DESCRIPTION
This adds a short note to the shadowing section to clarify a readability tradeoff.

Shadowing is often useful for short, local transformations, but it can become harder to follow when overused across larger or nested scopes. Since the section includes an example of shadowing across scope, this note briefly highlights that readability concern for learners.
