### PR TITLE
Clarify that static variables are not synonymous with global variables

### DIFF
--- a/src/ch20-01-unsafe-rust.md
+++ b/src/ch20-01-unsafe-rust.md
@@ -392,7 +392,9 @@ support but which can be problematic with Rust’s ownership rules. If two
 threads are accessing the same mutable global variable, it can cause a data
 race.
 
-In Rust, global variables are called _static_ variables. Listing 20-10 shows an
+Rust doesn’t have a dedicated “global variable” keyword; instead, it has
+_static_ variables, which live for the entire program and can be declared at
+module scope (globally) or inside a function (locally). Listing 20-10 shows an
 example declaration and use of a static variable with a string slice as a
 value.
 


### PR DESCRIPTION
## Summary

Fixes #4819.

Section 20.1 said "In Rust, global variables are called _static_ variables", which reads as global == static. A `static` item is defined by its `'static` lifetime, not by its scope: per the Reference, static items may be declared at module scope or inside a function. This rewords the paragraph to make that distinction while keeping the section's flow into Listing 20-10.

## Changes

- `src/ch20-01-unsafe-rust.md`: reworded one paragraph (3 lines) in the "Accessing or Modifying a Mutable Static Variable" section.

## Validation

- [x] Checked the wording against the [Rust Reference on static items](https://doc.rust-lang.org/reference/items/static-items.html) (statics have program lifetime and may appear in any scope)
- [x] `dprint check src/ch20-01-unsafe-rust.md` — the two reported regions (lines ~337-343, ~493+) also fail on unmodified `main`; they are pre-existing and outside this change's lines (~390-400).

## Notes

Kept the change minimal — no restructuring of the section, just the incorrect equivalence.