### PR TITLE
Clarify text about futures in a vector

### DIFF
--- a/src/ch17-05-traits-for-async.md
+++ b/src/ch17-05-traits-for-async.md
@@ -130,10 +130,11 @@ yet ready.
 ### The `Pin` Type and the `Unpin` Trait
 
 Back in Listing 17-13, we used the `trpl::join!` macro to await three
-futures. However, it’s common to have a collection such as a vector containing
-some number futures that won’t be known until runtime. Let’s change Listing
-17-13 to the code in Listing 17-23 that puts the three futures into a vector
-and calls the `trpl::join_all` function instead, which won’t compile yet.
+futures. However, it’s common to have a collection, such as a vector,
+containing many futures the exact number of which won’t be known until runtime.
+Let’s change Listing 17-13 to the code in Listing 17-23 that puts the three
+futures into a vector and calls the `trpl::join_all` function instead,
+which won’t compile yet.
 
 <Listing number="17-23" caption="Awaiting futures in a collection"  file-name="src/main.rs">
 


### PR DESCRIPTION
I thought about just adding the missing "of", but this way it clarifies that its not the futures themselves which are unknown until runtime, but the number of them.