### PR TITLE
Fix broken source links in mdbook-trpl README

### DIFF
--- a/packages/mdbook-trpl/README.md
+++ b/packages/mdbook-trpl/README.md
@@ -5,8 +5,8 @@ Programming Language_][trpl].
 
 Supplies the following preprocessor binaries:
 
-- [mdbook-trpl-note](./src/bin/note)
-- [mdbook-trpl-listing](./src/bin/listing)
+- [mdbook-trpl-note](./src/bin/note.rs)
+- [mdbook-trpl-listing](./src/bin/listing.rs)
 
 [mdbook]: https://crates.io/crates/mdbook
 [pre]: https://rust-lang.github.io/mdBook/format/configuration/preprocessors.html


### PR DESCRIPTION
The preprocessor binary links in `packages/mdbook-trpl/README.md` point at `./src/bin/note` and `./src/bin/listing`, which don't exist — the sources are `note.rs` and `listing.rs`, so both links 404 on GitHub.

One observation while here (left out to keep this minimal): `src/bin/` also contains `figure.rs` and `heading.rs`, which aren't listed in the README's preprocessor list — happy to add them in this PR if they're meant to be documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)