### PR TITLE
docs: add Indonesian translation to appendix

### DIFF
--- a/ci/dictionary.txt
+++ b/ci/dictionary.txt
@@ -16,6 +16,7 @@ allocator
 AlwaysEqual
 Amir
 anotherusername
+anugrahzeputra
 APIs
 app's
 aren
@@ -33,6 +34,7 @@ backtrace
 backtraces
 BACKTRACE
 Backtraces
+bahasa
 Baz's
 beefeb
 benchmarking
@@ -248,6 +250,7 @@ ImportantExcerpt
 incrementing
 IndexMut
 indices
+indonesia
 init
 initializer
 initializers

--- a/src/appendix-06-translation.md
+++ b/src/appendix-06-translation.md
@@ -30,3 +30,4 @@ For resources in languages other than English. Most are still in progress; see
 - [Tiếng Việt](https://github.com/tuanemdev/rust-book-vn)
 - [Italiano](https://nixxo.github.io/rust-lang-book-it/)
 - [বাংলা](https://github.com/IsmailHosenIsmailJames/rust-book-bn)
+- [Bahasa Indonesia](https://anugrahzeputra.github.io/rust-book) ([Source](https://github.com/anugrahzeputra/rust-book))


### PR DESCRIPTION
Hi! I have completed the full Indonesian translation of the Rust book. You can find the hosted version here:
  https://anugrahzeputra.github.io/rust-book/. This PR adds the link to the official translation appendix.

I am also new in open source contributions. please give me feedback, so I can improve or do what you need. thanks :)