### PR TITLE
docs(ch03-03): clarify statement evaluates to unit type (#4678)

### DIFF
--- a/src/ch03-03-how-functions-work.md
+++ b/src/ch03-03-how-functions-work.md
@@ -246,8 +246,8 @@ Compiling this code will produce an error, as follows:
 
 The main error message, `mismatched types`, reveals the core issue with this
 code. The definition of the function `plus_one` says that it will return an
-`i32`, but statements don’t evaluate to a value, which is expressed by `()`,
-the unit type. Therefore, nothing is returned, which contradicts the function
-definition and results in an error. In this output, Rust provides a message to
-possibly help rectify this issue: It suggests removing the semicolon, which
-would fix the error.
+`i32`, but statements evaluate to `()`, the unit type, which doesn’t satisfy
+the declared `i32` return type. This contradiction between the function’s
+declared return type and the actual type produced by the body results in an
+error. In this output, Rust provides a message to possibly help rectify this
+issue: It suggests removing the semicolon, which would fix the error.


### PR DESCRIPTION
Fixes #4678

## Summary
Chapter 3.3 says 'statements don't evaluate to a value, which is
expressed by (), the unit type. Therefore, nothing is returned'.
That wording implicitly names () then says 'nothing is returned',
contradicting the immediately preceding clause. Reword to one
unbroken sentence: statements evaluate to () which doesn't satisfy
the declared i32 return type.

The compiler error and the suggestion (remove the semicolon) remain
correct and unchanged.

## Test plan
- [x] git diff: single file, 5 insertions, 5 deletions.

## AI assistance
Prepared with help from an AI coding assistant; reviewed end-to-end.