### PR TITLE
docs(ch21-01): clarify HTTP request-header end-of-headers signaling (#4574)

### DIFF
--- a/src/ch21-01-single-threaded.md
+++ b/src/ch21-01-single-threaded.md
@@ -163,9 +163,10 @@ reading from the stream. Again, a production program should handle these errors
 more gracefully, but we’re choosing to stop the program in the error case for
 simplicity.
 
-The browser signals the end of an HTTP request by sending two newline
-characters in a row, so to get one request from the stream, we take lines until
-we get a line that is the empty string. Once we’ve collected the lines into the
+The browser signals the end of an HTTP request header by sending a
+carriage return and newline character twice in a row, so to get the
+headers of one request from the stream, we take lines until we get a
+line that is the empty string. Once we’ve collected the lines into the
 vector, we’re printing them out using pretty debug formatting so that we can
 take a look at the instructions the web browser is sending to our server.
 


### PR DESCRIPTION
Closes #4574

## Summary

Replace

> The browser signals the end of an HTTP request by sending two newline
> characters in a row, so to get one request from the stream, we take lines until
> we get a line that is the empty string.

with

> The browser signals the end of an HTTP request header by sending a
> carriage return and newline character twice in a row, so to get the
> headers of one request from the stream, we take lines until we get
> a line that is the empty string.

`\\r\\n\\r\\n` marks the end of the request headers, not the end of the
entire request — the request body (if any) follows the blank line and
is not delimited by another blank line. The original wording overstates
what the snippet parses.

Also tighten "so to get one request from the stream" to "so to get the
headers of one request", since the snippet below only reads header
lines.

## Test plan

- `mdbook build` compiles the chapter cleanly.
- `dprint fmt` reports no changes; the diff is whitespace-stable.

## AI assistance

Drafted with assistance from Claude; reviewed line by line before
submission. rust-lang/book has no formal AI policy, so this
disclosure is offered as good practice.