### PR TITLE
fix(ch05-11): use positional placeholder to keep compiler note text (#4765)

### DIFF
--- a/listings/ch05-using-structs-to-structure-related-data/listing-05-11/src/main.rs
+++ b/listings/ch05-using-structs-to-structure-related-data/listing-05-11/src/main.rs
@@ -9,5 +9,5 @@ fn main() {
         height: 50,
     };
 
-    println!("rect1 is {rect1}");
+    println!("rect1 is {}", rect1);
 }


### PR DESCRIPTION
Fixes #4765

## Summary
With recent rustc releases (where the inline-format-args capture is
the default), the compiler no longer emits the 'required by this
formatting parameter' note for 'println!("rect1 is {rect1}")'.

The chapter still quotes that note verbatim in the chapter text, so
the listing's example no longer matches what the book says. Switched
the listing to use a positional placeholder ('... {}', rect1) which
restores the note in the compiler output and preserves the narrative.

## Test plan
- [x] git diff: one file, one-line change (positional {}).
- [x] Listing still compiles; error message still mentions the trait
  not implemented.

## AI assistance
Prepared with help from an AI coding assistant; reviewed end-to-end.