### PR TITLE
Update `gen_range` to `random_range` in Appendix C

### DIFF
--- a/src/appendix-03-derivable-traits.md
+++ b/src/appendix-03-derivable-traits.md
@@ -93,9 +93,9 @@ value in each field in the order in which the fields appear in the struct
 definition. When derived on enums, variants of the enum declared earlier in the
 enum definition are considered less than the variants listed later.
 
-The `PartialOrd` trait is required, for example, for the `gen_range` method
-from the `rand` crate that generates a random value in the range specified by a
-range expression.
+The `PartialOrd` trait is required, for example, for the `random_range`
+method from the `rand` crate that generates a random value in the range
+specified by a range expression.
 
 The `Ord` trait allows you to know that for any two values of the annotated
 type, a valid ordering will exist. The `Ord` trait implements the `cmp` method,


### PR DESCRIPTION
rand 0.10 renamed `Rng::gen_range` to `random_range` (now provided by the `RngExt` trait). Appendix C still referenced the old name — the only remaining mention in `src/` after the upgrade to rand 0.10.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)