### PR TITLE
ch19-01: fix outdated claim that `if let` conditions can't be combined (let chains)

### DIFF
--- a/src/ch19-01-all-the-places-for-patterns.md
+++ b/src/ch19-01-all-the-places-for-patterns.md
@@ -162,10 +162,11 @@ background color`.
 You can see that `if let` can also introduce new variables that shadow existing
 variables in the same way that `match` arms can: The line `if let Ok(age) = age`
 introduces a new `age` variable that contains the value inside the `Ok` variant,
-shadowing the existing `age` variable. This means we need to place the `if age >
-30` condition within that block: We can’t combine these two conditions into `if
-let Ok(age) = age && age > 30`. The new `age` we want to compare to 30 isn’t
-valid until the new scope starts with the curly bracket.
+shadowing the existing `age` variable. In this example we place the `if age > 30` check inside the `if let
+Ok(age) = age` block, where the shadowed `age` is in scope. Since Rust 1.88,
+in the 2024 edition, *let chains* also let us combine the two conditions
+directly, as in `if let Ok(age) = age && age > 30` — the binding introduced by
+`if let` is available to the conditions that follow it in the chain.
 
 The downside of using `if let` expressions is that the compiler doesn’t check
 for exhaustiveness, whereas with `match` expressions it does. If we omitted the


### PR DESCRIPTION
Fixes #4612.

Chapter 19-01 ("Conditional `if let` Expressions") currently tells readers we *can't* write `if let Ok(age) = age && age > 30`. But **let chains** stabilized in **Rust 1.88**, and this book targets the **2024 edition** (`edition = "2024"`, toolchain 1.97) — where that combination is valid: the binding introduced by `if let` is in scope for the conditions that follow it in the chain. I verified the outdated text is still present on `main`, and the playground test in the issue confirms it compiles on stable.

This is a minimal wording fix: it keeps the nested example (which still usefully demonstrates mixing `if let` / `else if` / `else if let`) and replaces only the incorrect "we can't combine" sentence with an accurate note about let chains. Happy to adjust the framing if you'd prefer a different treatment. 🦀