### PR TITLE
Fix Write() method in ch06 listing 04

### DIFF
--- a/listings/ch06-enums-and-pattern-matching/no-listing-04-structs-similar-to-message-enum/src/main.rs
+++ b/listings/ch06-enums-and-pattern-matching/no-listing-04-structs-similar-to-message-enum/src/main.rs
@@ -4,7 +4,7 @@ struct MoveMessage {
     x: i32,
     y: i32,
 }
-struct WriteMessage(String); // tuple struct
+struct Write(String); // tuple struct
 struct ChangeColorMessage(i32, i32, i32); // tuple struct
 // ANCHOR_END: here
 


### PR DESCRIPTION
The following code snippet in ch06-01-defining-an-enum.md calls a Write() method, instead of WriteMessage().