### PR TITLE
feat: add rust playground ide online link button

### DIFF
--- a/ferris.js
+++ b/ferris.js
@@ -24,6 +24,31 @@ document.addEventListener("DOMContentLoaded", () => {
   for (let ferrisType of FERRIS_TYPES) {
     attachFerrises(ferrisType);
   }
+
+  // Rust Playground IDE button
+  const rightButtons = document.querySelector(".right-buttons");
+  if (rightButtons) {
+    const ideLink = document.createElement("a");
+    ideLink.setAttribute("href", "https://play.rust-lang.org/");
+    ideLink.setAttribute("target", "_blank");
+    ideLink.setAttribute("rel", "noopener noreferrer");
+    ideLink.setAttribute("title", "Rust Playground");
+    ideLink.setAttribute("aria-label", "Rust Playground");
+
+    // code-editor SVG icon 
+    ideLink.innerHTML =
+      '<span class="fa-svg">' +
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512">' +
+      "<!--! Font Awesome Free 6.2.0 by @fontawesome - https://fontawesome.com " +
+      "License - https://fontawesome.com/license/free " +
+      "(Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) " +
+      "Copyright 2022 Fonticons, Inc. -->" +
+      '<path d="M9.4 86.6C-3.1 74.1-3.1 53.9 9.4 41.4s32.8-12.5 45.3 0l192 192c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L178.7 256 9.4 86.6zM256 416H544c17.7 0 32 14.3 32 32s-14.3 32-32 32H256c-17.7 0-32-14.3-32-32s14.3-32 32-32z"/>' +
+      "</svg>" +
+      "</span>";
+
+    rightButtons.appendChild(ideLink);
+  }
 });
 
 /**


### PR DESCRIPTION

- Close #4762 

Add Rust Playground IDE onlilne button to navbar

Injects an IDE button into the right-hand navbar alongside the
existing GitHub and print buttons. Clicking it opens
play.rust-lang.org in a new tab. The logic is merged into
ferris.js to avoid a separate additional-js entry.



https://github.com/user-attachments/assets/35270216-d6f7-4a00-8fec-ba249e18f97e


## Here is the Button  Look like 

<img width="457" height="351" alt="Screenshot From 2026-06-06 19-58-19" src="https://github.com/user-attachments/assets/8b4e665d-e7cd-46bf-ab8a-77c37e046df5" />
