### PR TITLE
Made purpose of file handle accurate.

### DIFF
--- a/src/ch09-02-recoverable-errors-with-result.md
+++ b/src/ch09-02-recoverable-errors-with-result.md
@@ -73,8 +73,7 @@ before the `Ok` and `Err` variants in the `match` arms.
 
 When the result is `Ok`, this code will return the inner `file` value out of
 the `Ok` variant, and we then assign that file handle value to the variable
-`greeting_file`. After the `match`, we can use the file handle for reading or
-writing.
+`greeting_file`. After the `match`, we can use the file handle for reading.
 
 The other arm of the `match` handles the case where we get an `Err` value from
 `File::open`. In this example, we’ve chosen to call the `panic!` macro. If


### PR DESCRIPTION
The File::open() function opens the file only in read only mode, so the resulting handle can be used only for reading from the file. 

I updated the text by removing the text "or writing" to accurately reflect my finding. 

Yours respectfully,
Aravind A (Son Of Sindhu)