### PR TITLE
docs(ch02): clarify String is heap-allocated (#4758)

### DIFF
--- a/src/ch02-00-guessing-game-tutorial.md
+++ b/src/ch02-00-guessing-game-tutorial.md
@@ -156,7 +156,7 @@ want to bind something to the variable now. On the right of the equal sign is
 the value that `guess` is bound to, which is the result of calling
 `String::new`, a function that returns a new instance of a `String`.
 [`String`][string]<!-- ignore --> is a string type provided by the standard
-library that is a growable, UTF-8 encoded bit of text.
+library that is a heap-allocated, growable, UTF-8 encoded bit of text.
 
 The `::` syntax in the `::new` line indicates that `new` is an associated
 function of the `String` type. An _associated function_ is a function that’s


### PR DESCRIPTION
Fixes #4758

## Summary
The phrase 'a growable, UTF-8 encoded bit of text' in Chapter 2 is
grammatically ambiguous: 'growable' can be read as modifying 'bit of
text', which can mislead learners into thinking the value is mutable
by default. Adding 'heap-allocated' shifts the mental model to the
*container* while keeping the substantive content the same.

A one-word prepended qualifier is the minimum change that addresses
the issue's framing without rewriting the sentence structure.

## Test plan
- [x] `git diff` reviewed: single-file, single-line change, no whitespace drift.
- [x] dprint on the touched file reports pre-existing whitespace
  issues that exist in upstream main on multiple files. The fixed
  sentence is closer to dprint's expected layout than upstream; no
  additional formatting was applied to avoid touching unrelated files.

## AI assistance
Prepared with help from an AI coding assistant; reviewed end-to-end
before submission.