### PR TITLE
Clarify final expression return wording in ch09-02

### DIFF
--- a/src/ch09-02-recoverable-errors-with-result.md
+++ b/src/ch09-02-recoverable-errors-with-result.md
@@ -291,8 +291,9 @@ handle that `Result`: If `read_to_string` succeeds, then our function has
 succeeded, and we return the username from the file that’s now in `username`
 wrapped in an `Ok`. If `read_to_string` fails, we return the error value in the
 same way that we returned the error value in the `match` that handled the
-return value of `File::open`. However, we don’t need to explicitly say
-`return`, because this is the last expression in the function.
+return value of `File::open`. However, we don’t need to explicitly say `return`
+before the final `match`, because the entire `match` expression is the last
+expression in the function, so its value is returned.
 
 The code that calls this code will then handle getting either an `Ok` value
 that contains a username or an `Err` value that contains an `io::Error`. It’s


### PR DESCRIPTION
The current wording says “this is the last expression in the function,” which may be read as referring to Err(e) in the Err arm rather than to the entire match expression. This change makes that more explicit for learners.

It rewords the sentence to:

However, we don’t need to explicitly say return before the final match, because the entire match expression is the last expression in the function, so its value is returned.

When reading this section, I initially interpreted the earlier Err(e) => return Err(e) as a pattern that also applied to the final match. In that reading, the omitted return can seem unclear, especially for the Ok(username) arm. This change clarifies that the omitted idiomatic return applies to the entire final match, not to an individual arm.