### PR TITLE
Fix assignment direction in ch19-03 nested `_` example

### DIFF
--- a/src/ch19-03-pattern-syntax.md
+++ b/src/ch19-03-pattern-syntax.md
@@ -346,7 +346,7 @@ changed.
 
 In all other cases (if either `setting_value` or `new_setting_value` is `None`)
 expressed by the `_` pattern in the second arm, we want to allow
-`new_setting_value` to become `setting_value`.
+`setting_value` to become `new_setting_value`.
 
 We can also use underscores in multiple places within one pattern to ignore
 particular values. Listing 19-19 shows an example of ignoring the second and


### PR DESCRIPTION
## Summary

Fixes #4822.

The text in the "Parts of a Value with a Nested `_`" section said the second match arm allows `new_setting_value` to become `setting_value`, but the assignment in Listing 19-18 runs the other way:

```rust
setting_value = new_setting_value;
```

So it is `setting_value` that becomes `new_setting_value` (when the user has not yet customized the setting). One line, swap of the two identifiers.

## Changes

- `src/ch19-03-pattern-syntax.md`: swapped the two identifiers in the sentence below Listing 19-18.

## Validation

- [x] Read Listing 19-18 (`listings/ch19-patterns-and-matching/listing-19-18/src/main.rs`) and confirmed the assignment direction: `setting_value = new_setting_value;`
- [x] `dprint check src/ch19-03-pattern-syntax.md` — the only reported formatting issue (a blank line at line 78) also exists on unmodified `main`, so it is pre-existing and untouched by this change.

## Notes

None — docs-only, one line.