### PR TITLE
Clarify byte literal usage in first_word example

### DIFF
--- a/src/ch04-03-slices.md
+++ b/src/ch04-03-slices.md
@@ -64,9 +64,10 @@ for the index in the tuple and `&item` for the single byte in the tuple.
 Because we get a reference to the element from `.iter().enumerate()`, we use
 `&` in the pattern.
 
-Inside the `for` loop, we search for the byte that represents the space by
-using the byte literal syntax. If we find a space, we return the position.
-Otherwise, we return the length of the string by using `s.len()`.
+Inside the `for` loop, we check whether each byte is an ASCII space character
+by comparing it to the byte literal `b' '`. The `b` prefix creates a byte
+literal of type `u8`. If we find a space, we return the position. Otherwise,
+we return the length of the string by using `s.len()`.
 
 ```rust,ignore
 {{#rustdoc_include ../listings/ch04-understanding-ownership/listing-04-07/src/main.rs:inside_for}}


### PR DESCRIPTION
While reading Chapter 4, I found the explanation around `b' '` being unclear.

The original text mentions "byte literal syntax" but doesn't explain what `b' '` represents. 

This change clarifies that the loop compares bytes from `s.as_bytes()` against the byte literal `b' '`, which represents an ASCII space character, and briefly explains the `b` prefix.