### PR TITLE
fix: Improve clarity & grammar on smart pointer traits

### DIFF
--- a/src/ch15-00-smart-pointers.md
+++ b/src/ch15-00-smart-pointers.md
@@ -25,7 +25,7 @@ Smart pointers are usually implemented using structs. Unlike an ordinary
 struct, smart pointers implement the `Deref` and `Drop` traits. The `Deref`
 trait allows an instance of the smart pointer struct to behave like a reference
 so that you can write your code to work with either references or smart
-pointers. The `Drop` trait allows you to customize the code that’s run when an
+pointers. The `Drop` trait allows you to customize the code that runs when an
 instance of the smart pointer goes out of scope. In this chapter, we’ll discuss
 both of these traits and demonstrate why they’re important to smart pointers.
 


### PR DESCRIPTION
Clarify the explanation of the `Deref` and `Drop` traits in relation to smart pointers.

```diff
The Drop trait allows you to customize the code 
- that’s run
+ that runs
when an instance of the smart pointer goes out of scope.
````