### PR TITLE
docs(ch04-02): clarify slice is a type, not a kind of reference (#4768)

### DIFF
--- a/src/ch04-02-references-and-borrowing.md
+++ b/src/ch04-02-references-and-borrowing.md
@@ -260,4 +260,4 @@ Let’s recap what we’ve discussed about references:
   number of immutable references.
 - References must always be valid.
 
-Next, we’ll look at a different kind of reference: slices.
+Next, we’ll look at a different type: slices, which are often used behind a reference.


### PR DESCRIPTION
Closes #4768

## Summary

Replace the section trailer

> Next, we'll look at a different kind of reference: slices.

with

> Next, we'll look at a different type: slices, which are often used behind a reference.

Slices are a dynamically sized type (`[T]`), not a kind of reference. The
section header just below this line calls them "Reference and Borrowing";
readers coming out of this chapter expect slices to be a flavor of
`&T`, but they're actually a DST that lives "behind" a shared reference.

This phrasing matches the issue suggester's recommended wording and is
consistent with the existing reference pages:

- <https://doc.rust-lang.org/reference/types/slice.html>
- <https://doc.rust-lang.org/reference/dynamically-sized-types.html>

## Test plan

- `mdbook test` (or just `mdbook build`) recompiles the chapter without
  warnings; the changed line is prose-only.

## AI assistance

Drafted with assistance from Claude; reviewed line by line before
submission.