### PR TITLE
ch01: add `cargo fetch` to the working-offline setup steps

### DIFF
--- a/src/ch01-01-installation.md
+++ b/src/ch01-01-installation.md
@@ -170,11 +170,12 @@ what `cargo` is and what each of these commands does in detail later.)
 $ cargo new get-dependencies
 $ cd get-dependencies
 $ cargo add rand@0.10.1 trpl@0.2.0
+$ cargo fetch
 ```
 
-This will cache the downloads for these packages so you will not need to
-download them later. Once you have run this command, you do not need to keep the
-`get-dependencies` folder. If you have run this command, you can use the
+This will download and cache the packages so you will not need to download them
+later. Once you have run these commands, you do not need to keep the
+`get-dependencies` folder. If you have run these commands, you can use the
 `--offline` flag with all `cargo` commands in the rest of the book to use these
 cached versions instead of attempting to use the network.
 


### PR DESCRIPTION
## Summary

The "Working Offline with This Book" section instructs readers to run `cargo add rand@0.10.1 trpl@0.2.0` to cache dependencies, but `cargo add` only updates `Cargo.toml` and `Cargo.lock` — it does **not** download the `.crate` archives. As a result, subsequent `cargo` commands with `--offline` fail because the crate files are not present in the local registry.

Fixes #4817.

## Changes

- Add `cargo fetch` as a fourth step after `cargo add`, which downloads and caches the `.crate` files locally
- Update the prose from "Once you have run this command" → "Once you have run these commands" (plural)
- Update "If you have run this command" → "If you have run these commands" (plural)
- Fix "This will cache the downloads" → "This will download and cache the packages" for accuracy