### PR TITLE
Clarify std::env::args encoding requirements

### DIFF
--- a/src/ch12-01-accepting-command-line-arguments.md
+++ b/src/ch12-01-accepting-command-line-arguments.md
@@ -59,9 +59,10 @@ mistaken for a function that’s defined in the current module.
 
 > ### The `args` Function and Invalid Unicode
 >
-> Note that `std::env::args` will panic if any argument contains invalid
-> Unicode. If your program needs to accept arguments containing invalid
-> Unicode, use `std::env::args_os` instead. That function returns an iterator
+> Note that `std::env::args` will panic if any argument can’t be represented as
+> a valid Rust `String`. This includes arguments that aren’t valid UTF-8 on Unix
+> or aren’t valid UTF-16 on Windows. If your program needs to accept such
+> arguments, use `std::env::args_os` instead. That function returns an iterator
 > that produces `OsString` values instead of `String` values. We’ve chosen to
 > use `std::env::args` here for simplicity because `OsString` values differ per
 > platform and are more complex to work with than `String` values.


### PR DESCRIPTION
Closes #4796.

Clarifies that `std::env::args` panics when an operating-system argument cannot be represented as a Rust `String`. The text now calls out the platform-specific cases: invalid UTF-8 on Unix and invalid UTF-16 on Windows.

This avoids implying that Unicode itself is invalid while remaining accurate across platforms.

Tested with:

- `npx --yes dprint check src/ch12-01-accepting-command-line-arguments.md`
- `mdbook build` using the CI version, 0.5.1
- `bash ci/validate.sh`
- `cargo run --bin lfp src`

AI-assisted: Codex. I verified the wording against the official `std::env::args` and `OsString` documentation and reviewed the generated HTML.
