### PR TITLE
docs(ch03-02): clarify unsigned integers include zero (#4773)

### DIFF
--- a/src/ch03-02-data-types.md
+++ b/src/ch03-02-data-types.md
@@ -55,10 +55,11 @@ the type of an integer value.
 Each variant can be either signed or unsigned and has an explicit size.
 _Signed_ and _unsigned_ refer to whether it’s possible for the number to be
 negative—in other words, whether the number needs to have a sign with it
-(signed) or whether it will only ever be positive and can therefore be
-represented without a sign (unsigned). It’s like writing numbers on paper: When
-the sign matters, a number is shown with a plus sign or a minus sign; however,
-when it’s safe to assume the number is positive, it’s shown with no sign.
+(signed) or whether it's always non-negative (that is, zero or positive), so
+it can be represented without a sign (unsigned). It’s like writing numbers on
+paper: When the sign matters, a number is shown with a plus sign or a minus
+sign; however, when it’s safe to assume the number is positive, it’s shown
+with no sign.
 Signed numbers are stored using [two’s complement][twos-complement]<!-- ignore
 --> representation.
 


### PR DESCRIPTION
Fixes #4773

## Summary
Rust's unsigned integer types can represent zero and positive numbers
(non-negative), not just positive numbers. The current phrasing in
Chapter 3.2 ('only ever be positive') is mathematically imprecise.

This commit adopts the wording suggested in the issue: 'always
non-negative (that is, zero or positive), so it can be represented
without a sign'. Doc-only edit.

## Test plan
- [x] 'dprint check' on the touched file reports clean.
- [x] 'git diff' reviewed: single-file 5-line diff, no whitespace drift.
- [x] Suggested text from the issue body is used verbatim.

## AI assistance
Change prepared with help from an AI coding assistant. The diff was reviewed and edited before submission.