### PR TITLE
Clarify non-method associated functions

### DIFF
--- a/src/ch05-03-method-syntax.md
+++ b/src/ch05-03-method-syntax.md
@@ -194,11 +194,11 @@ parameters in functions.
 ### Associated Functions
 
 All functions defined within an `impl` block are called _associated functions_
-because they’re associated with the type named after the `impl`. We can define
-associated functions that don’t have `self` as their first parameter (and thus
-are not methods) because they don’t need an instance of the type to work with.
-We’ve already used one function like this: the `String::from` function that’s
-defined on the `String` type.
+because they’re associated with the type named after the `impl`. Some
+associated functions do not need an instance of the type to work with, and
+therefore do not have self as their first parameter (and thus are not
+methods). We’ve already used one function like this: the `String::from`
+function that’s defined on the `String` type.
 
 Associated functions that aren’t methods are often used for constructors that
 will return a new instance of the struct. These are often called `new`, but


### PR DESCRIPTION
Note: This targets the same sentence as open PR #4615 
However, in their change, the sentence structure remains
Refactoring the sentence will better help clarification

Current text contains structural ambiguity
where readers could either read it as
"We can ... because ..." or
“We can define ... as ...”

Replacing this with a direct statement removes the ambiguity
and provides a clearer explanation that may better aid beginners