### PR TITLE
Slice 'first' confused

### DIFF
--- a/src/ch04-03-slices.md
+++ b/src/ch04-03-slices.md
@@ -306,9 +306,9 @@ part of an array. We’d do so like this:
 ```rust
 let a = [1, 2, 3, 4, 5];
 
-let slice = &a[1..3];
+let slice = &a[2..4];
 
-assert_eq!(slice, &[2, 3]);
+assert_eq!(slice, &[3, 4]);
 ```
 
 This slice has the type `&[i32]`. It works the same way as string slices do, by

--- a/src/ch04-03-slices.md
+++ b/src/ch04-03-slices.md
@@ -312,7 +312,7 @@ assert_eq!(slice, &[3, 4]);
 ```
 
 This slice has the type `&[i32]`. It works the same way as string slices do, by
-storing a reference to the first element and a length. You’ll use this kind of
+storing a reference to its first element and a length. You’ll use this kind of
 slice for all sorts of other collections. We’ll discuss these collections in
 detail when we talk about vectors in Chapter 8.
 


### PR DESCRIPTION
In a discussion, due to the translation of `first element` as `1st element`, some people understood it as `1st element of variable a`

Then he felt confused about `1st element of variable a should be a[0]`
