### PR TITLE
docs(ch13-02): fix typo 'iteration' to 'iterator' in filter example (#4705)

### DIFF
--- a/src/ch13-02-iterators.md
+++ b/src/ch13-02-iterators.md
@@ -196,7 +196,7 @@ their environment.
 
 For this example, we’ll use the `filter` method that takes a closure. The
 closure gets an item from the iterator and returns a `bool`. If the closure
-returns `true`, the value will be included in the iteration produced by
+returns `true`, the value will be included in the iterator produced by
 `filter`. If the closure returns `false`, the value won’t be included.
 
 In Listing 13-16, we use `filter` with a closure that captures the `shoe_size`


### PR DESCRIPTION
Fixes #4705

## Summary

In `src/ch13-02-iterators.md`, the sentence describing the result of `filter`:

> If the closure returns `true`, the value will be included in the iteration produced by `filter`.

should read "the **iterator** produced by `filter`". `filter` returns an iterator that lazily yields the chosen items — not an "iteration". The surrounding paragraph already uses "iterator" consistently (e.g. "the closure gets an item **from the iterator** and returns a `bool`"), so this single-word fix keeps the terminology aligned.

## Test plan

- [x] Verified the typo exists in the current rendered sentence at <https://doc.rust-lang.org/stable/book/ch13-02-iterators.html#closures-that-capture-their-environment>.
- [x] Confirmed `grep -n iteration src/ch13-02-iterators.md` shows only this one occurrence in the `filter` example ("the iteration produced by `filter`"); other uses of "iteration" in the file (e.g. "one **iteration** of the loop", "when **iteration** is over", "the **iteration** behavior that the `Iterator` trait provides") are correct usages and are intentionally left untouched.
- [x] Ran `dprint fmt src/ch13-02-iterators.md` (the formatter the repo uses for Markdown per `CONTRIBUTING.md`) and confirmed there are no further formatting changes — the single-word fix is already dprint-clean.
- [x] `git diff --stat` reports `1 file changed, 1 insertion(+), 1 deletion(-)`.

## AI assistance

Used an AI coding assistant (Claude Code) to identify the affected line, write the patch, and draft this PR description. The change itself is a single-word substitution that I verified by re-reading the affected paragraph and the file's other usages of "iteration" against `grep`.

