### PR TITLE
Chapter 18 part 3: fix incorrect implication about constructing `Post`s

### DIFF
--- a/src/ch18-03-oo-design-patterns.md
+++ b/src/ch18-03-oo-design-patterns.md
@@ -119,9 +119,9 @@ want a post to start in.
 When we create a new `Post`, we set its `state` field to a `Some` value that
 holds a `Box`. This `Box` points to a new instance of the `Draft` struct. This
 ensures that whenever we create a new instance of `Post`, it will start out as
-a draft. Because the `state` field of `Post` is private, there is no way to
-create a `Post` in any other state! In the `Post::new` function, we set the
-`content` field to a new, empty `String`.
+a draft. Because the `state` field of `Post` is private, there is no way for
+code using our library to create a `Post` in any other state! In the `Post::new`
+function, we set the `content` field to a new, empty `String`.
 
 #### Storing the Text of the Post Content
 


### PR DESCRIPTION
The fact that `state` is private means that there is no way *for code outside of the defining module* to create a `Post` any way other than using `::new()`. It is still possible for code within the module to construct instances. Clarify that code using the library cannot create a `Post` with any other starting state.