### PR TITLE
fix(ch17-13): shorten tx_fut sleep to fit Playground timeout (#4689)

### DIFF
--- a/listings/ch17-async-await/listing-17-13/src/main.rs
+++ b/listings/ch17-async-await/listing-17-13/src/main.rs
@@ -38,7 +38,7 @@ fn main() {
 
             for val in vals {
                 tx.send(val).unwrap();
-                trpl::sleep(Duration::from_millis(1500)).await;
+                trpl::sleep(Duration::from_millis(750)).await;
             }
         };
 


### PR DESCRIPTION
Fixes #4689

## Summary
Listing 17-13 sleeps 1500ms between sends in the second producer
future, totalling 6000ms — over the Rust Playground's 5s JS timeout,
so the runnable example on the page times out before printing all
output.

Trimmed the sleep to 750ms. The example still demonstrates the
overlap behaviour of the two producers; total runtime is ~3s.

## Test plan
- [x] git diff: one-file, one-line change.
- [x] The example remains compilable (sleep duration is the only
  changed value).

## AI assistance
Prepared with help from an AI coding assistant.