### PR TITLE
docs(ch03-01): clarify type-mismatch error in spaces example (#4772)

### DIFF
--- a/src/ch03-01-variables-and-mutability.md
+++ b/src/ch03-01-variables-and-mutability.md
@@ -177,7 +177,8 @@ here, we’ll get a compile-time error:
 {{#rustdoc_include ../listings/ch03-common-programming-concepts/no-listing-05-mut-cant-change-types/src/main.rs:here}}
 ```
 
-The error says we’re not allowed to mutate a variable’s type:
+The error indicates that we can’t assign a value of type `usize` to a
+variable of type `&str` because their types are incompatible:
 
 ```console
 {{#include ../listings/ch03-common-programming-concepts/no-listing-05-mut-cant-change-types/output.txt}}


### PR DESCRIPTION
Fixes #4772

## Summary
Chapter 3.1 currently says 'The error says we're not allowed to mutate
a variable's type' for the compile-time error in the 'spaces'
example. This wording is misleading because Rust's shadowing feature
*does* allow a variable's type to change; the actual error (E0308)
is a type-mismatch assignment.

This commit adopts the issue's suggested phrasing.

## Test plan
- [x] git diff reviewed: 2 insertions, 1 deletion, single file.
- [x] No other files touched.

## AI assistance
Prepared with help from an AI coding assistant; reviewed end-to-end.