### PR TITLE
Update rand example to fix breaking changes in v0.10.1

### DIFF
--- a/listings/ch02-guessing-game-tutorial/listing-02-03/Cargo.toml
+++ b/listings/ch02-guessing-game-tutorial/listing-02-03/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2024"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rand = "0.8.5"
+rand = "0.10.1"

--- a/listings/ch02-guessing-game-tutorial/listing-02-03/src/main.rs
+++ b/listings/ch02-guessing-game-tutorial/listing-02-03/src/main.rs
@@ -9,7 +9,7 @@ fn main() {
     println!("Guess the number!");
 
     // ANCHOR: ch07-04
-    let secret_number = rand::thread_rng().gen_range(1..=100);
+    let secret_number = (rng.next_u32() % 100) as u32 + 1;
     // ANCHOR_END: ch07-04
 
     println!("The secret number is: {secret_number}");


### PR DESCRIPTION
Since new users tend to use the latest version of crates instead of the specific versions mentioned in the text, I have updated the rand crate to the latest version (v10.1) to ensure a seamless learning experience.

The rand::thread_rng() function has been updated to the new rand::rng() API introduced in recent versions.

Changes:
  - Cargo.toml: Upgraded rand dependency to 0.10.1.
  - listings/ch02-guessing-game-tutorial: Updated listing-02-03/src/main.rs to replace rand::thread_rng() with rand::rng().

Impact:
This change prevents "method not found" errors for beginners who unknowingly install the latest version of the rand crate while following the Guessing Game tutorial.