### PR TITLE
docs: remove legacy lifetimes comment in introduction

### DIFF
--- a/src/ch00-00-introduction.md
+++ b/src/ch00-00-introduction.md
@@ -154,8 +154,8 @@ concurrency model they enable.
 principles you might be familiar with. **Chapter 19** is a reference on
 patterns and pattern matching, which are powerful ways of expressing ideas
 throughout Rust programs. **Chapter 20** contains a smorgasbord of advanced
-topics of interest, including unsafe Rust, macros, and more about lifetimes,
-traits, types, functions, and closures.
+topics of interest, including unsafe Rust, macros, traits, types, functions,
+and closures.
 
 In **Chapter 21**, we’ll complete a project in which we’ll implement a
 low-level multithreaded web server!


### PR DESCRIPTION
Reason: 🧠 See commits c57c0777, 10f89936, 201a57d9, 022a046d🧠